### PR TITLE
windows: support empty manufacturer data

### DIFF
--- a/gap_windows.go
+++ b/gap_windows.go
@@ -137,6 +137,9 @@ func bufferToSlice(buffer *streams.IBuffer) []byte {
 	dataReader, _ := streams.FromBuffer(buffer)
 	defer dataReader.Release()
 	bufferSize, _ := buffer.GetLength()
+	if bufferSize == 0 {
+		return nil
+	}
 	data, _ := dataReader.ReadBytes(bufferSize)
 	return data
 }


### PR DESCRIPTION
Fixed a runtime error when `manufacturerData` is empty.