### PR TITLE
nrf: fix CGo errors after TinyGo update

### DIFF
--- a/adapter_sd.go
+++ b/adapter_sd.go
@@ -10,6 +10,14 @@ import (
 	"unsafe"
 )
 
+// #include "ble.h"
+// #ifdef NRF51
+//   #include "nrf_soc.h"
+// #else
+//   #include "nrf_nvic.h"
+// #endif
+import "C"
+
 var (
 	ErrNotDefaultAdapter = errors.New("bluetooth: not the default adapter")
 )

--- a/gattc_sd.go
+++ b/gattc_sd.go
@@ -134,7 +134,7 @@ func (d *Device) DiscoverServices(uuids []UUID) ([]DeviceService, error) {
 
 		// Store the discovered service.
 		svc := DeviceService{
-			uuid:             suuid,
+			uuid:             shortUUID(suuid),
 			connectionHandle: d.connectionHandle,
 			startHandle:      startHandle,
 			endHandle:        endHandle,
@@ -276,7 +276,7 @@ func (s *DeviceService) DiscoverCharacteristics(uuids []UUID) ([]DeviceCharacter
 			permissions |= CharacteristicIndicatePermission
 		}
 
-		dc := DeviceCharacteristic{uuid: discoveringCharacteristic.uuid}
+		dc := DeviceCharacteristic{uuid: shortUUID(discoveringCharacteristic.uuid)}
 		dc.permissions = permissions
 		dc.valueHandle = foundCharacteristicHandle
 

--- a/gatts_sd.go
+++ b/gatts_sd.go
@@ -8,6 +8,7 @@ package bluetooth
 #define SVCALL_AS_NORMAL_FUNCTION
 
 #include "ble_gap.h"
+#include "ble_gatts.h"
 */
 import "C"
 

--- a/uuid_sd.go
+++ b/uuid_sd.go
@@ -39,7 +39,7 @@ func (s shortUUID) UUID() UUID {
 // IsIn checks the passed in slice of short UUIDs to see if this uuid is in it.
 func (s shortUUID) IsIn(uuids []C.ble_uuid_t) bool {
 	for _, u := range uuids {
-		if u == s {
+		if shortUUID(u) == s {
 			return true
 		}
 	}


### PR DESCRIPTION
For details, see: https://github.com/tinygo-org/tinygo/pull/2774
Basically, CGo got a bit more strict and requires proper imports of all C functions.

This is a backwards compatible change: current/older TinyGo can still compile the package with this patch applied.