### PR TITLE
windows: disable cache when reading characteristics

### DIFF
--- a/gattc_windows.go
+++ b/gattc_windows.go
@@ -309,7 +309,7 @@ func (c *DeviceCharacteristic) Read(data []byte) (int, error) {
 		return 0, errNoRead
 	}
 
-	readOp, err := c.characteristic.ReadValueAsync()
+	readOp, err := c.characteristic.ReadValueWithCacheModeAsync(bluetooth.BluetoothCacheModeUncached)
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
The Windows cache may cause problems with characteristics that do not support notifications and require an explicit read. 
Checkout #119. 

This PR disables cache when reading characteristic values. 

fixes #119 