### PR TITLE
gap: add connection handler to be called on adapter connect/disconnect

### DIFF
--- a/adapter.go
+++ b/adapter.go
@@ -2,3 +2,10 @@ package bluetooth
 
 // Set this to true to print debug messages, for example for unknown events.
 const debug = false
+
+// SetConnectHandler sets a handler function to be called whenever the adaptor connects
+// or disconnects. You must call this before you call adaptor.Connect() for centrals
+// or adaptor.Start() for peripherals in order for it to work.
+func (a *Adapter) SetConnectHandler(c func(device Addresser, connected bool)) {
+	a.connectHandler = c
+}

--- a/adapter_darwin.go
+++ b/adapter_darwin.go
@@ -19,6 +19,8 @@ type Adapter struct {
 	scanChan               chan error
 	poweredChan            chan error
 	connectChan            chan cbgo.Peripheral
+
+	connectHandler func(device Addresser, connected bool)
 }
 
 // DefaultAdapter is the default adapter on the system.
@@ -28,6 +30,9 @@ var DefaultAdapter = &Adapter{
 	cm:          cbgo.NewCentralManager(nil),
 	pm:          cbgo.NewPeripheralManager(nil),
 	connectChan: make(chan cbgo.Peripheral),
+	connectHandler: func(device Addresser, connected bool) {
+		return
+	},
 }
 
 // Enable configures the BLE stack. It must be called before any

--- a/adapter_linux.go
+++ b/adapter_linux.go
@@ -15,13 +15,19 @@ type Adapter struct {
 	id                   string
 	cancelChan           chan struct{}
 	defaultAdvertisement *Advertisement
+
+	connectHandler func(device Addresser, connected bool)
 }
 
 // DefaultAdapter is the default adapter on the system. On Linux, it is the
 // first adapter available.
 //
 // Make sure to call Enable() before using it to initialize the adapter.
-var DefaultAdapter = &Adapter{}
+var DefaultAdapter = &Adapter{
+	connectHandler: func(device Addresser, connected bool) {
+		return
+	},
+}
 
 // Enable configures the BLE stack. It must be called before any
 // Bluetooth-related calls (unless otherwise indicated).

--- a/adapter_nrf51.go
+++ b/adapter_nrf51.go
@@ -47,6 +47,7 @@ func handleEvent() {
 		switch id {
 		case C.BLE_GAP_EVT_CONNECTED:
 			currentConnection.Reg = gapEvent.conn_handle
+			DefaultAdapter.connectHandler(Address{}, true)
 		case C.BLE_GAP_EVT_DISCONNECTED:
 			if defaultAdvertisement.isAdvertising.Get() != 0 {
 				// The advertisement was running but was automatically stopped
@@ -58,6 +59,7 @@ func handleEvent() {
 				defaultAdvertisement.start()
 			}
 			currentConnection.Reg = C.BLE_CONN_HANDLE_INVALID
+			DefaultAdapter.connectHandler(Address{}, false)
 		case C.BLE_GAP_EVT_CONN_PARAM_UPDATE_REQUEST:
 			// Respond with the default PPCP connection parameters by passing
 			// nil:

--- a/adapter_nrf51.go
+++ b/adapter_nrf51.go
@@ -47,7 +47,7 @@ func handleEvent() {
 		switch id {
 		case C.BLE_GAP_EVT_CONNECTED:
 			currentConnection.Reg = gapEvent.conn_handle
-			DefaultAdapter.connectHandler(Address{}, true)
+			DefaultAdapter.connectHandler(nil, true)
 		case C.BLE_GAP_EVT_DISCONNECTED:
 			if defaultAdvertisement.isAdvertising.Get() != 0 {
 				// The advertisement was running but was automatically stopped
@@ -59,7 +59,7 @@ func handleEvent() {
 				defaultAdvertisement.start()
 			}
 			currentConnection.Reg = C.BLE_CONN_HANDLE_INVALID
-			DefaultAdapter.connectHandler(Address{}, false)
+			DefaultAdapter.connectHandler(nil, false)
 		case C.BLE_GAP_EVT_CONN_PARAM_UPDATE_REQUEST:
 			// Respond with the default PPCP connection parameters by passing
 			// nil:

--- a/adapter_nrf528xx.go
+++ b/adapter_nrf528xx.go
@@ -64,12 +64,14 @@ func handleEvent() {
 					println("evt: connected in peripheral role")
 				}
 				currentConnection.Reg = gapEvent.conn_handle
+				DefaultAdapter.connectHandler(Address{}, true)
 			case C.BLE_GAP_ROLE_CENTRAL:
 				if debug {
 					println("evt: connected in central role")
 				}
 				connectionAttempt.connectionHandle = gapEvent.conn_handle
 				connectionAttempt.state.Set(2) // connection was successful
+				DefaultAdapter.connectHandler(Address{}, true)
 			}
 		case C.BLE_GAP_EVT_DISCONNECTED:
 			if debug {
@@ -92,6 +94,7 @@ func handleEvent() {
 				// necessary.
 				C.sd_ble_gap_adv_start(defaultAdvertisement.handle, C.BLE_CONN_CFG_TAG_DEFAULT)
 			}
+			DefaultAdapter.connectHandler(Address{}, false)
 		case C.BLE_GAP_EVT_ADV_REPORT:
 			advReport := gapEvent.params.unionfield_adv_report()
 			if debug && &scanReportBuffer.data[0] != advReport.data.p_data {

--- a/adapter_nrf528xx.go
+++ b/adapter_nrf528xx.go
@@ -64,14 +64,14 @@ func handleEvent() {
 					println("evt: connected in peripheral role")
 				}
 				currentConnection.Reg = gapEvent.conn_handle
-				DefaultAdapter.connectHandler(Address{}, true)
+				DefaultAdapter.connectHandler(nil, true)
 			case C.BLE_GAP_ROLE_CENTRAL:
 				if debug {
 					println("evt: connected in central role")
 				}
 				connectionAttempt.connectionHandle = gapEvent.conn_handle
 				connectionAttempt.state.Set(2) // connection was successful
-				DefaultAdapter.connectHandler(Address{}, true)
+				DefaultAdapter.connectHandler(nil, true)
 			}
 		case C.BLE_GAP_EVT_DISCONNECTED:
 			if debug {
@@ -94,7 +94,7 @@ func handleEvent() {
 				// necessary.
 				C.sd_ble_gap_adv_start(defaultAdvertisement.handle, C.BLE_CONN_CFG_TAG_DEFAULT)
 			}
-			DefaultAdapter.connectHandler(Address{}, false)
+			DefaultAdapter.connectHandler(nil, false)
 		case C.BLE_GAP_EVT_ADV_REPORT:
 			advReport := gapEvent.params.unionfield_adv_report()
 			if debug && &scanReportBuffer.data[0] != advReport.data.p_data {

--- a/adapter_sd.go
+++ b/adapter_sd.go
@@ -39,13 +39,18 @@ type Adapter struct {
 	isDefault         bool
 	scanning          bool
 	charWriteHandlers []charWriteHandler
+
+	connectHandler func(device Addresser, connected bool)
 }
 
 // DefaultAdapter is the default adapter on the current system. On Nordic chips,
 // it will return the SoftDevice interface.
 //
 // Make sure to call Enable() before using it to initialize the adapter.
-var DefaultAdapter = &Adapter{isDefault: true}
+var DefaultAdapter = &Adapter{isDefault: true,
+	connectHandler: func(device Addresser, connected bool) {
+		return
+	}}
 
 // Enable configures the BLE stack. It must be called before any
 // Bluetooth-related calls (unless otherwise indicated).

--- a/adapter_windows.go
+++ b/adapter_windows.go
@@ -7,12 +7,18 @@ import (
 
 type Adapter struct {
 	watcher *winbt.IBluetoothLEAdvertisementWatcher
+
+	connectHandler func(device Addresser, connected bool)
 }
 
 // DefaultAdapter is the default adapter on the system.
 //
 // Make sure to call Enable() before using it to initialize the adapter.
-var DefaultAdapter = &Adapter{}
+var DefaultAdapter = &Adapter{
+	connectHandler: func(device Addresser, connected bool) {
+		return
+	},
+}
 
 // Enable configures the BLE stack. It must be called before any
 // Bluetooth-related calls (unless otherwise indicated).

--- a/gap_darwin.go
+++ b/gap_darwin.go
@@ -116,7 +116,7 @@ func (a *Adapter) Connect(address Addresser, params ConnectionParams) (*Device, 
 		d.delegate = &peripheralDelegate{d: d}
 		p.SetDelegate(d.delegate)
 
-		a.connectHandler(Address{}, true)
+		a.connectHandler(nil, true)
 
 		return d, nil
 	case <-time.NewTimer(10 * time.Second).C:

--- a/gap_darwin.go
+++ b/gap_darwin.go
@@ -116,6 +116,8 @@ func (a *Adapter) Connect(address Addresser, params ConnectionParams) (*Device, 
 		d.delegate = &peripheralDelegate{d: d}
 		p.SetDelegate(d.delegate)
 
+		a.connectHandler(Address{}, true)
+
 		return d, nil
 	case <-time.NewTimer(10 * time.Second).C:
 		return nil, errors.New("timeout on Connect")

--- a/gap_linux.go
+++ b/gap_linux.go
@@ -259,6 +259,9 @@ func (a *Adapter) Connect(address Addresser, params ConnectionParams) (*Device, 
 		}
 	}
 
+	// TODO: a proper async callback.
+	a.connectHandler(Address{}, true)
+
 	return &Device{
 		device: dev,
 	}, nil

--- a/gap_linux.go
+++ b/gap_linux.go
@@ -260,7 +260,7 @@ func (a *Adapter) Connect(address Addresser, params ConnectionParams) (*Device, 
 	}
 
 	// TODO: a proper async callback.
-	a.connectHandler(Address{}, true)
+	a.connectHandler(nil, true)
 
 	return &Device{
 		device: dev,


### PR DESCRIPTION
This PR adds a connection handler to be called on adapter connect/disconnect whenever possible.

The `Addresser` param passed in is not currently populated, but the second param telling if we are connecting or disconnecting is hooked up.