### PR TITLE
gap: Set and SetRandom methods should have a pointer receiver

### DIFF
--- a/gap.go
+++ b/gap.go
@@ -25,12 +25,12 @@ func (mac MACAddress) IsRandom() bool {
 }
 
 // SetRandom if is a random address.
-func (mac MACAddress) SetRandom(val bool) {
+func (mac *MACAddress) SetRandom(val bool) {
 	mac.isRandom = val
 }
 
 // Set the address
-func (mac MACAddress) Set(val string) {
+func (mac *MACAddress) Set(val string) {
 	m, err := ParseMAC(val)
 	if err != nil {
 		return

--- a/gap_darwin.go
+++ b/gap_darwin.go
@@ -20,11 +20,11 @@ func (ad Address) IsRandom() bool {
 }
 
 // SetRandom ignored on macOS.
-func (ad Address) SetRandom(val bool) {
+func (ad *Address) SetRandom(val bool) {
 }
 
 // Set the address
-func (ad Address) Set(val string) {
+func (ad *Address) Set(val string) {
 	uuid, err := ParseUUID(val)
 	if err != nil {
 		return


### PR DESCRIPTION
Without it, these calls are a no-op.

Fixes: https://github.com/tinygo-org/bluetooth/issues/144

In particular, this fixes a problem where IsRandom() would always return false on Linux. With this fix, it correctly returns whether the address is a random address.