### PR TITLE
darwin: make Adapter.Connect thread-safe

### DIFF
--- a/gap_darwin.go
+++ b/gap_darwin.go
@@ -105,11 +105,18 @@ func (a *Adapter) Connect(address Addresser, params ConnectionParams) (*Device, 
 	if len(prphs) == 0 {
 		return nil, fmt.Errorf("Connect failed: no peer with address: %s", adr.UUID.String())
 	}
+
+	id := prphs[0].Identifier().String()
+	prphCh := make(chan cbgo.Peripheral)
+
+	a.connectMap.Store(id, prphCh)
+	defer a.connectMap.Delete(id)
+
 	a.cm.Connect(prphs[0], nil)
 
 	// wait on channel for connect
 	select {
-	case p := <-a.connectChan:
+	case p := <-prphCh:
 		d := &Device{
 			cm:           a.cm,
 			prph:         p,


### PR DESCRIPTION
This change allows multiple concurrent goroutines to call
`Adapter.Connect` without racing.

Fixes #57.

I've tested this locally to confirm that it fixes the case where I saw the buggy behavior described in #57.

Kind of a naive implementation. Another option would be to just add a `sync.Mutex` around the entire `adapter.Connect` call, but the current approach lets us initiate connections with multiple devices at once without blocking other callers.