### PR TITLE
gap/linux: correct issue with new Bluez and manufacturer data

### DIFF
--- a/gap_linux.go
+++ b/gap_linux.go
@@ -246,6 +246,7 @@ func makeScanResult(props *device.Device1Properties) ScanResult {
 
 	mData := make(map[uint16][]byte)
 	for k, v := range props.ManufacturerData {
+		// can be either variant or just byte value
 		switch val := v.(type) {
 		case dbus.Variant:
 			mData[k] = val.Value().([]byte)

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.15
 require (
 	github.com/go-ole/go-ole v1.2.6
 	github.com/godbus/dbus/v5 v5.0.3
-	github.com/muka/go-bluetooth v0.0.0-20220323170840-382ca1d29f29
+	github.com/muka/go-bluetooth v0.0.0-20220830075246-0746e3a1ea53
 	github.com/saltosystems/winrt-go v0.0.0-20220826130236-ddc8202da421
 	github.com/sirupsen/logrus v1.9.0 // indirect
 	github.com/tinygo-org/cbgo v0.0.4

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfn
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/muka/go-bluetooth v0.0.0-20220323170840-382ca1d29f29 h1:kktgrt46k7/jbIpOpcOvULZgMYlTkgq4BJJ3fhT27Dc=
-github.com/muka/go-bluetooth v0.0.0-20220323170840-382ca1d29f29/go.mod h1:dMCjicU6vRBk34dqOmIZm0aod6gUwZXOXzBROqGous0=
+github.com/muka/go-bluetooth v0.0.0-20220830075246-0746e3a1ea53 h1:zfLHhuGzmSbthZ00FfbEjgAHUOOj7NGiITojMTCFy6U=
+github.com/muka/go-bluetooth v0.0.0-20220830075246-0746e3a1ea53/go.mod h1:dMCjicU6vRBk34dqOmIZm0aod6gUwZXOXzBROqGous0=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/paypal/gatt v0.0.0-20151011220935-4ae819d591cf/go.mod h1:+AwQL2mK3Pd3S+TUwg0tYQjid0q1txyNUJuuSmz8Kdk=


### PR DESCRIPTION
This PR updates to use the latest muka/go-bluetooth and then also provides a work-around for https://github.com/muka/go-bluetooth/issues/163