### PR TITLE
macos: support duplicate characteristics

### DIFF
--- a/gap_darwin.go
+++ b/gap_darwin.go
@@ -195,14 +195,19 @@ func (pd *peripheralDelegate) DidUpdateValueForCharacteristic(prph cbgo.Peripher
 	svcuuid, _ := ParseUUID(chr.Service().UUID().String())
 
 	if svc, ok := pd.d.services[svcuuid]; ok {
-		if char, ok := svc.characteristics[uuid]; ok {
-			if err == nil && char.callback != nil {
-				go char.callback(chr.Value())
+		for _, char := range svc.characteristics {
+
+			if char.characteristic == chr && uuid == char.UUID() { // compare pointers
+				if err == nil && char.callback != nil {
+					go char.callback(chr.Value())
+				}
+
+				if char.readChan != nil {
+					char.readChan <- err
+				}
 			}
 
-			if char.readChan != nil {
-				char.readChan <- err
-			}
 		}
+
 	}
 }

--- a/gattc_darwin.go
+++ b/gattc_darwin.go
@@ -72,7 +72,7 @@ type deviceService struct {
 	device *Device
 
 	service         cbgo.Service
-	characteristics map[UUID]DeviceCharacteristic
+	characteristics []DeviceCharacteristic
 }
 
 // UUID returns the UUID for this DeviceService.
@@ -95,7 +95,7 @@ func (s *DeviceService) DiscoverCharacteristics(uuids []UUID) ([]DeviceCharacter
 	s.device.prph.DiscoverCharacteristics(cbuuids, s.service)
 
 	// clear cache of characteristics
-	s.characteristics = make(map[UUID]DeviceCharacteristic)
+	s.characteristics = make([]DeviceCharacteristic, 0)
 
 	// wait on channel for characteristic discovery
 	select {
@@ -150,7 +150,7 @@ func (s *DeviceService) makeCharacteristic(uuid UUID, dchar cbgo.Characteristic)
 			characteristic: dchar,
 		},
 	}
-	s.characteristics[char.uuidWrapper] = char
+	s.characteristics = append(s.characteristics, char)
 	return char
 }
 


### PR DESCRIPTION
This is a fix for duplicate UUID's mentioned in #131.

It changes from a `map[UUID]DeviceCharacteristic` to a slice `[]DeviceCharacteristic`. The only place this really impacts anything is in `DidUpdateValueForCharacteristic`, where we now have to find our matching characteristic by comparing the `cbgo.Characteristic` pointer. As far as I can tell this should be fine to do. 

I have tested these changes in my existing projects and have found no issues. However, I have no devices with duplicate characteristic UUID's and it is not something that can be mocked in nRF Connect. 

@viric are you able to test and confirm this solves your problem?