### PR TITLE
Adding option to add ManufacturerData to Advertisement

### DIFF
--- a/gap.go
+++ b/gap.go
@@ -53,6 +53,10 @@ type AdvertisementOptions struct {
 
 	// Interval in BLE-specific units. Create an interval by using NewDuration.
 	Interval Duration
+
+	// ManufacturerData stores Advertising Data.
+	// Keys are the Manufacturer ID to associate with the data.
+	ManufacturerData map[uint16]interface{}
 }
 
 // Duration is the unit of time used in BLE, in 0.625µs units. This unit of time

--- a/gap_linux.go
+++ b/gap_linux.go
@@ -50,9 +50,10 @@ func (a *Advertisement) Configure(options AdvertisementOptions) error {
 	}
 
 	a.properties = &advertising.LEAdvertisement1Properties{
-		Type:      advertising.AdvertisementTypeBroadcast,
-		Timeout:   1<<16 - 1,
-		LocalName: options.LocalName,
+		Type:             advertising.AdvertisementTypeBroadcast,
+		Timeout:          1<<16 - 1,
+		LocalName:        options.LocalName,
+		ManufacturerData: options.ManufacturerData,
 	}
 	for _, uuid := range options.ServiceUUIDs {
 		a.properties.ServiceUUIDs = append(a.properties.ServiceUUIDs, uuid.String())


### PR DESCRIPTION
Hello Awesome People 👋

Currently I need an option to add `ManufacturerData` to my Bluetooth Advertisement.

Luckily only two lines need to be added because `github.com/muka/go-bluetooth` already supports that.

Have a nice day ☀️