### PR TITLE
examples: add example for Circuit Playground Bluefruit board to contr…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,8 @@ smoketest-tinygo:
 	@md5sum test.hex
 	$(TINYGO) build -o test.uf2 -size=short -target=circuitplay-bluefruit ./examples/advertisement
 	@md5sum test.hex
+	$(TINYGO) build -o test.uf2 -size=short -target=circuitplay-bluefruit ./examples/circuitplay
+	@md5sum test.hex
 	$(TINYGO) build -o test.hex -size=short -target=pca10040-s132v6       ./examples/heartrate
 	@md5sum test.hex
 	$(TINYGO) build -o test.hex -size=short -target=reelboard-s140v7      ./examples/ledcolor

--- a/examples/circuitplay/main.go
+++ b/examples/circuitplay/main.go
@@ -1,0 +1,90 @@
+// This example is intended to be used with the Adafruit Circuitplay Bluefruit board.
+// It allows you to control the color of the built-in NeoPixel LEDS while they animate
+// in a circular pattern.
+//
+package main
+
+import (
+	"image/color"
+	"machine"
+	"time"
+
+	"tinygo.org/x/bluetooth"
+	"tinygo.org/x/drivers/ws2812"
+)
+
+var adapter = bluetooth.DefaultAdapter
+
+// TODO: use atomics to access this value.
+var ledColor = [3]byte{0xff, 0x00, 0x00} // start out with red
+var leds [10]color.RGBA
+var hasColorChange = true
+
+var (
+	serviceUUID = [16]byte{0xa0, 0xb4, 0x00, 0x01, 0x92, 0x6d, 0x4d, 0x61, 0x98, 0xdf, 0x8c, 0x5c, 0x62, 0xee, 0x53, 0xb3}
+	charUUID    = [16]byte{0xa0, 0xb4, 0x00, 0x02, 0x92, 0x6d, 0x4d, 0x61, 0x98, 0xdf, 0x8c, 0x5c, 0x62, 0xee, 0x53, 0xb3}
+)
+
+var neo machine.Pin = machine.NEOPIXELS
+var led machine.Pin = machine.LED
+
+func main() {
+	println("starting")
+
+	led.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	neo.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	ws := ws2812.New(neo)
+
+	must("enable BLE stack", adapter.Enable())
+	adv := adapter.DefaultAdvertisement()
+	must("config adv", adv.Configure(bluetooth.AdvertisementOptions{
+		LocalName: "TinyGo colors",
+	}))
+	must("start adv", adv.Start())
+
+	var ledColorCharacteristic bluetooth.Characteristic
+	must("add service", adapter.AddService(&bluetooth.Service{
+		UUID: bluetooth.NewUUID(serviceUUID),
+		Characteristics: []bluetooth.CharacteristicConfig{
+			{
+				Handle: &ledColorCharacteristic,
+				UUID:   bluetooth.NewUUID(charUUID),
+				Value:  ledColor[:],
+				Flags:  bluetooth.CharacteristicReadPermission | bluetooth.CharacteristicWritePermission,
+				WriteEvent: func(client bluetooth.Connection, offset int, value []byte) {
+					if offset != 0 || len(value) != 3 {
+						return
+					}
+					ledColor[0] = value[0]
+					ledColor[1] = value[1]
+					ledColor[2] = value[2]
+					hasColorChange = true
+				},
+			},
+		},
+	}))
+
+	rg := false
+
+	for {
+		rg = !rg
+		for i := range leds {
+			rg = !rg
+			if rg {
+				leds[i] = color.RGBA{R: ledColor[0], G: ledColor[1], B: ledColor[2]}
+			} else {
+				leds[i] = color.RGBA{R: 0x00, G: 0x00, B: 0x00}
+			}
+		}
+
+		ws.WriteColors(leds[:])
+		led.Set(rg)
+		time.Sleep(100 * time.Millisecond)
+	}
+}
+
+func must(action string, err error) {
+	if err != nil {
+		panic("failed to " + action + ": " + err.Error())
+	}
+}

--- a/examples/circuitplay/main.go
+++ b/examples/circuitplay/main.go
@@ -18,7 +18,6 @@ var adapter = bluetooth.DefaultAdapter
 // TODO: use atomics to access this value.
 var ledColor = [3]byte{0xff, 0x00, 0x00} // start out with red
 var leds [10]color.RGBA
-var hasColorChange = true
 
 var (
 	serviceUUID = [16]byte{0xa0, 0xb4, 0x00, 0x01, 0x92, 0x6d, 0x4d, 0x61, 0x98, 0xdf, 0x8c, 0x5c, 0x62, 0xee, 0x53, 0xb3}
@@ -58,7 +57,6 @@ func main() {
 					ledColor[0] = value[0]
 					ledColor[1] = value[1]
 					ledColor[2] = value[2]
-					hasColorChange = true
 				},
 			},
 		},

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module tinygo.org/x/bluetooth
 
-go 1.14
+go 1.15
 
 require (
 	github.com/JuulLabs-OSS/cbgo v0.0.2
@@ -10,4 +10,5 @@ require (
 	github.com/sirupsen/logrus v1.6.0 // indirect
 	golang.org/x/crypto v0.0.0-20200602180216-279210d13fed
 	golang.org/x/sys v0.0.0-20200826173525-f9321e4c35a6 // indirect
+	tinygo.org/x/drivers v0.13.0
 )


### PR DESCRIPTION
This PR adds an example for Circuit Playground Bluefruit board to control the built-in NeoPixels.