### PR TITLE
fixes bluez 5.55 service registration allowing muka to be updated.

### DIFF
--- a/gatts_linux.go
+++ b/gatts_linux.go
@@ -24,6 +24,13 @@ func (a *Adapter) AddService(s *Service) error {
 		return err
 	}
 
+	// disable magic uuid generation because we send through a fully formed UUID.
+	// muka/go-bluetooth does some magic so you can use short UUIDs and it'll auto
+	// expand them to the full 128 bit uuid.
+	// setting these flags disables that behavior.
+	app.Options.UUIDSuffix = ""
+	app.Options.UUID = ""
+
 	bluezService, err := app.NewService(s.UUID.String())
 	if err != nil {
 		return err


### PR DESCRIPTION
muka/go-bluetooth does some magic so you can use short UUIDs and it'll auto
expand them to the full 128 bit uuid. setting these flags disables that behavior.

related issues:
- allows updating muka library to resolve https://github.com/tinygo-org/bluetooth/issues/35
- fixes the regression the upgrade caused https://github.com/tinygo-org/bluetooth/issues/46
- commit causing the regression in upstream https://github.com/muka/go-bluetooth/commit/1c4c1c86132bee2694386657a9e821c41b41d9ac

I am unsure how safe this change is for previous versions as I do not have any to test prior to bluez 5.60.

```golang
	svc := &bluetooth.Service{
		UUID: bluetooth.ServiceUUIDNordicUART,
	}

	if err = adapter.AddService(svc); err != nil {
		return errors.Wrap(err, "failed to add bluetooth service")
	}
```

before
```text
INFO[0000] muka/go-bluetooth generated uuid 6e400001-b5a3-f393-e0a9-e50e24dcca9e -> 12346e400001-b5a3-f393-e0a9-e50e24dcca9e-0000-1000-8000-00805F9B34FB 
2021/08/10 16:24:42 failed to add bluetooth service: Failed to create entry in database
```
after:
```text
INFO[0000] muka/go-bluetooth generated uuid 6e400001-b5a3-f393-e0a9-e50e24dcca9e -> 6e400001-b5a3-f393-e0a9-e50e24dcca9e
```

bluetooth logs describing failure:
```
Aug 10 16:24:42 dambli bluetoothd[538246]: src/gatt-database.c:database_add_service() Failed to read "UUID" property of service
Aug 10 16:24:42 dambli bluetoothd[538246]: src/gatt-database.c:database_add_app() Failed to add service
Aug 10 16:24:42 dambli bluetoothd[538246]: src/gatt-database.c:client_ready_cb() Failed to create GATT service entry in local database
```