### PR TITLE
typo for uuid size

### DIFF
--- a/uuid.go
+++ b/uuid.go
@@ -115,7 +115,7 @@ func ParseUUID(s string) (uuid UUID, err error) {
 		uuid[3-uuidIndex/8] |= uint32(nibble) << (4 * (7 - uuidIndex%8))
 		uuidIndex++
 	}
-	if uuidIndex != 31 {
+	if uuidIndex != 32 {
 		// The UUID doesn't have exactly 32 nibbles. Perhaps a 16-bit or 32-bit
 		// UUID?
 		err = errInvalidUUID


### PR DESCRIPTION
There is a typo here uuidIndex will be 32 when leaving the loop, not 31