### PR TITLE
gattc/linux: correct false positive error when using DiscoverServices

### DIFF
--- a/gattc_linux.go
+++ b/gattc_linux.go
@@ -107,7 +107,7 @@ func (d *Device) DiscoverServices(uuids []UUID) ([]DeviceService, error) {
 		uuidServices[service.Properties.UUID] = service.Properties.UUID
 	}
 
-	if servicesFound <= len(uuids) {
+	if servicesFound < len(uuids) {
 		return nil, errors.New("bluetooth: could not find some services")
 	}
 


### PR DESCRIPTION
This PR corrects a false positive error when using `DiscoverServices()` with a specific list of UUID under Linux.