### PR TITLE
gattc: use GetUUID() to allow for bare metal use of short UUID.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ smoketest-linux:
 	GOOS=linux go build -o /tmp/go-build-discard ./examples/heartrate
 	GOOS=linux go build -o /tmp/go-build-discard ./examples/nusserver
 	GOOS=linux go build -o /tmp/go-build-discard ./examples/scanner
+	GOOS=linux go build -o /tmp/go-build-discard ./examples/discover
 
 smoketest-windows:
 	# Test on Windows.
@@ -41,3 +42,4 @@ smoketest-windows:
 smoketest-macos:
 	# Test on macos.
 	GOOS=darwin CGO_ENABLED=1 go build -o /tmp/go-build-discard ./examples/scanner
+	GOOS=darwin CGO_ENABLED=1 go build -o /tmp/go-build-discard ./examples/discover

--- a/adapter_nrf528xx.go
+++ b/adapter_nrf528xx.go
@@ -177,6 +177,7 @@ func handleEvent() {
 				// one discovered service. Use the first as a sensible fallback.
 				discoveringService.startHandle.Set(discoveryEvent.services[0].handle_range.start_handle)
 				discoveringService.endHandle.Set(discoveryEvent.services[0].handle_range.end_handle)
+				// TODO: something like discoveringService.uuid = discoveryEvent.services[0].uuid
 			} else {
 				// No service found.
 				discoveringService.startHandle.Set(0)

--- a/adapter_nrf528xx.go
+++ b/adapter_nrf528xx.go
@@ -193,6 +193,9 @@ func handleEvent() {
 				discoveringCharacteristic.handle_value.Set(discoveryEvent.chars[0].handle_value)
 				discoveringCharacteristic.char_props = discoveryEvent.chars[0].char_props
 				discoveringCharacteristic.uuid = discoveryEvent.chars[0].uuid
+			} else {
+				// zero indicates we received no characteristic, set handle_value to last
+				discoveringCharacteristic.handle_value.Set(0xffff)
 			}
 		case C.BLE_GATTC_EVT_DESC_DISC_RSP:
 			discoveryEvent := gattcEvent.params.unionfield_desc_disc_rsp()

--- a/adapter_nrf528xx.go
+++ b/adapter_nrf528xx.go
@@ -177,7 +177,7 @@ func handleEvent() {
 				// one discovered service. Use the first as a sensible fallback.
 				discoveringService.startHandle.Set(discoveryEvent.services[0].handle_range.start_handle)
 				discoveringService.endHandle.Set(discoveryEvent.services[0].handle_range.end_handle)
-				// TODO: something like discoveringService.uuid = discoveryEvent.services[0].uuid
+				discoveringService.uuid = discoveryEvent.services[0].uuid
 			} else {
 				// No service found.
 				discoveringService.startHandle.Set(0)

--- a/examples/discover/main.go
+++ b/examples/discover/main.go
@@ -48,11 +48,11 @@ func main() {
 	println("discovering services/characteristics")
 	srvcs, err := device.DiscoverServices(nil)
 	for _, srvc := range srvcs {
-		println("- service", srvc.UUID.String())
+		println("- service", srvc.UUID().String())
 
 		chars, _ := srvc.DiscoverCharacteristics(nil)
 		for _, char := range chars {
-			println("-- characteristic", char.UUID.String())
+			println("-- characteristic", char.UUID().String())
 		}
 	}
 

--- a/examples/discover/main.go
+++ b/examples/discover/main.go
@@ -1,7 +1,23 @@
+// This example scans and then connects to a specific Bluetooth peripheral
+// and then displays all of the services and characteristics.
+//
+// To run this on a desktop system:
+//
+// 		go run ./examples/discover EE:74:7D:C9:2A:68
+//
+// To run this on a microcontroller, change the constant value in the file
+// "mcu.go" to set the MAC address of the device you want to discover.
+// Then, flash to the microcontroller board like this:
+//
+//		tinygo flash -o circuitplay-bluefruit ./examples/discover
+//
+// Once the program is flashed to the board, connect to the USB port
+// via serial to view the output.
+//
 package main
 
 import (
-	"os"
+	"time"
 
 	"tinygo.org/x/bluetooth"
 )
@@ -9,13 +25,9 @@ import (
 var adapter = bluetooth.DefaultAdapter
 
 func main() {
-	if len(os.Args) < 2 {
-		println("usage: discover [local name]")
-		os.Exit(1)
-	}
+	time.Sleep(3 * time.Second)
 
-	// look for device with specific name
-	name := os.Args[1]
+	println("enabling")
 
 	// Enable BLE interface.
 	must("enable BLE stack", adapter.Enable())
@@ -26,7 +38,7 @@ func main() {
 	println("scanning...")
 	err := adapter.Scan(func(adapter *bluetooth.Adapter, result bluetooth.ScanResult) {
 		println("found device:", result.Address.String(), result.RSSI, result.LocalName())
-		if result.LocalName() == name {
+		if result.Address.String() == connectAddress() {
 			adapter.StopScan()
 			ch <- result
 		}
@@ -38,25 +50,30 @@ func main() {
 		device, err = adapter.Connect(result.Address, bluetooth.ConnectionParams{})
 		if err != nil {
 			println(err.Error())
-			os.Exit(1)
+			return
 		}
 
-		println("connected to ", result.LocalName())
+		println("connected to ", result.Address.String())
 	}
 
 	// get services
 	println("discovering services/characteristics")
 	srvcs, err := device.DiscoverServices(nil)
+	must("discover services", err)
+
 	for _, srvc := range srvcs {
 		println("- service", srvc.UUID().String())
 
-		chars, _ := srvc.DiscoverCharacteristics(nil)
+		chars, err := srvc.DiscoverCharacteristics(nil)
+		if err != nil {
+			println(err)
+		}
 		for _, char := range chars {
 			println("-- characteristic", char.UUID().String())
 		}
 	}
 
-	must("start scan", err)
+	done()
 }
 
 func must(action string, err error) {

--- a/examples/discover/mcu.go
+++ b/examples/discover/mcu.go
@@ -1,0 +1,21 @@
+// +build baremetal
+
+package main
+
+import (
+	"time"
+)
+
+// replace this with the MAC address of the Bluetooth peripheral you want to connect to.
+const deviceAddress = "E4:B7:F4:11:8D:33"
+
+func connectAddress() string {
+	return deviceAddress
+}
+
+// done just blocks forever, allows USB CDC reset for flashing new software.
+func done() {
+	println("Done.")
+
+	time.Sleep(1 * time.Hour)
+}

--- a/examples/discover/os.go
+++ b/examples/discover/os.go
@@ -1,0 +1,22 @@
+// +build !baremetal
+
+package main
+
+import "os"
+
+func connectAddress() string {
+	if len(os.Args) < 2 {
+		println("usage: discover [address]")
+		os.Exit(1)
+	}
+
+	// look for device with specific name
+	address := os.Args[1]
+
+	return address
+}
+
+// done just prints a message and allows program to exit.
+func done() {
+	println("Done.")
+}

--- a/gattc_darwin.go
+++ b/gattc_darwin.go
@@ -33,9 +33,9 @@ func (d *Device) DiscoverServices(uuids []UUID) ([]DeviceService, error) {
 		for _, dsvc := range d.prph.Services() {
 			uuid, _ := ParseUUID(dsvc.UUID().String())
 			svc := DeviceService{
-				UUID:    uuid,
-				device:  d,
-				service: dsvc,
+				uuidWrapper: uuid,
+				device:      d,
+				service:     dsvc,
 			}
 			svcs = append(svcs, svc)
 			d.services[svc.UUID] = &svc
@@ -46,13 +46,22 @@ func (d *Device) DiscoverServices(uuids []UUID) ([]DeviceService, error) {
 	}
 }
 
+// uuidWrapper is a type alias for UUID so we ensure no conflicts with
+// struct method of the same name.
+type uuidWrapper = UUID
+
 // DeviceService is a BLE service on a connected peripheral device.
 type DeviceService struct {
-	UUID
+	uuidWrapper
 
 	device *Device
 
 	service cbgo.Service
+}
+
+// UUID returns the UUID for this DeviceService.
+func (s *DeviceService) UUID() UUID {
+	return s.uuidWrapper
 }
 
 // DiscoverCharacteristics discovers characteristics in this service. Pass a
@@ -83,7 +92,7 @@ func (s *DeviceService) DiscoverCharacteristics(uuids []UUID) ([]DeviceCharacter
 		for _, dchar := range s.service.Characteristics() {
 			uuid, _ := ParseUUID(dchar.UUID().String())
 			char := DeviceCharacteristic{
-				UUID:           uuid,
+				uuidWrapper:    uuid,
 				service:        s,
 				characteristic: dchar,
 			}
@@ -99,12 +108,17 @@ func (s *DeviceService) DiscoverCharacteristics(uuids []UUID) ([]DeviceCharacter
 // DeviceCharacteristic is a BLE characteristic on a connected peripheral
 // device.
 type DeviceCharacteristic struct {
-	UUID
+	uuidWrapper
 
 	service *DeviceService
 
 	characteristic cbgo.Characteristic
 	callback       func(buf []byte)
+}
+
+// UUID returns the UUID for this DeviceCharacteristic.
+func (c *DeviceCharacteristic) UUID() UUID {
+	return c.uuidWrapper
 }
 
 // WriteWithoutResponse replaces the characteristic value with a new value. The

--- a/gattc_darwin.go
+++ b/gattc_darwin.go
@@ -38,7 +38,7 @@ func (d *Device) DiscoverServices(uuids []UUID) ([]DeviceService, error) {
 				service:     dsvc,
 			}
 			svcs = append(svcs, svc)
-			d.services[svc.UUID] = &svc
+			d.services[svc.uuidWrapper] = &svc
 		}
 		return svcs, nil
 	case <-time.NewTimer(10 * time.Second).C:
@@ -97,7 +97,7 @@ func (s *DeviceService) DiscoverCharacteristics(uuids []UUID) ([]DeviceCharacter
 				characteristic: dchar,
 			}
 			chars = append(chars, char)
-			s.device.characteristics[char.UUID] = &char
+			s.device.characteristics[char.uuidWrapper] = &char
 		}
 		return chars, nil
 	case <-time.NewTimer(10 * time.Second).C:

--- a/gattc_linux.go
+++ b/gattc_linux.go
@@ -11,11 +11,20 @@ import (
 	"github.com/muka/go-bluetooth/bluez/profile/gatt"
 )
 
+// UUIDWrapper is a type alias for UUID so we ensure no conflicts with
+// struct method of the same name.
+type uuidWrapper = UUID
+
 // DeviceService is a BLE service on a connected peripheral device.
 type DeviceService struct {
-	UUID
+	uuidWrapper
 
 	service *gatt.GattService1
+}
+
+// UUID returns the UUID for this DeviceService.
+func (s *DeviceService) UUID() UUID {
+	return s.uuidWrapper
 }
 
 // DiscoverServices starts a service discovery procedure. Pass a list of service
@@ -89,7 +98,7 @@ func (d *Device) DiscoverServices(uuids []UUID) ([]DeviceService, error) {
 		}
 
 		uuid, _ := ParseUUID(service.Properties.UUID)
-		ds := DeviceService{UUID: uuid,
+		ds := DeviceService{uuidWrapper: uuid,
 			service: service,
 		}
 
@@ -108,9 +117,14 @@ func (d *Device) DiscoverServices(uuids []UUID) ([]DeviceService, error) {
 // DeviceCharacteristic is a BLE characteristic on a connected peripheral
 // device.
 type DeviceCharacteristic struct {
-	UUID
+	uuidWrapper
 
 	characteristic *gatt.GattCharacteristic1
+}
+
+// UUID returns the UUID for this DeviceCharacteristic.
+func (c *DeviceCharacteristic) UUID() UUID {
+	return c.uuidWrapper
 }
 
 // DiscoverCharacteristics discovers characteristics in this service. Pass a
@@ -171,7 +185,7 @@ func (s *DeviceService) DiscoverCharacteristics(uuids []UUID) ([]DeviceCharacter
 		}
 
 		uuid, _ := ParseUUID(char.Properties.UUID)
-		dc := DeviceCharacteristic{UUID: uuid,
+		dc := DeviceCharacteristic{uuidWrapper: uuid,
 			characteristic: char,
 		}
 

--- a/gattc_sd.go
+++ b/gattc_sd.go
@@ -67,8 +67,8 @@ func (d *Device) DiscoverServices(uuids []UUID) ([]DeviceService, error) {
 		return nil, errAlreadyDiscovering
 	}
 
-	services := make([]DeviceService, len(uuids))
-	for i, uuid := range uuids {
+	services := []DeviceService{}
+	for _, uuid := range uuids {
 		// Start discovery of this service.
 		shortUUID, errCode := uuid.shortUUID()
 		if errCode != 0 {
@@ -100,12 +100,13 @@ func (d *Device) DiscoverServices(uuids []UUID) ([]DeviceService, error) {
 		}
 
 		// Store the discovered service.
-		services[i] = DeviceService{
+		svc := DeviceService{
 			uuidWrapper:      uuid,
 			connectionHandle: d.connectionHandle,
 			startHandle:      startHandle,
 			endHandle:        endHandle,
 		}
+		services = append(services, svc)
 	}
 
 	return services, nil
@@ -157,7 +158,7 @@ func (s *DeviceService) DiscoverCharacteristics(uuids []UUID) ([]DeviceCharacter
 	}
 
 	// Make a map of UUIDs in SoftDevice short form, for easier comparing.
-	shortUUIDs := make(map[UUID]C.ble_uuid_t)
+	shortUUIDs := make(map[uuidWrapper]C.ble_uuid_t)
 	for _, uuid := range uuids {
 		var errCode uint32
 		shortUUIDs[uuid], errCode = uuid.shortUUID()

--- a/gattc_sd.go
+++ b/gattc_sd.go
@@ -34,6 +34,7 @@ var discoveringService struct {
 	state       volatile.Register8 // 0 means nothing happening, 1 means in progress, 2 means found something
 	startHandle volatile.Register16
 	endHandle   volatile.Register16
+	uuid        C.ble_uuid_t
 }
 
 // DeviceService is a BLE service on a connected peripheral device. It is only
@@ -122,6 +123,7 @@ func (d *Device) DiscoverServices(uuids []UUID) ([]DeviceService, error) {
 		// Retrieve values, and mark the global as unused.
 		startHandle = discoveringService.startHandle.Get()
 		endHandle := discoveringService.endHandle.Get()
+		suuid = discoveringService.uuid
 		discoveringService.state.Set(0)
 
 		if startHandle == 0 {

--- a/uuid_sd.go
+++ b/uuid_sd.go
@@ -12,6 +12,8 @@ package bluetooth
 import "C"
 import "unsafe"
 
+type shortUUID C.ble_uuid_t
+
 func (uuid UUID) shortUUID() (C.ble_uuid_t, uint32) {
 	var short C.ble_uuid_t
 	short.uuid = uint16(uuid[3])
@@ -21,4 +23,24 @@ func (uuid UUID) shortUUID() (C.ble_uuid_t, uint32) {
 	}
 	errCode := C.sd_ble_uuid_vs_add((*C.ble_uuid128_t)(unsafe.Pointer(&uuid[0])), &short._type)
 	return short, errCode
+}
+
+// UUID returns the full length UUID for this short UUID.
+func (s shortUUID) UUID() UUID {
+	var outLen C.uint8_t
+	var outUUID [16]C.uint8_t
+
+	C.sd_ble_uuid_encode(((*C.ble_uuid_t)(unsafe.Pointer(&s))), ((*C.uint8_t)(unsafe.Pointer(&outLen))), ((*C.uint8_t)(unsafe.Pointer(&outUUID[0]))))
+
+	return NewUUID(outUUID)
+}
+
+// IsIn checks the passed in slice of short UUIDs to see if this uuid is in it.
+func (s shortUUID) IsIn(uuids []C.ble_uuid_t) bool {
+	for _, u := range uuids {
+		if u == s {
+			return true
+		}
+	}
+	return false
 }

--- a/uuid_sd.go
+++ b/uuid_sd.go
@@ -27,12 +27,13 @@ func (uuid UUID) shortUUID() (C.ble_uuid_t, uint32) {
 
 // UUID returns the full length UUID for this short UUID.
 func (s shortUUID) UUID() UUID {
+	if s._type == C.BLE_UUID_TYPE_BLE {
+		return New16BitUUID(s.uuid)
+	}
 	var outLen C.uint8_t
-	var outUUID C.uint16_t
-
-	C.sd_ble_uuid_encode(((*C.ble_uuid_t)(unsafe.Pointer(&s))), ((*C.uint8_t)(unsafe.Pointer(&outLen))), ((*C.uint8_t)(unsafe.Pointer(&outUUID))))
-
-	return New16BitUUID(outUUID)
+	var outUUID UUID
+	C.sd_ble_uuid_encode(((*C.ble_uuid_t)(unsafe.Pointer(&s))), &outLen, ((*C.uint8_t)(unsafe.Pointer(&outUUID))))
+	return outUUID
 }
 
 // IsIn checks the passed in slice of short UUIDs to see if this uuid is in it.

--- a/uuid_sd.go
+++ b/uuid_sd.go
@@ -28,11 +28,11 @@ func (uuid UUID) shortUUID() (C.ble_uuid_t, uint32) {
 // UUID returns the full length UUID for this short UUID.
 func (s shortUUID) UUID() UUID {
 	var outLen C.uint8_t
-	var outUUID [16]C.uint8_t
+	var outUUID C.uint16_t
 
-	C.sd_ble_uuid_encode(((*C.ble_uuid_t)(unsafe.Pointer(&s))), ((*C.uint8_t)(unsafe.Pointer(&outLen))), ((*C.uint8_t)(unsafe.Pointer(&outUUID[0]))))
+	C.sd_ble_uuid_encode(((*C.ble_uuid_t)(unsafe.Pointer(&s))), ((*C.uint8_t)(unsafe.Pointer(&outLen))), ((*C.uint8_t)(unsafe.Pointer(&outUUID))))
 
-	return NewUUID(outUUID)
+	return New16BitUUID(outUUID)
 }
 
 // IsIn checks the passed in slice of short UUIDs to see if this uuid is in it.


### PR DESCRIPTION
This PR adds a GetUUID() accessor to both `DeviceService` and `DeviceCharacteristic` to simplify use on bare metal with short UUIDs.