### PR TITLE
Disconnect event handling for Linux and Macos

### DIFF
--- a/gap_darwin.go
+++ b/gap_darwin.go
@@ -146,10 +146,16 @@ func (a *Adapter) Connect(address Address, params ConnectionParams) (*Device, er
 			a.connectHandler(address, true)
 
 			return d, nil
+
 		case <-timeoutTimer.C:
-			a.cm.CancelConnect(prphs[0]) // we need to cancel the connection if we have timed out ourselves
+			// we need to cancel the connection if we have timed out ourselves
+			a.cm.CancelConnect(prphs[0])
+
+			// record an error to use when the disconnect comes through later.
 			connectionError = errors.New("timeout on Connect")
-			// we are not ready to return yet, we need to wait for the disconnect event to come through so continue from this case and wait for prphCh
+
+			// we are not ready to return yet, we need to wait for the disconnect event to come through
+			// so continue on from this case and wait for something to show up on prphCh
 			continue
 		}
 	}

--- a/gap_linux.go
+++ b/gap_linux.go
@@ -4,11 +4,13 @@
 package bluetooth
 
 import (
+	"context"
 	"errors"
 	"strings"
 
 	"github.com/godbus/dbus/v5"
 	"github.com/muka/go-bluetooth/api"
+	"github.com/muka/go-bluetooth/bluez"
 	"github.com/muka/go-bluetooth/bluez/profile/advertising"
 	"github.com/muka/go-bluetooth/bluez/profile/device"
 )
@@ -270,7 +272,12 @@ func makeScanResult(props *device.Device1Properties) ScanResult {
 
 // Device is a connection to a remote peripheral.
 type Device struct {
-	device *device.Device1
+	device      *device.Device1             // bluez device interface
+	ctx         context.Context             // context for our event watcher, canceled on disconnect event
+	cancel      context.CancelFunc          // cancel function to halt our event watcher context
+	propchanged chan *bluez.PropertyChanged // channel that device property changes will show up on
+	adapter     *Adapter                    // the adapter that was used to form this device connection
+	address     Address                     // the address of the device
 }
 
 // Connect starts a connection attempt to the given peripheral device address.
@@ -283,25 +290,74 @@ func (a *Adapter) Connect(address Address, params ConnectionParams) (*Device, er
 		return nil, err
 	}
 
+	device := &Device{
+		device:  dev,
+		adapter: a,
+		address: address,
+	}
+	device.ctx, device.cancel = context.WithCancel(context.Background())
+	device.watchForConnect() // Set this up before we trigger a connection so we can capture the connect event
+
 	if !dev.Properties.Connected {
 		// Not yet connected, so do it now.
 		// The properties have just been read so this is fresh data.
 		err := dev.Connect()
 		if err != nil {
+			device.cancel() // cancel our watcher routine
 			return nil, err
 		}
 	}
 
-	// TODO: a proper async callback.
-	a.connectHandler(Address{}, true)
-
-	return &Device{
-		device: dev,
-	}, nil
+	return device, nil
 }
 
 // Disconnect from the BLE device. This method is non-blocking and does not
 // wait until the connection is fully gone.
 func (d *Device) Disconnect() error {
+	// we don't call our cancel function here, instead we wait for the
+	// property change in `watchForConnect` and cancel things then
 	return d.device.Disconnect()
+}
+
+// watchForConnect watches for a signal from the bluez device interface that indicates a Connection/Disconnection.
+//
+// We can add extra signals to watch for here,
+// see https://git.kernel.org/pub/scm/bluetooth/bluez.git/tree/doc/device-api.txt, for a full list
+func (d *Device) watchForConnect() error {
+	var err error
+	d.propchanged, err = d.device.WatchProperties()
+	if err != nil {
+		return err
+	}
+
+	go func() {
+		for {
+			select {
+			case changed := <-d.propchanged:
+
+				// we will receive a nil if bluez.UnwatchProperties(a, ch) is called, if so we can stop watching
+				if changed == nil {
+					d.cancel()
+					return
+				}
+
+				switch changed.Name {
+				case "Connected":
+					// Send off a notification indicating we have connected or disconnected
+					d.adapter.connectHandler(d.address, d.device.Properties.Connected)
+
+					if !d.device.Properties.Connected {
+						d.cancel()
+						return
+					}
+				}
+
+				continue
+			case <-d.ctx.Done():
+				return
+			}
+		}
+	}()
+
+	return nil
 }


### PR DESCRIPTION
This PR extends the connectHandler behaviour to work as expected for MacOS and Linux implementations. 

The expected behaviour of `adapter.SetConnectHandler` is that the callback will be fired when peripherals are both connected **and** disconnected. This behaviour is crucial for the correct handling of device connection states such as in a BLE gateway. However, the current implementation for this on MacOS and Linux is that the callback is only fired on a connection, and when doing so the address information is not included. Also, from what I can tell, no functionality exists on the windows side of things but I have no capability to test any improvements at this stage. 

This PR improves the behaviour for connection event callbacks of `adapter.SetConnectHandler` by adding the device address to the function call. It also implements the functionality to detect disconnection events and subsequently trigger the callback, also with the address of the disconnected device.

On MacOS this functionality is implemented by simply implementing `DidDisconnectPeripheral`  signature on the `centralManagerDelegate` as exposed by `github.com/tinygo-org/cbgo`.

On Linux, this functionality is implemented by creating a watcher for `Device1` property changes on the `"Connected"` property. Both connection and disconnection events are handled this way. The way this is implemented could be extended to other property changes but more plumbing would need to be added to achieve this and at the moment I have not distilled the need to do so.

A minor change this PR brings is to apply the `params.ConnectionTimeout` parameter to the connection timeout behaviour on MacOS and to correctly cancel the connection if this timeout is triggered.

This PR does not change the API in any way but should provide some useful & expected functionality. Further work will need to be done to bring the Windows implementation into line. I have tested it on an M1 MacBook Pro and a Raspberry Pi 4.

Looking forward to hearing your suggestions for any changes/improvements. 