### PR TITLE
examples: let macos use rawterm to compile nusclient

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,3 +43,4 @@ smoketest-macos:
 	# Test on macos.
 	GOOS=darwin CGO_ENABLED=1 go build -o /tmp/go-build-discard ./examples/scanner
 	GOOS=darwin CGO_ENABLED=1 go build -o /tmp/go-build-discard ./examples/discover
+	GOOS=darwin CGO_ENABLED=1 go build -o /tmp/go-build-discard ./examples/nusclient

--- a/rawterm/hosted.go
+++ b/rawterm/hosted.go
@@ -1,4 +1,4 @@
-// +build linux,!baremetal
+// +build linux,!baremetal darwin
 
 // Package rawterm provides some sort of raw terminal interface, both on hosted
 // systems and baremetal. It is intended only for use by examples.


### PR DESCRIPTION
This PR lets macos use rawterm to compile nusclient example, and also adds it to the smoketests.