### PR TITLE
build: switch to ghcr.io for docker container

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: tinygo/tinygo-dev
+    container: ghcr.io/tinygo-org/tinygo-dev
     steps:
       - name: Work around CVE-2022-24765
         # We're not on a multi-user machine, so this is safe.


### PR DESCRIPTION
This PR switches the build to use `ghcr.io` as the container repo for the `tinygo-dev` docker container.