### PR TITLE
Don't do heap allocations in interrupts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,8 @@ smoketest-tinygo:
 	@md5sum test.hex
 	$(TINYGO) build -o test.hex -size=short -target=pca10040-s132v6       ./examples/scanner
 	@md5sum test.hex
+	$(TINYGO) build -o test.hex -size=short -target=pca10040-s132v6       ./examples/stop-advertisement
+	@md5sum test.hex
 	# Test some more boards that are not tested above.
 	$(TINYGO) build -o test.hex -size=short -target=pca10056-s140v7       ./examples/advertisement
 	@md5sum test.hex

--- a/adapter.go
+++ b/adapter.go
@@ -6,6 +6,6 @@ const debug = false
 // SetConnectHandler sets a handler function to be called whenever the adaptor connects
 // or disconnects. You must call this before you call adaptor.Connect() for centrals
 // or adaptor.Start() for peripherals in order for it to work.
-func (a *Adapter) SetConnectHandler(c func(device Addresser, connected bool)) {
+func (a *Adapter) SetConnectHandler(c func(device Address, connected bool)) {
 	a.connectHandler = c
 }

--- a/adapter_darwin.go
+++ b/adapter_darwin.go
@@ -24,7 +24,7 @@ type Adapter struct {
 	// used to allow multiple callers to call Connect concurrently.
 	connectMap sync.Map
 
-	connectHandler func(device Addresser, connected bool)
+	connectHandler func(device Address, connected bool)
 }
 
 // DefaultAdapter is the default adapter on the system.
@@ -35,7 +35,7 @@ var DefaultAdapter = &Adapter{
 	pm:         cbgo.NewPeripheralManager(nil),
 	connectMap: sync.Map{},
 
-	connectHandler: func(device Addresser, connected bool) {
+	connectHandler: func(device Address, connected bool) {
 		return
 	},
 }

--- a/adapter_linux.go
+++ b/adapter_linux.go
@@ -19,7 +19,7 @@ type Adapter struct {
 	cancelChan           chan struct{}
 	defaultAdvertisement *Advertisement
 
-	connectHandler func(device Addresser, connected bool)
+	connectHandler func(device Address, connected bool)
 }
 
 // DefaultAdapter is the default adapter on the system. On Linux, it is the
@@ -27,7 +27,7 @@ type Adapter struct {
 //
 // Make sure to call Enable() before using it to initialize the adapter.
 var DefaultAdapter = &Adapter{
-	connectHandler: func(device Addresser, connected bool) {
+	connectHandler: func(device Address, connected bool) {
 		return
 	},
 }

--- a/adapter_nrf51.go
+++ b/adapter_nrf51.go
@@ -48,7 +48,7 @@ func handleEvent() {
 		switch id {
 		case C.BLE_GAP_EVT_CONNECTED:
 			currentConnection.Reg = gapEvent.conn_handle
-			DefaultAdapter.connectHandler(nil, true)
+			DefaultAdapter.connectHandler(Address{}, true)
 		case C.BLE_GAP_EVT_DISCONNECTED:
 			if defaultAdvertisement.isAdvertising.Get() != 0 {
 				// The advertisement was running but was automatically stopped
@@ -60,7 +60,7 @@ func handleEvent() {
 				defaultAdvertisement.start()
 			}
 			currentConnection.Reg = C.BLE_CONN_HANDLE_INVALID
-			DefaultAdapter.connectHandler(nil, false)
+			DefaultAdapter.connectHandler(Address{}, false)
 		case C.BLE_GAP_EVT_CONN_PARAM_UPDATE_REQUEST:
 			// Respond with the default PPCP connection parameters by passing
 			// nil:

--- a/adapter_nrf528xx-full.go
+++ b/adapter_nrf528xx-full.go
@@ -36,14 +36,14 @@ func handleEvent() {
 					println("evt: connected in peripheral role")
 				}
 				currentConnection.Reg = gapEvent.conn_handle
-				DefaultAdapter.connectHandler(nil, true)
+				DefaultAdapter.connectHandler(Address{}, true)
 			case C.BLE_GAP_ROLE_CENTRAL:
 				if debug {
 					println("evt: connected in central role")
 				}
 				connectionAttempt.connectionHandle = gapEvent.conn_handle
 				connectionAttempt.state.Set(2) // connection was successful
-				DefaultAdapter.connectHandler(nil, true)
+				DefaultAdapter.connectHandler(Address{}, true)
 			}
 		case C.BLE_GAP_EVT_DISCONNECTED:
 			if debug {
@@ -66,7 +66,7 @@ func handleEvent() {
 				// necessary.
 				C.sd_ble_gap_adv_start(defaultAdvertisement.handle, C.BLE_CONN_CFG_TAG_DEFAULT)
 			}
-			DefaultAdapter.connectHandler(nil, false)
+			DefaultAdapter.connectHandler(Address{}, false)
 		case C.BLE_GAP_EVT_ADV_REPORT:
 			advReport := gapEvent.params.unionfield_adv_report()
 			if debug && &scanReportBuffer.data[0] != advReport.data.p_data {

--- a/adapter_nrf528xx-peripheral.go
+++ b/adapter_nrf528xx-peripheral.go
@@ -33,7 +33,7 @@ func handleEvent() {
 				println("evt: connected in peripheral role")
 			}
 			currentConnection.Reg = gapEvent.conn_handle
-			DefaultAdapter.connectHandler(nil, true)
+			DefaultAdapter.connectHandler(Address{}, true)
 		case C.BLE_GAP_EVT_DISCONNECTED:
 			if debug {
 				println("evt: disconnected")
@@ -49,7 +49,7 @@ func handleEvent() {
 				// necessary.
 				C.sd_ble_gap_adv_start(defaultAdvertisement.handle, C.BLE_CONN_CFG_TAG_DEFAULT)
 			}
-			DefaultAdapter.connectHandler(nil, false)
+			DefaultAdapter.connectHandler(Address{}, false)
 		case C.BLE_GAP_EVT_DATA_LENGTH_UPDATE_REQUEST:
 			// We need to respond with sd_ble_gap_data_length_update. Setting
 			// both parameters to nil will make sure we send the default values.

--- a/adapter_sd.go
+++ b/adapter_sd.go
@@ -49,7 +49,7 @@ type Adapter struct {
 	scanning          bool
 	charWriteHandlers []charWriteHandler
 
-	connectHandler func(device Addresser, connected bool)
+	connectHandler func(device Address, connected bool)
 }
 
 // DefaultAdapter is the default adapter on the current system. On Nordic chips,
@@ -57,7 +57,7 @@ type Adapter struct {
 //
 // Make sure to call Enable() before using it to initialize the adapter.
 var DefaultAdapter = &Adapter{isDefault: true,
-	connectHandler: func(device Addresser, connected bool) {
+	connectHandler: func(device Address, connected bool) {
 		return
 	}}
 

--- a/adapter_sd.go
+++ b/adapter_sd.go
@@ -61,6 +61,8 @@ var DefaultAdapter = &Adapter{isDefault: true,
 		return
 	}}
 
+var eventBufLen uint16
+
 // Enable configures the BLE stack. It must be called before any
 // Bluetooth-related calls (unless otherwise indicated).
 func (a *Adapter) Enable() error {
@@ -71,7 +73,7 @@ func (a *Adapter) Enable() error {
 	// Enable the IRQ that handles all events.
 	intr := interrupt.New(nrf.IRQ_SWI2, func(interrupt.Interrupt) {
 		for {
-			eventBufLen := uint16(unsafe.Sizeof(eventBuf))
+			eventBufLen = uint16(unsafe.Sizeof(eventBuf))
 			errCode := C.sd_ble_evt_get((*uint8)(unsafe.Pointer(&eventBuf)), &eventBufLen)
 			if errCode != 0 {
 				// Possible error conditions:

--- a/adapter_windows.go
+++ b/adapter_windows.go
@@ -12,14 +12,14 @@ import (
 type Adapter struct {
 	watcher *advertisement.BluetoothLEAdvertisementWatcher
 
-	connectHandler func(device Addresser, connected bool)
+	connectHandler func(device Address, connected bool)
 }
 
 // DefaultAdapter is the default adapter on the system.
 //
 // Make sure to call Enable() before using it to initialize the adapter.
 var DefaultAdapter = &Adapter{
-	connectHandler: func(device Addresser, connected bool) {
+	connectHandler: func(device Address, connected bool) {
 		return
 	},
 }

--- a/examples/circuitplay/main.go
+++ b/examples/circuitplay/main.go
@@ -39,7 +39,7 @@ func main() {
 	neo.Configure(machine.PinConfig{Mode: machine.PinOutput})
 	ws = ws2812.New(neo)
 
-	adapter.SetConnectHandler(func(d bluetooth.Addresser, c bool) {
+	adapter.SetConnectHandler(func(d bluetooth.Address, c bool) {
 		connected = c
 
 		if !connected && !disconnected {

--- a/examples/stop-advertisement/main.go
+++ b/examples/stop-advertisement/main.go
@@ -21,7 +21,7 @@ func main() {
 	must("config adv", adv.Configure(bluetooth.AdvertisementOptions{
 		LocalName: "Go Bluetooth",
 	}))
-	adapter.SetConnectHandler(func(device bluetooth.Addresser, connected bool) {
+	adapter.SetConnectHandler(func(device bluetooth.Address, connected bool) {
 		if connected {
 			println("connected, not advertising...")
 			advState = false

--- a/gap.go
+++ b/gap.go
@@ -69,32 +69,11 @@ func NewDuration(interval time.Duration) Duration {
 // Connection is a numeric identifier that indicates a connection handle.
 type Connection uint16
 
-// Addresser contains a Bluetooth address, which is a MAC address plus some extra
-// information.
-type Addresser interface {
-	// String of the address
-	String() string
-
-	// Set the address
-	Set(val string)
-
-	// Is this address a random address?
-	// Bluetooth addresses are roughly split in two kinds: public
-	// (IEEE-assigned) addresses and random (not IEEE assigned) addresses.
-	// "Random" here doesn't mean it is exactly random but at least it looks
-	// random. Sometimes, it contains a hash.
-	// For more information:
-	// https://www.novelbits.io/bluetooth-address-privacy-ble/
-	// Set the address
-	SetRandom(bool)
-	IsRandom() bool
-}
-
 // ScanResult contains information from when an advertisement packet was
 // received. It is passed as a parameter to the callback of the Scan method.
 type ScanResult struct {
 	// Bluetooth address of the scanned device.
-	Address Addresser
+	Address Address
 
 	// RSSI the last time a packet from this device has been received.
 	RSSI int16

--- a/gap_darwin.go
+++ b/gap_darwin.go
@@ -95,15 +95,14 @@ type Device struct {
 }
 
 // Connect starts a connection attempt to the given peripheral device address.
-func (a *Adapter) Connect(address Addresser, params ConnectionParams) (*Device, error) {
-	adr := address.(Address)
-	uuid, err := cbgo.ParseUUID(adr.UUID.String())
+func (a *Adapter) Connect(address Address, params ConnectionParams) (*Device, error) {
+	uuid, err := cbgo.ParseUUID(address.UUID.String())
 	if err != nil {
 		return nil, err
 	}
 	prphs := a.cm.RetrievePeripheralsWithIdentifiers([]cbgo.UUID{uuid})
 	if len(prphs) == 0 {
-		return nil, fmt.Errorf("Connect failed: no peer with address: %s", adr.UUID.String())
+		return nil, fmt.Errorf("Connect failed: no peer with address: %s", address.UUID.String())
 	}
 
 	id := prphs[0].Identifier().String()
@@ -127,7 +126,7 @@ func (a *Adapter) Connect(address Addresser, params ConnectionParams) (*Device, 
 		d.delegate = &peripheralDelegate{d: d}
 		p.SetDelegate(d.delegate)
 
-		a.connectHandler(nil, true)
+		a.connectHandler(Address{}, true)
 
 		return d, nil
 	case <-time.NewTimer(10 * time.Second).C:

--- a/gap_linux.go
+++ b/gap_linux.go
@@ -276,9 +276,8 @@ type Device struct {
 // Connect starts a connection attempt to the given peripheral device address.
 //
 // On Linux and Windows, the IsRandom part of the address is ignored.
-func (a *Adapter) Connect(address Addresser, params ConnectionParams) (*Device, error) {
-	adr := address.(Address)
-	devicePath := dbus.ObjectPath(string(a.adapter.Path()) + "/dev_" + strings.Replace(adr.MAC.String(), ":", "_", -1))
+func (a *Adapter) Connect(address Address, params ConnectionParams) (*Device, error) {
+	devicePath := dbus.ObjectPath(string(a.adapter.Path()) + "/dev_" + strings.Replace(address.MAC.String(), ":", "_", -1))
 	dev, err := device.NewDevice1(devicePath)
 	if err != nil {
 		return nil, err
@@ -294,7 +293,7 @@ func (a *Adapter) Connect(address Addresser, params ConnectionParams) (*Device, 
 	}
 
 	// TODO: a proper async callback.
-	a.connectHandler(nil, true)
+	a.connectHandler(Address{}, true)
 
 	return &Device{
 		device: dev,

--- a/gap_nrf528xx-central.go
+++ b/gap_nrf528xx-central.go
@@ -113,13 +113,12 @@ var connectionAttempt struct {
 // connection attempt at once and that the address parameter must have the
 // IsRandom bit set correctly. This bit is set correctly for scan results, so
 // you can reuse that address directly.
-func (a *Adapter) Connect(address Addresser, params ConnectionParams) (*Device, error) {
-	adr := address.(Address)
+func (a *Adapter) Connect(address Address, params ConnectionParams) (*Device, error) {
 	// Construct an address object as used in the SoftDevice.
 	var addr C.ble_gap_addr_t
-	addr.addr = adr.MAC
+	addr.addr = address.MAC
 	if address.IsRandom() {
-		switch adr.MAC[5] >> 6 {
+		switch address.MAC[5] >> 6 {
 		case 0b11:
 			addr.set_bitfield_addr_type(C.BLE_GAP_ADDR_TYPE_RANDOM_STATIC)
 		case 0b01:

--- a/gap_windows.go
+++ b/gap_windows.go
@@ -163,9 +163,7 @@ type Device struct {
 // Connect starts a connection attempt to the given peripheral device address.
 //
 // On Linux and Windows, the IsRandom part of the address is ignored.
-func (a *Adapter) Connect(addresser Addresser, params ConnectionParams) (*Device, error) {
-	address := addresser.(Address).MACAddress
-
+func (a *Adapter) Connect(address Address, params ConnectionParams) (*Device, error) {
 	var winAddr uint64
 	for i := range address.MAC {
 		winAddr += uint64(address.MAC[i]) << (8 * i)


### PR DESCRIPTION
This is a work in progress. I will force-push this branch later (it most likely needs some changes on MacOS in particular). But here it is, for people who need a working Bluetooth package _now_.

It also breaks backwards compatibility, but I hope most programs won't need to be updated (the main breaking change is in `SetConnectHandler`). Go modules allow older programs to continue to work without updating, so I don't think it's that bad. But if the breaking change really is a problem, the PR could likely be changed to not break backwards compatibility.