### PR TITLE
Document async Disconnect behaviour

### DIFF
--- a/gap_darwin.go
+++ b/gap_darwin.go
@@ -128,7 +128,8 @@ func (a *Adapter) Connect(address Addresser, params ConnectionParams) (*Device, 
 	}
 }
 
-// Disconnect from the BLE device.
+// Disconnect from the BLE device. This method is non-blocking and does not
+// wait until the connection is fully gone.
 func (d *Device) Disconnect() error {
 	d.cm.CancelConnect(d.prph)
 	return nil

--- a/gap_linux.go
+++ b/gap_linux.go
@@ -267,7 +267,8 @@ func (a *Adapter) Connect(address Addresser, params ConnectionParams) (*Device, 
 	}, nil
 }
 
-// Disconnect from the BLE device.
+// Disconnect from the BLE device. This method is non-blocking and does not
+// wait until the connection is fully gone.
 func (d *Device) Disconnect() error {
 	return d.device.Disconnect()
 }


### PR DESCRIPTION
This was mentioned by @aykevl in https://github.com/tinygo-org/bluetooth/pull/32#issuecomment-698313299

Sorry if it is a low-effort PR, hopefully it is still useful though.

I would love to also document the behavior in linux, but I'm not sure how to figure it out.

Any suggestions are welcome :)