### PR TITLE
{darwin,linux,windows,sd}: add get mtu function

### DIFF
--- a/gattc_darwin.go
+++ b/gattc_darwin.go
@@ -173,6 +173,11 @@ func (c DeviceCharacteristic) EnableNotifications(callback func(buf []byte)) err
 	return nil
 }
 
+// GetMTU returns the MTU for the characteristic.
+func (c DeviceCharacteristic) GetMTU() (uint16, error) {
+	return uint16(c.service.device.prph.MaximumWriteValueLength(false)), nil
+}
+
 // Read reads the current characteristic value.
 func (c *deviceCharacteristic) Read(data []byte) (n int, err error) {
 	c.readChan = make(chan error)

--- a/gattc_linux.go
+++ b/gattc_linux.go
@@ -238,6 +238,15 @@ func (c DeviceCharacteristic) EnableNotifications(callback func(buf []byte)) err
 	return c.characteristic.StartNotify()
 }
 
+// GetMTU returns the MTU for the characteristic.
+func (c DeviceCharacteristic) GetMTU() (uint16, error) {
+	mtu, err := c.characteristic.GetProperty("MTU")
+	if err != nil {
+		return uint16(0), err
+	}
+	return mtu.Value().(uint16), nil
+}
+
 // Read reads the current characteristic value.
 func (c *DeviceCharacteristic) Read(data []byte) (int, error) {
 	options := make(map[string]interface{})

--- a/gattc_sd.go
+++ b/gattc_sd.go
@@ -451,3 +451,8 @@ func (c *DeviceCharacteristic) Read(data []byte) (n int, err error) {
 
 	return
 }
+
+// GetMTU returns the MTU for the characteristic.
+func (c DeviceCharacteristic) GetMTU() (uint16, error) {
+	return uint16(C.BLE_GATT_ATT_MTU_DEFAULT), nil
+}

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/go-ole/go-ole v1.2.6
 	github.com/godbus/dbus/v5 v5.0.3
 	github.com/muka/go-bluetooth v0.0.0-20220830075246-0746e3a1ea53
-	github.com/saltosystems/winrt-go v0.0.0-20220826130236-ddc8202da421
+	github.com/saltosystems/winrt-go v0.0.0-20220913104103-712830fcd2ad
 	github.com/sirupsen/logrus v1.9.0 // indirect
 	github.com/tinygo-org/cbgo v0.0.4
 	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519

--- a/go.sum
+++ b/go.sum
@@ -34,8 +34,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/sago35/go-bdf v0.0.0-20200313142241-6c17821c91c4/go.mod h1:rOebXGuMLsXhZAC6mF/TjxONsm45498ZyzVhel++6KM=
-github.com/saltosystems/winrt-go v0.0.0-20220826130236-ddc8202da421 h1:eOgynOew0HzvLwtAsughGzqkrcuTJ6XFpT7+WNCuRNU=
-github.com/saltosystems/winrt-go v0.0.0-20220826130236-ddc8202da421/go.mod h1:UvKm1lyhg+8ehk99i8g5Q7AX1LXUJgks0lRyAkG/ahQ=
+github.com/saltosystems/winrt-go v0.0.0-20220913104103-712830fcd2ad h1:sE3kYG0WAV8eML/eK3uoKgsD85qH8yvlKuPGWOgAecg=
+github.com/saltosystems/winrt-go v0.0.0-20220913104103-712830fcd2ad/go.mod h1:UvKm1lyhg+8ehk99i8g5Q7AX1LXUJgks0lRyAkG/ahQ=
 github.com/sirupsen/logrus v1.5.0/go.mod h1:+F7Ogzej0PZc/94MaYx/nvG9jOFMD2osvC3s+Squfpo=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
 github.com/sirupsen/logrus v1.9.0 h1:trlNQbNUG3OdDrDil03MCb1H2o9nJ1x4/5LYw7byDE0=


### PR DESCRIPTION
This PR adds a function to retrieve the MTU of a characteristic on Darwin, Linux, Windows and SoftDevice. 

## Implementation details

I tried to keep the same signature on both implementations. So I had to adapt the Darwin implementation a little bit to match the requirements of linux:
- In Linux (`bluez`) we read the MTU property in the characteristic. So I did the same in other platforms, even though we read the MTU from the device.
- Since in Linux reading the MTU can fail, I added the same return type (`(uint16, error)`) on other platforms, even though it cannot fail.

Regarding Linux implementation, the MTU property is quite recent (bluez 5.62), so it is going to fail to anyone using an older version of bluez. I though about calling `AcquireWrite` as a fallback. This method returns a file descriptor to write messages and its MTU, and we could just call it and immediately close the file descriptor to get the MTU. But it felt ugly, and hacky, and I'm not sure if it has any other implications.