### PR TITLE
gatts/sd: [WIP] allow placing attribute values in user RAM

### DIFF
--- a/gatts_sd.go
+++ b/gatts_sd.go
@@ -54,10 +54,12 @@ func (a *Adapter) AddService(service *Service) error {
 			init_offs: 0,
 			max_len:   20, // This is a conservative maximum length.
 		}
+		var vlocBitfield uint8 = C.BLE_GATTS_VLOC_STACK
 		if len(char.Value) != 0 {
+			vlocBitfield = C.BLE_GATTS_VLOC_USER
 			value.p_value = &char.Value[0]
 		}
-		value.p_attr_md.set_bitfield_vloc(C.BLE_GATTS_VLOC_STACK)
+		value.p_attr_md.set_bitfield_vloc(vlocBitfield)
 		value.p_attr_md.set_bitfield_vlen(1)
 		errCode = C.sd_ble_gatts_characteristic_add(service.handle, &metadata, &value, &handles)
 		if errCode != 0 {


### PR DESCRIPTION
This PR targets issue #104 

This PR is Work in Progress: still need to find a platform-compatible way of determining
whether an attribute value must be located in stack or in user RAM for SoftDevice targets.

Currently, the algorithm works this way: if a characteristics' config
has an attribute value with length greater than zero, the value is set
to be placed in user RAM; otherwise, in stack.

This is a breaking change, since previous software written with non-zero
lengths attrib. values will not be aware that using user RAM instead of
the stack forces them to lock that RAM, i.e., the memory must be reserved
for the lifetime of the attribute. There should be an option for specifying
what attribute will go to RAM and what will go to stack, defaulting to stack,
but introducing new members in the CharacteristicsConfig struct will make
the source incompatible with targets other than SoftDevice.