### PR TITLE
all: fix Go module name and import path

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,6 @@ jobs:
   build:
     docker:
       - image: tinygo/tinygo-dev
-    working_directory: /usr/local/go/src/github.com/tinygo-org/bluetooth
     steps:
       - checkout
       - run: tinygo version


### PR DESCRIPTION
This completes the switch over to tinygo.org/x/bluetooth (from github.com/tinygo-org/bluetooth). I spent some time debugging an issue that was caused by some confusion over the import path, among others.