### PR TITLE
gap/all: add Disconnect() to Driver

### DIFF
--- a/examples/discover/main.go
+++ b/examples/discover/main.go
@@ -17,15 +17,13 @@
 package main
 
 import (
-	"time"
-
 	"tinygo.org/x/bluetooth"
 )
 
 var adapter = bluetooth.DefaultAdapter
 
 func main() {
-	time.Sleep(3 * time.Second)
+	wait()
 
 	println("enabling")
 

--- a/examples/discover/main.go
+++ b/examples/discover/main.go
@@ -73,6 +73,11 @@ func main() {
 		}
 	}
 
+	err = device.Disconnect()
+	if err != nil {
+		println(err)
+	}
+
 	done()
 }
 

--- a/examples/discover/mcu.go
+++ b/examples/discover/mcu.go
@@ -13,6 +13,11 @@ func connectAddress() string {
 	return deviceAddress
 }
 
+// wait on baremetal, proceed immediately on desktop OS.
+func wait() {
+	time.Sleep(3 * time.Second)
+}
+
 // done just blocks forever, allows USB CDC reset for flashing new software.
 func done() {
 	println("Done.")

--- a/examples/discover/os.go
+++ b/examples/discover/os.go
@@ -16,6 +16,10 @@ func connectAddress() string {
 	return address
 }
 
+// wait on baremetal, proceed immediately on desktop OS.
+func wait() {
+}
+
 // done just prints a message and allows program to exit.
 func done() {
 	println("Done.")

--- a/gap_darwin.go
+++ b/gap_darwin.go
@@ -128,6 +128,12 @@ func (a *Adapter) Connect(address Addresser, params ConnectionParams) (*Device, 
 	}
 }
 
+// Disconnect from the BLE device.
+func (d *Device) Disconnect() error {
+	d.cm.CancelConnect(d.prph)
+	return nil
+}
+
 // Peripheral delegate functions
 
 type peripheralDelegate struct {

--- a/gap_linux.go
+++ b/gap_linux.go
@@ -266,3 +266,8 @@ func (a *Adapter) Connect(address Addresser, params ConnectionParams) (*Device, 
 		device: dev,
 	}, nil
 }
+
+// Disconnect from the BLE device.
+func (d *Device) Disconnect() error {
+	return d.device.Disconnect()
+}

--- a/gap_nrf528xx.go
+++ b/gap_nrf528xx.go
@@ -252,3 +252,13 @@ func (a *Adapter) Connect(address Addresser, params ConnectionParams) (*Device, 
 		connectionHandle: connectionHandle,
 	}, nil
 }
+
+// Disconnect from the BLE device.
+func (d *Device) Disconnect() error {
+	errCode := C.sd_ble_gap_disconnect(d.connectionHandle, C.BLE_HCI_REMOTE_USER_TERMINATED_CONNECTION)
+	if errCode != 0 {
+		return Error(errCode)
+	}
+
+	return nil
+}


### PR DESCRIPTION
This PR adds a `Disconnect()` function to `Device` as mentioned in #30 

It also modifies the `discover` example to call `Disconnect()` on completion. 

There is another small change to this same example, which is to only wait on startup on baremetal. This actually also causes a problem on macOS, so it is a needed change as well.