### PR TITLE
build: use latest tinygo-dev image for container builds, add Go 1.21 to macOS builds

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -20,6 +20,8 @@ jobs:
         uses: actions/checkout@v3.5.3
       - name: TinyGo version check
         run: tinygo version
+      - name: Download Go modules
+        run: go mod download
       - name: Run unit tests
         run: go test
       - name: Run TinyGo smoke tests

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -11,13 +11,13 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: ghcr.io/tinygo-org/tinygo-dev
+    container: ghcr.io/tinygo-org/tinygo-dev:latest
     steps:
       - name: Work around CVE-2022-24765
         # We're not on a multi-user machine, so this is safe.
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.5.3
       - name: TinyGo version check
         run: tinygo version
       - name: Run unit tests

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -22,6 +22,8 @@ jobs:
           go-version: '1.18'
       - name: Checkout
         uses: actions/checkout@v3.5.3
+      - name: Download Go modules
+        run: go mod download
       - name: Run unit tests
         run: go test
       - name: "Run macOS smoke tests"
@@ -37,6 +39,8 @@ jobs:
           go-version: '1.21'
       - name: Checkout
         uses: actions/checkout@v3.5.3
+      - name: Download Go modules
+        run: go mod download
       - name: Run unit tests
         run: go test
       - name: "Run macOS smoke tests"

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -12,16 +12,31 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
-    name: build
+  build-go1-18:
+    name: build-go1-18
     runs-on: macos-11
     steps:
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4.1.0
         with:
-          go-version: '1.18.3'
+          go-version: '1.18'
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.5.3
+      - name: Run unit tests
+        run: go test
+      - name: "Run macOS smoke tests"
+        run: make smoketest-macos
+
+  build-go1-21:
+    name: build-go1-21
+    runs-on: macos-11
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v4.1.0
+        with:
+          go-version: '1.21'
+      - name: Checkout
+        uses: actions/checkout@v3.5.3
       - name: Run unit tests
         run: go test
       - name: "Run macOS smoke tests"


### PR DESCRIPTION
This PR updates the GH actions builds to use latest tinygo-dev image for container builds, and also adds Go 1.21 to the macOS builds.