### PR TITLE
examples: add channelscan example that shows use of goroutines and channels

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,8 @@ smoketest-tinygo:
 	@md5sum test.hex
 	$(TINYGO) build -o test.uf2 -size=short -target=circuitplay-bluefruit ./examples/discover
 	@md5sum test.hex
+	$(TINYGO) build -o test.uf2 -size=short -target=circuitplay-bluefruit ./examples/channelscan
+	@md5sum test.hex
 	$(TINYGO) build -o test.hex -size=short -target=pca10040-s132v6       ./examples/heartrate
 	@md5sum test.hex
 	$(TINYGO) build -o test.hex -size=short -target=reelboard-s140v7      ./examples/ledcolor
@@ -41,12 +43,14 @@ smoketest-linux:
 	GOOS=linux go build -o /tmp/go-build-discard ./examples/nusserver
 	GOOS=linux go build -o /tmp/go-build-discard ./examples/scanner
 	GOOS=linux go build -o /tmp/go-build-discard ./examples/discover
+	GOOS=linux go build -o /tmp/go-build-discard ./examples/channelscan
 
 smoketest-windows:
 	# Test on Windows.
 	GOOS=windows CGO_ENABLED=1 CC=x86_64-w64-mingw32-gcc go build -o /tmp/go-build-discard ./examples/scanner
 	GOOS=windows CGO_ENABLED=1 CC=x86_64-w64-mingw32-gcc go build -o /tmp/go-build-discard ./examples/discover
 	GOOS=windows CGO_ENABLED=1 CC=x86_64-w64-mingw32-gcc go build -o /tmp/go-build-discard ./examples/heartrate-monitor
+	GOOS=windows CGO_ENABLED=1 CC=x86_64-w64-mingw32-gcc go build -o /tmp/go-build-discard ./examples/channelscan
 
 smoketest-macos:
 	# Test on macos.
@@ -54,6 +58,7 @@ smoketest-macos:
 	GOOS=darwin CGO_ENABLED=1 go build -o /tmp/go-build-discard ./examples/discover
 	GOOS=darwin CGO_ENABLED=1 go build -o /tmp/go-build-discard ./examples/nusclient
 	GOOS=darwin CGO_ENABLED=1 go build -o /tmp/go-build-discard ./examples/heartrate-monitor
+	GOOS=darwin CGO_ENABLED=1 go build -o /tmp/go-build-discard ./examples/channelscan
 
 gen-uuids:
 	# generate the standard service and characteristic UUIDs

--- a/examples/channelscan/main.go
+++ b/examples/channelscan/main.go
@@ -1,0 +1,71 @@
+// This example program shows using Go routines and channels to coordinate
+// BLE scanning.
+//
+// The first Go routine starts scanning using the BLE adaptor. When it finds
+// a new device, it puts the information into a channel so it can be displayed.
+//
+// The second Go routine is a ticker that puts a "true" value into a channel every 3 seconds.
+//
+// The main function uses a select{} statement to wait until one of the two channels is unblocked
+// by receiving data. If a new device is found, the boolean variable named "found" will
+// be set to true, so that the timeout is reset for each 3 second period.
+package main
+
+import (
+	"time"
+
+	"tinygo.org/x/bluetooth"
+)
+
+var (
+	adapter = bluetooth.DefaultAdapter
+	devices = make(chan bluetooth.ScanResult, 1)
+	ticker  = make(chan bool, 1)
+	found   = true
+)
+
+func main() {
+	// Enable BLE interface.
+	if err := adapter.Enable(); err != nil {
+		panic("failed to enable adaptor:" + err.Error())
+	}
+
+	// Start scanning
+	go performScan()
+
+	// Start timeout ticker
+	go startTicker()
+
+	// Wait for devices to be scanned
+	for {
+		select {
+		case device := <-devices:
+			found = true
+			println("found device:", device.Address.String(), device.RSSI, device.LocalName())
+		case <-ticker:
+			if !found {
+				println("no devices found in last 3 seconds...")
+			}
+			found = false
+		}
+	}
+}
+
+func performScan() {
+	println("scanning...")
+
+	err := adapter.Scan(func(adapter *bluetooth.Adapter, device bluetooth.ScanResult) {
+		devices <- device
+	})
+	if err != nil {
+		panic("failed to scan:" + err.Error())
+	}
+}
+
+func startTicker() {
+	for {
+		time.Sleep(3 * time.Second)
+		ticker <- true
+	}
+
+}


### PR DESCRIPTION
This PR adds the "channelscan" example that shows use of goroutines and channels with Go Bluetooth.