### PR TITLE
Improve UUID

### DIFF
--- a/uuid.go
+++ b/uuid.go
@@ -118,6 +118,7 @@ func ParseUUID(s string) (uuid UUID, err error) {
 // 00001234-0000-1000-8000-00805f9b34fb.
 func (uuid UUID) String() string {
 	var s strings.Builder
+	s.Grow(36)
 	raw := uuid.Bytes()
 	for i := range raw {
 		// Insert a hyphen at the correct locations.

--- a/uuid.go
+++ b/uuid.go
@@ -3,7 +3,9 @@ package bluetooth
 // This file implements 16-bit and 128-bit UUIDs as defined in the Bluetooth
 // specification.
 
-import "errors"
+import (
+	"errors"
+)
 
 // UUID is a single UUID as used in the Bluetooth stack. It is represented as a
 // [4]uint32 instead of a [16]byte for efficiency.
@@ -90,6 +92,8 @@ func ParseUUID(s string) (uuid UUID, err error) {
 			nibble = c - '0' + 0x0
 		} else if c >= 'a' && c <= 'f' {
 			nibble = c - 'a' + 0xa
+		} else if c >= 'A' && c <= 'F' {
+			nibble = c - 'A' + 0xa
 		} else {
 			err = errInvalidUUID
 			return

--- a/uuid.go
+++ b/uuid.go
@@ -5,6 +5,7 @@ package bluetooth
 
 import (
 	"errors"
+	"strings"
 )
 
 // UUID is a single UUID as used in the Bluetooth stack. It is represented as a
@@ -116,13 +117,12 @@ func ParseUUID(s string) (uuid UUID, err error) {
 // String returns a human-readable version of this UUID, such as
 // 00001234-0000-1000-8000-00805f9b34fb.
 func (uuid UUID) String() string {
-	// TODO: make this more efficient.
-	s := ""
+	var s strings.Builder
 	raw := uuid.Bytes()
 	for i := range raw {
 		// Insert a hyphen at the correct locations.
 		if i == 4 || i == 6 || i == 8 || i == 10 {
-			s += "-"
+			s.WriteRune('-')
 		}
 
 		// The character to convert to hex.
@@ -131,19 +131,19 @@ func (uuid UUID) String() string {
 		// First nibble.
 		nibble := c >> 4
 		if nibble <= 9 {
-			s += string(nibble + '0')
+			s.WriteByte(nibble + '0')
 		} else {
-			s += string(nibble + 'a' - 10)
+			s.WriteByte(nibble + 'a' - 10)
 		}
 
 		// Second nibble.
 		nibble = c & 0x0f
 		if nibble <= 9 {
-			s += string(nibble + '0')
+			s.WriteByte(nibble + '0')
 		} else {
-			s += string(nibble + 'a' - 10)
+			s.WriteByte(nibble + 'a' - 10)
 		}
 	}
 
-	return s
+	return s.String()
 }

--- a/uuid_test.go
+++ b/uuid_test.go
@@ -68,6 +68,6 @@ func BenchmarkUUIDToString(b *testing.B) {
 		b.Errorf("expected nil but got %v", e)
 	}
 	for i := 0; i < b.N; i++ {
-		uuid.String()
+		_ = uuid.String()
 	}
 }

--- a/uuid_test.go
+++ b/uuid_test.go
@@ -1,6 +1,7 @@
 package bluetooth
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -36,5 +37,27 @@ func TestStringUUID(t *testing.T) {
 	}
 	if u.String() != uuidString {
 		t.Errorf("expected %s but got %s", uuidString, u.String())
+	}
+}
+
+func TestStringUUIDUpperCase(t *testing.T) {
+	uuidString := strings.ToUpper("00001234-0000-1000-8000-00805f9b34fb")
+	u, e := ParseUUID(uuidString)
+	if e != nil {
+		t.Errorf("expected nil but got %v", e)
+	}
+	if !strings.EqualFold(u.String(), uuidString) {
+		t.Errorf("%s does not match %s ignoring case", uuidString, u.String())
+	}
+}
+
+func TestStringUUIDLowerCase(t *testing.T) {
+	uuidString := strings.ToLower("00001234-0000-1000-8000-00805f9b34fb")
+	u, e := ParseUUID(uuidString)
+	if e != nil {
+		t.Errorf("expected nil but got %v", e)
+	}
+	if !strings.EqualFold(u.String(), uuidString) {
+		t.Errorf("%s does not match %s ignoring case", uuidString, u.String())
 	}
 }

--- a/uuid_test.go
+++ b/uuid_test.go
@@ -61,3 +61,13 @@ func TestStringUUIDLowerCase(t *testing.T) {
 		t.Errorf("%s does not match %s ignoring case", uuidString, u.String())
 	}
 }
+
+func BenchmarkUUIDToString(b *testing.B) {
+	uuid, e := ParseUUID("00001234-0000-1000-8000-00805f9b34fb")
+	if e != nil {
+		b.Errorf("expected nil but got %v", e)
+	}
+	for i := 0; i < b.N; i++ {
+		uuid.String()
+	}
+}


### PR DESCRIPTION
Updated the `ParseUUID` so it can handle both upper and lower-case hex numbers, added simple test-cases.

Also sped up the `UUID.String()` by using a `strings.Builder` and added a benchmark.

This is the difference on my PC when I temporarily had both:

```
go test -bench=^BenchmarkUUIDToString -benchmem      
goos: windows
goarch: amd64
pkg: tinygo.org/x/bluetooth
cpu: AMD Ryzen 9 3900X 12-Core Processor
BenchmarkUUIDToString-24                10256830              114.4 ns/op             48 B/op          1 allocs/op
BenchmarkUUIDToStringSlow-24              585391               1899 ns/op            944 B/op         67 allocs/op
PASS
ok      tinygo.org/x/bluetooth  2.732s
```

`BenchmarkUUIDToStringSlow` is the old implementation, `BenchmarkUUIDToString` the updated-one in this PR
