### PR TITLE
add support multiple services and notifications for macOS(darwin)

### DIFF
--- a/gap_darwin.go
+++ b/gap_darwin.go
@@ -166,14 +166,16 @@ func (pd *peripheralDelegate) DidDiscoverCharacteristics(prph cbgo.Peripheral, s
 // for a Peripheral receives a notification with a new value,
 // or receives a value for a read request.
 func (pd *peripheralDelegate) DidUpdateValueForCharacteristic(prph cbgo.Peripheral, chr cbgo.Characteristic, err error) {
+	svcuuid, _ := ParseUUID(chr.Service().UUID().String())
 	uuid, _ := ParseUUID(chr.UUID().String())
-	if char, ok := pd.d.characteristics[uuid]; ok {
-		if err == nil && char.callback != nil {
-			go char.callback(chr.Value())
-		}
-
-		if char.readChan != nil {
-			char.readChan <- err
+	if svc, ok := pd.d.services[svcuuid]; ok {
+		if char, ok := svc.characteristics[uuid]; ok {
+			if err == nil && char.callback != nil {
+				go char.callback(chr.Value())
+			}
+			if char.readChan != nil {
+				char.readChan <- err
+			}
 		}
 	}
 }


### PR DESCRIPTION
#54 fix

Add support multiple services and notifications for macOS.

## Reason:

DeviceService-Value has a pointer for "cache of characteristics".
DeviceService-Value argument is a duplicated value.
So this cache pointer diverges before and after calling the DiscoverCharacteristics method.

https://github.com/tinygo-org/bluetooth/pull/56/files#diff-ab073822f13f923ebae9d8ec0e06899ef263c615fb9d27794634260744015bb9L90-L91

## Changes:

- DeviceService rename to deviceService and wrapped `DeviceService{*deviceService}`
- DeviceService has charactaristics-cache.
