### PR TITLE
Expose ServiceData() in AdvertisementFields

### DIFF
--- a/adapter_darwin.go
+++ b/adapter_darwin.go
@@ -133,6 +133,17 @@ func makeScanResult(prph cbgo.Peripheral, advFields cbgo.AdvFields, rssi int) Sc
 		manufacturerData[manufacturerID] = advFields.ManufacturerData[2:]
 	}
 
+	serviceData := make(map[uint16][]byte)
+	for _, svcData := range advFields.ServiceData {
+		cbgoUUID := svcData.UUID
+		uuid, err := ParseUUID(cbgoUUID.String())
+		if err != nil || uuid.String() != cbgoUUID.String() {
+			continue
+		}
+		svcID := uuid.Get16Bit()
+		serviceData[svcID] = svcData.Data[:]
+	}
+
 	// Peripheral UUID is randomized on macOS, which means to
 	// different centrals it will appear to have a different UUID.
 	return ScanResult{
@@ -145,6 +156,7 @@ func makeScanResult(prph cbgo.Peripheral, advFields cbgo.AdvFields, rssi int) Sc
 				LocalName:        advFields.LocalName,
 				ServiceUUIDs:     serviceUUIDs,
 				ManufacturerData: manufacturerData,
+				ServiceData:      serviceData,
 			},
 		},
 	}

--- a/gap.go
+++ b/gap.go
@@ -128,7 +128,7 @@ type AdvertisementPayload interface {
 	Bytes() []byte
 
 	// ManufacturerData returns a map with all the manufacturer data present in the
-	//advertising. IT may be empty.
+	// advertising. It may be empty.
 	ManufacturerData() map[uint16][]byte
 }
 

--- a/gap.go
+++ b/gap.go
@@ -130,6 +130,10 @@ type AdvertisementPayload interface {
 	// ManufacturerData returns a map with all the manufacturer data present in the
 	// advertising. It may be empty.
 	ManufacturerData() map[uint16][]byte
+
+	// ServiceData returns a map with all the service data present in the
+	// advertising. It may be empty.
+	ServiceData() map[uint16][]byte
 }
 
 // AdvertisementFields contains advertisement fields in structured form.
@@ -145,6 +149,9 @@ type AdvertisementFields struct {
 
 	// ManufacturerData is the manufacturer data of the advertisement.
 	ManufacturerData map[uint16][]byte
+
+	// ServiceData is the service data of the advertisement.
+	ServiceData map[uint16][]byte
 }
 
 // advertisementFields wraps AdvertisementFields to implement the
@@ -180,6 +187,10 @@ func (p *advertisementFields) Bytes() []byte {
 // ManufacturerData returns the underlying ManufacturerData field.
 func (p *advertisementFields) ManufacturerData() map[uint16][]byte {
 	return p.AdvertisementFields.ManufacturerData
+}
+
+func (p *advertisementFields) ServiceData() map[uint16][]byte {
+	return p.AdvertisementFields.ServiceData
 }
 
 // rawAdvertisementPayload encapsulates a raw advertisement packet. Methods to

--- a/gap.go
+++ b/gap.go
@@ -300,6 +300,11 @@ func (buf *rawAdvertisementPayload) ManufacturerData() map[uint16][]byte {
 	return mData
 }
 
+// ServiceData is not implemented yet.
+func (buf *rawAdvertisementPayload) ServiceData() map[uint16][]byte {
+	return map[uint16][]byte{}
+}
+
 // reset restores this buffer to the original state.
 func (buf *rawAdvertisementPayload) reset() {
 	// The data is not reset (only the length), because with a zero length the

--- a/gap_linux.go
+++ b/gap_linux.go
@@ -255,6 +255,28 @@ func makeScanResult(props *device.Device1Properties) ScanResult {
 		}
 	}
 
+	sData := make(map[uint16][]byte)
+	for k, v := range props.ServiceData {
+		uuid, err := ParseUUID(k)
+		if err != nil || uuid.String() != k {
+			continue
+		}
+		svcID := uuid.Get16Bit()
+		switch data := v.(type) {
+		case []byte:
+			sData[svcID] = data[:]
+		case dbus.Variant:
+			switch dbusData := data.Value().(type) {
+			case []byte:
+				sData[svcID] = dbusData[:]
+			default:
+				continue
+			}
+		default:
+			continue
+		}
+	}
+
 	return ScanResult{
 		RSSI:    props.RSSI,
 		Address: a,
@@ -263,6 +285,7 @@ func makeScanResult(props *device.Device1Properties) ScanResult {
 				LocalName:        props.Name,
 				ServiceUUIDs:     serviceUUIDs,
 				ManufacturerData: mData,
+				ServiceData:      sData,
 			},
 		},
 	}


### PR DESCRIPTION
This PR adds a `ServiceData()` function to `AdvertisementFields` which returns a map of service data, similar to manufacturer data.

I don't know the Bluetooth spec enough to understand the difference between these two, but I have different BLE devices and some advertise the data I'm interested in as service data, while others use manufacturer data. I'd like to use this library to handle both types of devices.

I have tested this on Linux and macOS. Both works, but as IIRC you can't get hold of the device MAC on macOS, I couldn't verify the data completely. I don't have access to Windows or custom devices to test further.

Hope this feature makes sense!