### PR TITLE
linux: fix io.Reader impl for characteristics

### DIFF
--- a/gattc_linux.go
+++ b/gattc_linux.go
@@ -5,6 +5,7 @@ package bluetooth
 
 import (
 	"errors"
+	"io"
 	"strings"
 	"time"
 
@@ -126,6 +127,7 @@ type DeviceCharacteristic struct {
 	uuidWrapper
 
 	characteristic *gatt.GattCharacteristic1
+	cachedRead     []byte
 }
 
 // UUID returns the UUID for this DeviceCharacteristic.
@@ -240,11 +242,18 @@ func (c DeviceCharacteristic) EnableNotifications(callback func(buf []byte)) err
 
 // Read reads the current characteristic value.
 func (c *DeviceCharacteristic) Read(data []byte) (int, error) {
-	options := make(map[string]interface{})
-	result, err := c.characteristic.ReadValue(options)
-	if err != nil {
-		return 0, err
+	if len(c.cachedRead) == 0 {
+		//	options := make(map[string]interface{})
+		var err error
+		c.cachedRead, err = c.characteristic.ReadValue(nil)
+		if err != nil {
+			return 0, err
+		}
 	}
-	copy(data, result)
-	return len(result), nil
+	n := copy(data, c.cachedRead)
+	c.cachedRead = c.cachedRead[n:]
+	if len(c.cachedRead) == 0 {
+		return n, io.EOF
+	}
+	return n, nil
 }


### PR DESCRIPTION
The DeviceCharacteristics type implements io.Reader, but previously did not follow the semantics as defined in the docs.
Several bugs are present that were fixed by this pull request:

1. the previous code always returned the full length of the data, regardless of how much data was actually read from the copy
2. io.EOF was never returned, meaning that we could never tell if the read was complete
3. the read always filled the buffer, then started over, meaning if the destination buffer was too small you would always get a partial read with no way to tell that the read was incomplete

This patch fixes this by caching the read internally, then copying from the read slice. The value is not actually read again using the upstream methods until the internal cached value is fully read.

---

It may also be beneficial to expose the internal read method in the future

```
func (*DeviceCharacteristics) ReadValue() ([]byte, error)
```

This would always allocate a byte slice, but would also always call the upstream read method, ignoring the internal cache. Effectively this would be the same as:

```
io.ReadAll(characteristic)
```