### PR TITLE
sd: use constants from C instead of magic numbers

### DIFF
--- a/error_sd.go
+++ b/error_sd.go
@@ -3,73 +3,77 @@
 
 package bluetooth
 
+// #include "nrf_error.h"
+// #include "nrf_error_sdm.h"
+import "C"
+
 // Error is an error from within the SoftDevice.
 type Error uint32
 
 func (e Error) Error() string {
 	switch {
-	case e < 0x1000:
+	case e >= C.NRF_ERROR_BASE_NUM && e < C.NRF_ERROR_SDM_BASE_NUM:
 		// Global errors.
 		switch e {
-		case 0:
+		case C.NRF_SUCCESS:
 			return "no error"
-		case 1:
+		case C.NRF_ERROR_SVC_HANDLER_MISSING:
 			return "SVC handler is missing"
-		case 2:
+		case C.NRF_ERROR_SOFTDEVICE_NOT_ENABLED:
 			return "SoftDevice has not been enabled"
-		case 3:
+		case C.NRF_ERROR_INTERNAL:
 			return "internal error"
-		case 4:
+		case C.NRF_ERROR_NO_MEM:
 			return "no memory for operation"
-		case 5:
+		case C.NRF_ERROR_NOT_FOUND:
 			return "not found"
-		case 6:
+		case C.NRF_ERROR_NOT_SUPPORTED:
 			return "not supported"
-		case 7:
+		case C.NRF_ERROR_INVALID_PARAM:
 			return "invalid parameter"
-		case 8:
+		case C.NRF_ERROR_INVALID_STATE:
 			return "invalid state, operation disallowed in this state"
-		case 9:
+		case C.NRF_ERROR_INVALID_LENGTH:
 			return "invalid Length"
-		case 10:
+		case C.NRF_ERROR_INVALID_FLAGS:
 			return "invalid flags"
-		case 11:
+		case C.NRF_ERROR_INVALID_DATA:
 			return "invalid data"
-		case 12:
+		case C.NRF_ERROR_DATA_SIZE:
 			return "invalid data size"
-		case 13:
+		case C.NRF_ERROR_TIMEOUT:
 			return "operation timed out"
-		case 14:
+		case C.NRF_ERROR_NULL:
 			return "null pointer"
-		case 15:
+		case C.NRF_ERROR_FORBIDDEN:
 			return "forbidden operation"
-		case 16:
+		case C.NRF_ERROR_INVALID_ADDR:
 			return "bad memory address"
-		case 17:
+		case C.NRF_ERROR_BUSY:
 			return "busy"
-		case 18:
+		case 18: // C.NRF_ERROR_CONN_COUNT, not available on nrf51
 			return "maximum connection count exceeded"
-		case 19:
+		case 19: // C.NRF_ERROR_RESOURCES, not available on nrf51
 			return "not enough resources for operation"
 		default:
 			return "other global error"
 		}
-	case e < 0x2000:
+	case e >= C.NRF_ERROR_SDM_BASE_NUM && e < C.NRF_ERROR_SOC_BASE_NUM:
 		// SDM errors.
 		switch e {
-		case 0x1000:
+		case C.NRF_ERROR_SDM_LFCLK_SOURCE_UNKNOWN:
 			return "unknown LFCLK source"
-		case 0x1001:
+		case C.NRF_ERROR_SDM_INCORRECT_INTERRUPT_CONFIGURATION:
 			return "incorrect interrupt configuration"
-		case 0x1002:
+		case C.NRF_ERROR_SDM_INCORRECT_CLENR0:
 			return "incorrect CLENR0"
 		default:
 			return "other SDM error"
 		}
-	case e < 0x3000:
+	case e >= C.NRF_ERROR_SOC_BASE_NUM && e < C.NRF_ERROR_STK_BASE_NUM:
 		// SoC errors.
 		return "other SoC error"
-	case e < 0x4000:
+	case e >= C.NRF_ERROR_STK_BASE_NUM && e < 0x4000:
 		// STK errors.
 		return "other STK error"
 	default:


### PR DESCRIPTION
This change depends on https://github.com/tinygo-org/tinygo/pull/1896.