### PR TITLE
nrf: keep advertisement payload alive

### DIFF
--- a/gap.go
+++ b/gap.go
@@ -254,6 +254,13 @@ func (buf *rawAdvertisementPayload) HasServiceUUID(uuid UUID) bool {
 	}
 }
 
+// reset restores this buffer to the original state.
+func (buf *rawAdvertisementPayload) reset() {
+	// The data is not reset (only the length), because with a zero length the
+	// data is undefined.
+	buf.len = 0
+}
+
 // addFromOptions constructs a new advertisement payload (assumed to be empty
 // before the call) from the advertisement options. It returns true if it fits,
 // false otherwise.


### PR DESCRIPTION
The memory from the advertisement payload must be kept alive until the
advertisement is stopped. Therefore, it is not allowed to use a local
variable for it. Instead, it is now part of the defaultAdvertisement
global which of course is alive as long as the program runs.