### PR TITLE
Use TinyGo __app_ram_base

### DIFF
--- a/adapter_sd.go
+++ b/adapter_sd.go
@@ -73,6 +73,9 @@ func DefaultAdapter() (*Adapter, error) {
 	return &defaultAdapter, nil
 }
 
+//go:extern __app_ram_base
+var appRAMBase [0]uint32
+
 // Enable configures the BLE stack. It must be called before any
 // Bluetooth-related calls (unless otherwise indicated).
 func (a *Adapter) Enable() error {
@@ -89,8 +92,7 @@ func (a *Adapter) Enable() error {
 		return Error(errCode)
 	}
 
-	appRAMBase := uint32(0x200039c0)
-	errCode = C.sd_ble_enable(&appRAMBase)
+	errCode = C.sd_ble_enable((*uint32)(unsafe.Pointer(&appRAMBase)))
 	if errCode != 0 {
 		return Error(errCode)
 	}


### PR DESCRIPTION
This makes sure the SoftDevice start address is configured in only one
place, and thus avoid potential issues when it is changed. It also will
allow setting a different SoftDevice RAM size with a linker flag, in
LLVM 11 (when expressions are allowed in the MEMORY part of a linker
script).