### PR TITLE
Include WriteWithoutResponse permission where Write exists

### DIFF
--- a/examples/circuitplay/main.go
+++ b/examples/circuitplay/main.go
@@ -1,7 +1,6 @@
 // This example is intended to be used with the Adafruit Circuitplay Bluefruit board.
 // It allows you to control the color of the built-in NeoPixel LEDS while they animate
 // in a circular pattern.
-//
 package main
 
 import (
@@ -67,7 +66,7 @@ func main() {
 				Handle: &ledColorCharacteristic,
 				UUID:   bluetooth.NewUUID(charUUID),
 				Value:  ledColor[:],
-				Flags:  bluetooth.CharacteristicReadPermission | bluetooth.CharacteristicWritePermission,
+				Flags:  bluetooth.CharacteristicReadPermission | bluetooth.CharacteristicWritePermission | bluetooth.CharacteristicWriteWithoutResponsePermission,
 				WriteEvent: func(client bluetooth.Connection, offset int, value []byte) {
 					if offset != 0 || len(value) != 3 {
 						return

--- a/examples/ledcolor/main.go
+++ b/examples/ledcolor/main.go
@@ -36,7 +36,7 @@ func main() {
 				Handle: &ledColorCharacteristic,
 				UUID:   bluetooth.NewUUID(charUUID),
 				Value:  ledColor[:],
-				Flags:  bluetooth.CharacteristicReadPermission | bluetooth.CharacteristicWritePermission,
+				Flags:  bluetooth.CharacteristicReadPermission | bluetooth.CharacteristicWritePermission | bluetooth.CharacteristicWriteWithoutResponsePermission,
 				WriteEvent: func(client bluetooth.Connection, offset int, value []byte) {
 					if offset != 0 || len(value) != 3 {
 						return


### PR DESCRIPTION
Considering Write is not exposed in Mac side API, examples with characteristics that only permit Write (but not WriteWithoutResponse) don't function. Considering these are examples, no harm is allowing WriteWithoutResponse so that Mac Go clients can functions as clients to these characteristics

This is the only way I could make a Mac client communicate with a Adafruit tinygo-based peripheral running these example code.

Also see a related discussion in this issue https://github.com/tinygo-org/bluetooth/issues/153