### PR TITLE
UUID parsing error

### DIFF
--- a/uuid.go
+++ b/uuid.go
@@ -115,12 +115,12 @@ func ParseUUID(s string) (uuid UUID, err error) {
 		uuid[3-uuidIndex/8] |= uint32(nibble) << (4 * (7 - uuidIndex%8))
 		uuidIndex++
 	}
-	if uuidIndex != 31 {
+	if uuidIndex != 32 {
 		// The UUID doesn't have exactly 32 nibbles. Perhaps a 16-bit or 32-bit
 		// UUID?
 		err = errInvalidUUID
 	}
-	return uuid, nil
+	return
 }
 
 // String returns a human-readable version of this UUID, such as

--- a/uuid_test.go
+++ b/uuid_test.go
@@ -1,13 +1,40 @@
 package bluetooth
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestUUIDString(t *testing.T) {
-	checkUUID(t, New16BitUUID(0x1234), "00001234-0000-1000-8000-00805F9B34FB")
+	checkUUID(t, New16BitUUID(0x1234), "00001234-0000-1000-8000-00805f9b34fb")
 }
 
 func checkUUID(t *testing.T, uuid UUID, check string) {
 	if uuid.String() != check {
 		t.Errorf("expected UUID %s but got %s", check, uuid.String())
+	}
+}
+
+func TestParseUUIDTooSmall(t *testing.T) {
+	_, e := ParseUUID("00001234-0000-1000-8000-00805f9b34f")
+	if e != errInvalidUUID {
+		t.Errorf("expected errInvalidUUID but got %v", e)
+	}
+}
+
+func TestParseUUIDTooLarge(t *testing.T) {
+	_, e := ParseUUID("00001234-0000-1000-8000-00805F9B34FB0")
+	if e != errInvalidUUID {
+		t.Errorf("expected errInvalidUUID but got %v", e)
+	}
+}
+
+func TestStringUUID(t *testing.T) {
+	uuidString := "00001234-0000-1000-8000-00805f9b34fb"
+	u, e := ParseUUID(uuidString)
+	if e != nil {
+		t.Errorf("expected nil but got %v", e)
+	}
+	if u.String() != uuidString {
+		t.Errorf("expected %s but got %s", uuidString, u.String())
 	}
 }


### PR DESCRIPTION
This PR replaces #6  .

Added a few unit tests to check if problem  is resolved.
For some reasones UUID strings are lowercase. Not sure if this was intended.