### PR TITLE
darwin: properly handle 16-bit UUIDs for service and characteristics

### DIFF
--- a/uuid.go
+++ b/uuid.go
@@ -11,20 +11,6 @@ type UUID [4]uint32
 
 var errInvalidUUID = errors.New("bluetooth: failed to parse UUID")
 
-// New16BitUUID returns a new 128-bit UUID based on a 16-bit UUID.
-//
-// Note: only use registered UUIDs. See
-// https://www.bluetooth.com/specifications/gatt/services/ for a list.
-func New16BitUUID(shortUUID uint16) UUID {
-	// https://stackoverflow.com/questions/36212020/how-can-i-convert-a-bluetooth-16-bit-service-uuid-into-a-128-bit-uuid
-	var uuid UUID
-	uuid[0] = 0x5F9B34FB
-	uuid[1] = 0x80000080
-	uuid[2] = 0x00001000
-	uuid[3] = uint32(shortUUID)
-	return uuid
-}
-
 // NewUUID returns a new UUID based on the 128-bit (or 16-byte) input.
 func NewUUID(uuid [16]byte) UUID {
 	u := UUID{}

--- a/uuid16.go
+++ b/uuid16.go
@@ -1,0 +1,17 @@
+// +build !darwin
+
+package bluetooth
+
+// New16BitUUID returns a new 128-bit UUID based on a 16-bit UUID.
+//
+// Note: only use registered UUIDs. See
+// https://www.bluetooth.com/specifications/gatt/services/ for a list.
+func New16BitUUID(shortUUID uint16) UUID {
+	// https://stackoverflow.com/questions/36212020/how-can-i-convert-a-bluetooth-16-bit-service-uuid-into-a-128-bit-uuid
+	var uuid UUID
+	uuid[0] = 0x5F9B34FB
+	uuid[1] = 0x80000080
+	uuid[2] = 0x00001000
+	uuid[3] = uint32(shortUUID)
+	return uuid
+}

--- a/uuid16_darwin.go
+++ b/uuid16_darwin.go
@@ -1,0 +1,15 @@
+package bluetooth
+
+// New16BitUUID returns a new 128-bit UUID based on a 16-bit UUID.
+//
+// Note: only use registered UUIDs. See
+// https://www.bluetooth.com/specifications/gatt/services/ for a list.
+func New16BitUUID(shortUUID uint16) UUID {
+	// mac OS uses a unique format for UUID.
+	var uuid UUID
+	uuid[0] = 0x00000000
+	uuid[1] = 0x00000000
+	uuid[2] = 0x00000000
+	uuid[3] = uint32(shortUUID) << 16
+	return uuid
+}


### PR DESCRIPTION
This PR properly handles the 16-bit UUIDs for service and characteristics in the unique format used by macOS.