### PR TITLE
docs,domain: use import for custom domain for package

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This example scans for peripheral devices and then displays information about th
 package main
 
 import (
-	"github.com/tinygo-org/bluetooth"
+	"tinygo.org/x/bluetooth"
 )
 
 var adapter = bluetooth.DefaultAdapter

--- a/adapter_windows.go
+++ b/adapter_windows.go
@@ -2,7 +2,7 @@ package bluetooth
 
 import (
 	"github.com/go-ole/go-ole"
-	"github.com/tinygo-org/bluetooth/winbt"
+	"tinygo.org/x/bluetooth/winbt"
 )
 
 type Adapter struct {

--- a/bluetooth.go
+++ b/bluetooth.go
@@ -1,0 +1,9 @@
+// Package bluetooth provides a cross-platform Bluetooth module for Go
+// that can be used on operating systems such as Linux, macOS, and Windows.
+//
+// It can also be used running "bare metal" on microcontrollers such as
+// those produced by Nordic Semiconductor.
+//
+// This package can be use to create Bluetooth Low Energy centrals as well as peripherals.
+//
+package bluetooth // import "tinygo.org/x/bluetooth"

--- a/examples/advertisement/main.go
+++ b/examples/advertisement/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"time"
 
-	"github.com/tinygo-org/bluetooth"
+	"tinygo.org/x/bluetooth"
 )
 
 var adapter = bluetooth.DefaultAdapter

--- a/examples/discover/main.go
+++ b/examples/discover/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"os"
 
-	"github.com/tinygo-org/bluetooth"
+	"tinygo.org/x/bluetooth"
 )
 
 var adapter = bluetooth.DefaultAdapter

--- a/examples/heartrate/main.go
+++ b/examples/heartrate/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"time"
 
-	"github.com/tinygo-org/bluetooth"
+	"tinygo.org/x/bluetooth"
 )
 
 var adapter = bluetooth.DefaultAdapter

--- a/examples/ledcolor/main.go
+++ b/examples/ledcolor/main.go
@@ -4,7 +4,7 @@ import (
 	"machine"
 	"time"
 
-	"github.com/tinygo-org/bluetooth"
+	"tinygo.org/x/bluetooth"
 )
 
 var adapter = bluetooth.DefaultAdapter

--- a/examples/nusclient/main.go
+++ b/examples/nusclient/main.go
@@ -4,8 +4,8 @@ package main
 // details.
 
 import (
-	"github.com/tinygo-org/bluetooth"
-	"github.com/tinygo-org/bluetooth/rawterm"
+	"tinygo.org/x/bluetooth"
+	"tinygo.org/x/bluetooth/rawterm"
 )
 
 var (

--- a/examples/nusserver/main.go
+++ b/examples/nusserver/main.go
@@ -8,8 +8,8 @@ package main
 // Code to interact with a raw terminal is in separate files with build tags.
 
 import (
-	"github.com/tinygo-org/bluetooth"
-	"github.com/tinygo-org/bluetooth/rawterm"
+	"tinygo.org/x/bluetooth"
+	"tinygo.org/x/bluetooth/rawterm"
 )
 
 var (

--- a/examples/scanner/main.go
+++ b/examples/scanner/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/tinygo-org/bluetooth"
+	"tinygo.org/x/bluetooth"
 )
 
 var adapter = bluetooth.DefaultAdapter

--- a/gap_windows.go
+++ b/gap_windows.go
@@ -1,7 +1,7 @@
 package bluetooth
 
 import (
-	"github.com/tinygo-org/bluetooth/winbt"
+	"tinygo.org/x/bluetooth/winbt"
 )
 
 // Address contains a Bluetooth MAC address.

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/godbus/dbus/v5 v5.0.3
 	github.com/muka/go-bluetooth v0.0.0-20200619025933-f6113f7141c5
 	github.com/sirupsen/logrus v1.6.0 // indirect
-	github.com/tinygo-org/bluetooth v0.0.0-20200801163934-de824e188486
 	golang.org/x/crypto v0.0.0-20200602180216-279210d13fed
 	golang.org/x/sys v0.0.0-20200826173525-f9321e4c35a6 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/tinygo-org/bluetooth
+module tinygo.org/x/bluetooth
 
 go 1.14
 
@@ -8,6 +8,7 @@ require (
 	github.com/godbus/dbus/v5 v5.0.3
 	github.com/muka/go-bluetooth v0.0.0-20200619025933-f6113f7141c5
 	github.com/sirupsen/logrus v1.6.0 // indirect
+	github.com/tinygo-org/bluetooth v0.0.0-20200801163934-de824e188486
 	golang.org/x/crypto v0.0.0-20200602180216-279210d13fed
 	golang.org/x/sys v0.0.0-20200826173525-f9321e4c35a6 // indirect
 )

--- a/winbt/winbt.go
+++ b/winbt/winbt.go
@@ -13,7 +13,8 @@
 // https://blog.magnusmontin.net/2017/12/30/minimal-uwp-wrl-xaml-app/
 // https://yizhang82.dev/what-is-winrt
 // https://www.slideshare.net/goldshtn/deep-dive-into-winrt
-package winbt
+//
+package winbt // import "tinygo.org/x/bluetooth/winbt"
 
 import (
 	"github.com/go-ole/go-ole"


### PR DESCRIPTION
This PR uses the custom domain import `tinygo.org/x/bluetooth` for this package. It also adds some of the package level GoDocs format info.