### PR TITLE
macos: fix to enable notifications on multiple services 

### DIFF
--- a/gap_darwin.go
+++ b/gap_darwin.go
@@ -93,7 +93,7 @@ type Device struct {
 	servicesChan chan error
 	charsChan    chan error
 
-	services map[UUID]*DeviceService
+	services map[UUID]DeviceService
 }
 
 // Connect starts a connection attempt to the given peripheral device address.

--- a/gattc_darwin.go
+++ b/gattc_darwin.go
@@ -18,7 +18,7 @@ func (d *Device) DiscoverServices(uuids []UUID) ([]DeviceService, error) {
 	d.prph.DiscoverServices([]cbgo.UUID{})
 
 	// clear cache of services
-	d.services = make(map[UUID]*DeviceService)
+	d.services = make(map[UUID]DeviceService)
 
 	// wait on channel for service discovery
 	select {
@@ -49,7 +49,7 @@ func (d *Device) DiscoverServices(uuids []UUID) ([]DeviceService, error) {
 				},
 			}
 			svcs = append(svcs, svc)
-			d.services[svc.uuidWrapper] = &svc
+			d.services[svc.uuidWrapper] = svc
 		}
 		return svcs, nil
 	case <-time.NewTimer(10 * time.Second).C:
@@ -72,7 +72,7 @@ type deviceService struct {
 	device *Device
 
 	service         cbgo.Service
-	characteristics map[UUID]*DeviceCharacteristic
+	characteristics map[UUID]DeviceCharacteristic
 }
 
 // UUID returns the UUID for this DeviceService.
@@ -95,7 +95,7 @@ func (s *DeviceService) DiscoverCharacteristics(uuids []UUID) ([]DeviceCharacter
 	s.device.prph.DiscoverCharacteristics(cbuuids, s.service)
 
 	// clear cache of characteristics
-	s.characteristics = make(map[UUID]*DeviceCharacteristic)
+	s.characteristics = make(map[UUID]DeviceCharacteristic)
 
 	// wait on channel for characteristic discovery
 	select {
@@ -150,7 +150,7 @@ func (s *DeviceService) makeCharacteristic(uuid UUID, dchar cbgo.Characteristic)
 			characteristic: dchar,
 		},
 	}
-	s.characteristics[char.uuidWrapper] = &char
+	s.characteristics[char.uuidWrapper] = char
 	return char
 }
 


### PR DESCRIPTION
This is a fix for #54, it is the same approach as taken in #73. I have just brought it up to date with the latest changes on `dev`. 

Worth noting that the `DeviceService` now pointer embeds `deviceService` to enable the slice of services to be returned by value without issue. Otherwise, two copies of the service will exist. One the user interacts with and another recorded on the `peripheralDelegate` that we try to find matching notify callbacks on in  `DidUpdateValueForCharacteristic`. 

Is there a reason that `DiscoverServices` and `DiscoverCharacteristics` don't return slices of pointers? Doing so would alleviate this problem. 

Also, if we clear the cache of characteristics each time we enter `DiscoverCharacteristics`, reentrant calls will erase any enabled notifications.  This was the behaviour before, and I have left it as such. However, is it expected?
