### PR TITLE
examples: extend HRS to perform notifications, add heartrate-monitor …

### DIFF
--- a/examples/heartrate-monitor/main.go
+++ b/examples/heartrate-monitor/main.go
@@ -1,0 +1,99 @@
+// This example scans and then connects to a specific Bluetooth peripheral
+// that can provide the Heart Rate Service (HRS).
+//
+// Once connected, it subscribes to notifications for the data value, and
+// displays it.
+//
+// To run this on a desktop system:
+//
+// 		go run ./examples/heartrate-monitor EE:74:7D:C9:2A:68
+//
+// To run this on a microcontroller, change the constant value in the file
+// "mcu.go" to set the MAC address of the device you want to discover.
+// Then, flash to the microcontroller board like this:
+//
+//		tinygo flash -o circuitplay-bluefruit ./examples/heartrate-monitor
+//
+// Once the program is flashed to the board, connect to the USB port
+// via serial to view the output.
+//
+package main
+
+import (
+	"tinygo.org/x/bluetooth"
+)
+
+var (
+	adapter = bluetooth.DefaultAdapter
+
+	heartRateServiceUUID        = bluetooth.New16BitUUID(0x180D)
+	heartRateCharacteristicUUID = bluetooth.New16BitUUID(0x2A37)
+)
+
+func main() {
+	println("enabling")
+
+	// Enable BLE interface.
+	must("enable BLE stack", adapter.Enable())
+
+	ch := make(chan bluetooth.ScanResult, 1)
+
+	// Start scanning.
+	println("scanning...")
+	err := adapter.Scan(func(adapter *bluetooth.Adapter, result bluetooth.ScanResult) {
+		println("found device:", result.Address.String(), result.RSSI, result.LocalName())
+		if result.Address.String() == connectAddress() {
+			adapter.StopScan()
+			ch <- result
+		}
+	})
+
+	var device *bluetooth.Device
+	select {
+	case result := <-ch:
+		device, err = adapter.Connect(result.Address, bluetooth.ConnectionParams{})
+		if err != nil {
+			println(err.Error())
+			return
+		}
+
+		println("connected to ", result.Address.String())
+	}
+
+	// get services
+	println("discovering services/characteristics")
+	srvcs, err := device.DiscoverServices([]bluetooth.UUID{heartRateServiceUUID})
+	must("discover services", err)
+
+	if len(srvcs) == 0 {
+		panic("could not find heart rate service")
+	}
+
+	srvc := srvcs[0]
+
+	println("found service", srvc.UUID().String())
+
+	chars, err := srvc.DiscoverCharacteristics([]bluetooth.UUID{heartRateCharacteristicUUID})
+	if err != nil {
+		println(err)
+	}
+
+	if len(chars) == 0 {
+		panic("could not find heart rate characteristic")
+	}
+
+	char := chars[0]
+	println("found characteristic", char.UUID().String())
+
+	char.EnableNotifications(func(buf []byte) {
+		println("data:", uint8(buf[0]))
+	})
+
+	select {}
+}
+
+func must(action string, err error) {
+	if err != nil {
+		panic("failed to " + action + ": " + err.Error())
+	}
+}

--- a/examples/heartrate-monitor/mcu.go
+++ b/examples/heartrate-monitor/mcu.go
@@ -1,0 +1,21 @@
+// +build baremetal
+
+package main
+
+import (
+	"time"
+)
+
+// replace this with the MAC address of the Bluetooth peripheral you want to connect to.
+const deviceAddress = "E4:B7:F4:11:8D:33"
+
+func connectAddress() string {
+	return deviceAddress
+}
+
+// done just blocks forever, allows USB CDC reset for flashing new software.
+func done() {
+	println("Done.")
+
+	time.Sleep(1 * time.Hour)
+}

--- a/examples/heartrate-monitor/os.go
+++ b/examples/heartrate-monitor/os.go
@@ -1,0 +1,22 @@
+// +build !baremetal
+
+package main
+
+import "os"
+
+func connectAddress() string {
+	if len(os.Args) < 2 {
+		println("usage: heartrate-monitor [address]")
+		os.Exit(1)
+	}
+
+	// look for device with specific name
+	address := os.Args[1]
+
+	return address
+}
+
+// done just prints a message and allows program to exit.
+func done() {
+	println("Done.")
+}


### PR DESCRIPTION
This PR extends extend the heartrate example to perform notifications and then also adds a new "heartrate-monitor" example that shows these notifications, if connected:

```
found device: E4:B7:F4:11:8D:33 -42 Go HRS
connected to  E4:B7:F4:11:8D:33
discovering services/characteristics
found service 0000180d-0000-1000-8000-00805f9b34fb
found characteristic 00002a37-0000-1000-8000-00805f9b34fb
data: 68
data: 79
data: 67
data: 78
data: 79
```