### PR TITLE
linux: allow Linux to DiscoverServices/DiscoverCharacteristics without a specific list

### DIFF
--- a/examples/discover/main.go
+++ b/examples/discover/main.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"os"
+
+	"github.com/tinygo-org/bluetooth"
+)
+
+var adapter = bluetooth.DefaultAdapter
+
+func main() {
+	if len(os.Args) < 2 {
+		println("usage: discover [local name]")
+		os.Exit(1)
+	}
+
+	// look for device with specific name
+	name := os.Args[1]
+
+	// Enable BLE interface.
+	must("enable BLE stack", adapter.Enable())
+
+	ch := make(chan bluetooth.ScanResult, 1)
+
+	// Start scanning.
+	println("scanning...")
+	err := adapter.Scan(func(adapter *bluetooth.Adapter, result bluetooth.ScanResult) {
+		println("found device:", result.Address.String(), result.RSSI, result.LocalName())
+		if result.LocalName() == name {
+			adapter.StopScan()
+			ch <- result
+		}
+	})
+
+	var device *bluetooth.Device
+	select {
+	case result := <-ch:
+		device, err = adapter.Connect(result.Address, bluetooth.ConnectionParams{})
+		if err != nil {
+			println(err.Error())
+			os.Exit(1)
+		}
+
+		println("connected to ", result.LocalName())
+	}
+
+	// get services
+	println("discovering services/characteristics")
+	srvcs, err := device.DiscoverServices(nil)
+	for _, srvc := range srvcs {
+		println("- service", srvc.UUID.String())
+
+		chars, _ := srvc.DiscoverCharacteristics(nil)
+		for _, char := range chars {
+			println("-- characteristic", char.UUID.String())
+		}
+	}
+
+	must("start scan", err)
+}
+
+func must(action string, err error) {
+	if err != nil {
+		panic("failed to " + action + ": " + err.Error())
+	}
+}

--- a/gap_linux.go
+++ b/gap_linux.go
@@ -219,7 +219,7 @@ func makeScanResult(props *device.Device1Properties) ScanResult {
 		serviceUUIDs = append(serviceUUIDs, parsedUUID)
 	}
 
-	a := &Address{MACAddress{MAC: addr}}
+	a := Address{MACAddress{MAC: addr}}
 	a.SetRandom(props.AddressType == "random")
 
 	return ScanResult{

--- a/gattc_darwin.go
+++ b/gattc_darwin.go
@@ -11,6 +11,9 @@ import (
 // UUIDs you are interested in to this function. Either a slice of all services
 // is returned (of the same length as the requested UUIDs and in the same
 // order), or if some services could not be discovered an error is returned.
+//
+// Passing a nil slice of UUIDs will return a complete list of
+// services.
 func (d *Device) DiscoverServices(uuids []UUID) ([]DeviceService, error) {
 	cbuuids := []cbgo.UUID{}
 	for _, u := range uuids {
@@ -58,6 +61,9 @@ type DeviceService struct {
 // discovered an error is returned. If there is no error, the characteristics
 // slice has the same length as the UUID slice with characteristics in the same
 // order in the slice as in the requested UUID list.
+//
+// Passing a nil slice of UUIDs will return a complete list of
+// characteristics.
 func (s *DeviceService) DiscoverCharacteristics(uuids []UUID) ([]DeviceCharacteristic, error) {
 	cbuuids := []cbgo.UUID{}
 	for _, u := range uuids {

--- a/gattc_linux.go
+++ b/gattc_linux.go
@@ -13,6 +13,8 @@ import (
 
 // DeviceService is a BLE service on a connected peripheral device.
 type DeviceService struct {
+	UUID
+
 	service *gatt.GattService1
 }
 
@@ -75,6 +77,7 @@ func (d *Device) DiscoverServices(uuids []UUID) ([]DeviceService, error) {
 				// Don't overwrite it, to keep the servicesFound count correct.
 				continue
 			}
+			services[i].UUID = uuid
 			services[i].service = service
 			servicesFound++
 			break
@@ -91,6 +94,8 @@ func (d *Device) DiscoverServices(uuids []UUID) ([]DeviceService, error) {
 // DeviceCharacteristic is a BLE characteristic on a connected peripheral
 // device.
 type DeviceCharacteristic struct {
+	UUID
+
 	characteristic *gatt.GattCharacteristic1
 }
 
@@ -140,6 +145,7 @@ func (s *DeviceService) DiscoverCharacteristics(uuids []UUID) ([]DeviceCharacter
 				// Don't overwrite it, to keep the servicesFound count correct.
 				continue
 			}
+			chars[i].UUID = uuid
 			chars[i].characteristic = char
 			characteristicsFound++
 			break


### PR DESCRIPTION
This PR allows the Linux GATT implementation to DiscoverServices/DiscoverCharacteristics without a specific list of UUIDs.

It also adds an examples program to discover the services/characteristics for a known device name:

```
$ ./discover SK-2A68
scanning...
found device: 28:11:A5:5D:67:1B -97 
found device: 34:9F:7B:67:15:A9 -77 the printer
found device: EE:74:7D:C9:2A:68 -66 SK-2A68
connected to  SK-2A68
discovering services/characteristics
- service 22bb746f-2bb0-7554-2d6f-726568705327
-- characteristic 22bb746f-2bb2-7554-2d6f-726568705327
-- characteristic 22bb746f-2bbf-7554-2d6f-726568705327
-- characteristic 22bb746f-2bbe-7554-2d6f-726568705327
-- characteristic 22bb746f-2bba-7554-2d6f-726568705327
-- characteristic 22bb746f-2bb7-7554-2d6f-726568705327
-- characteristic 22bb746f-2bb9-7554-2d6f-726568705327
-- characteristic 22bb746f-2bbd-7554-2d6f-726568705327
-- characteristic 22bb746f-3bba-7554-2d6f-726568705327
-- characteristic 22bb746f-2bb1-7554-2d6f-726568705327
-- characteristic 22bb746f-2bb8-7554-2d6f-726568705327
-- characteristic 22bb746f-2bb6-7554-2d6f-726568705327
- service 0000180a-0000-1000-8000-00805f9b34fb
-- characteristic 00002a24-0000-1000-8000-00805f9b34fb
-- characteristic 00002a25-0000-1000-8000-00805f9b34fb
-- characteristic 00002a27-0000-1000-8000-00805f9b34fb
-- characteristic 00002a26-0000-1000-8000-00805f9b34fb
-- characteristic 00002a29-0000-1000-8000-00805f9b34fb
- service 22bb746f-2ba0-7554-2d6f-726568705327
-- characteristic 22bb746f-2ba1-7554-2d6f-726568705327
-- characteristic 22bb746f-2ba6-7554-2d6f-726568705327
- service 00001801-0000-1000-8000-00805f9b34fb
-- characteristic 00002a05-0000-1000-8000-00805f9b34fb
- service 00001016-d102-11e1-9b23-00025b00a5a5
-- characteristic 00001014-d102-11e1-9b23-00025b00a5a5
-- characteristic 00001013-d102-11e1-9b23-00025b00a5a5
-- characteristic 00001017-d102-11e1-9b23-00025b00a5a5
```