### PR TITLE
windows: scanning should be set to active

### DIFF
--- a/gap_windows.go
+++ b/gap_windows.go
@@ -36,6 +36,13 @@ func (a *Adapter) Scan(callback func(*Adapter, ScanResult)) (err error) {
 		a.watcher = nil
 	}()
 
+	// Set scanning mode to active so we receive scan responses
+	// from devices in advertising mode
+	err = a.watcher.SetScanningMode(advertisement.BluetoothLEScanningModeActive)
+	if err != nil {
+		return
+	}
+
 	// Listen for incoming BLE advertisement packets.
 	// We need a TypedEventHandler<TSender, TResult> to listen to events, but since this is a parameterized delegate
 	// its GUID depends on the classes used as sender and result, so we need to compute it:

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/go-ole/go-ole v1.2.6
 	github.com/godbus/dbus/v5 v5.0.3
 	github.com/muka/go-bluetooth v0.0.0-20220830075246-0746e3a1ea53
-	github.com/saltosystems/winrt-go v0.0.0-20230124093143-967a889c6c8f
+	github.com/saltosystems/winrt-go v0.0.0-20230510070731-e096b9afa761
 	github.com/sirupsen/logrus v1.9.0 // indirect
 	github.com/tinygo-org/cbgo v0.0.4
 	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519

--- a/go.sum
+++ b/go.sum
@@ -36,6 +36,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/sago35/go-bdf v0.0.0-20200313142241-6c17821c91c4/go.mod h1:rOebXGuMLsXhZAC6mF/TjxONsm45498ZyzVhel++6KM=
 github.com/saltosystems/winrt-go v0.0.0-20230124093143-967a889c6c8f h1:sxsy5XkcxSzkiUkYgx38V9JviWLL8wthO2TURCi0Lcs=
 github.com/saltosystems/winrt-go v0.0.0-20230124093143-967a889c6c8f/go.mod h1:UvKm1lyhg+8ehk99i8g5Q7AX1LXUJgks0lRyAkG/ahQ=
+github.com/saltosystems/winrt-go v0.0.0-20230510070731-e096b9afa761 h1:xEscoMxTrGSpdho1mP9VnGsK0DGhXKwm0qP7kYcjgrI=
+github.com/saltosystems/winrt-go v0.0.0-20230510070731-e096b9afa761/go.mod h1:UvKm1lyhg+8ehk99i8g5Q7AX1LXUJgks0lRyAkG/ahQ=
 github.com/sirupsen/logrus v1.5.0/go.mod h1:+F7Ogzej0PZc/94MaYx/nvG9jOFMD2osvC3s+Squfpo=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
 github.com/sirupsen/logrus v1.9.0 h1:trlNQbNUG3OdDrDil03MCb1H2o9nJ1x4/5LYw7byDE0=


### PR DESCRIPTION
Following this change in `winrt-go` here: https://github.com/saltosystems/winrt-go/pull/70

We can now scan in active mode, which is the current (and best) default behaviour on other platforms.

fixes #132 