### PR TITLE
gap: change signature for Addresser interface Set() function

### DIFF
--- a/gap.go
+++ b/gap.go
@@ -30,8 +30,12 @@ func (mac MACAddress) SetRandom(val bool) {
 }
 
 // Set the address
-func (mac MACAddress) Set(val interface{}) {
-	m := val.(MAC)
+func (mac MACAddress) Set(val string) {
+	m, err := ParseMAC(val)
+	if err != nil {
+		return
+	}
+
 	mac.MAC = m
 }
 
@@ -72,7 +76,7 @@ type Addresser interface {
 	String() string
 
 	// Set the address
-	Set(val interface{})
+	Set(val string)
 
 	// Is this address a random address?
 	// Bluetooth addresses are roughly split in two kinds: public

--- a/gap_darwin.go
+++ b/gap_darwin.go
@@ -24,8 +24,12 @@ func (ad Address) SetRandom(val bool) {
 }
 
 // Set the address
-func (ad Address) Set(val interface{}) {
-	ad.UUID = val.(UUID)
+func (ad Address) Set(val string) {
+	uuid, err := ParseUUID(val)
+	if err != nil {
+		return
+	}
+	ad.UUID = uuid
 }
 
 // Scan starts a BLE scan. It is stopped by a call to StopScan. A common pattern


### PR DESCRIPTION
This PR changes the signature for the `Addresser` interface `Set()` function to accept a string and then parse it into the address (MAC or UUID) as needed.