### PR TITLE
linux & macos: adapter power state handling

### DIFF
--- a/adapter.go
+++ b/adapter.go
@@ -3,9 +3,45 @@ package bluetooth
 // Set this to true to print debug messages, for example for unknown events.
 const debug = false
 
+// AdapterState represents the state of the adaptor.
+type AdapterState int
+
+const (
+	// AdapterStatePoweredOff is the state of the adaptor when it is powered off.
+	AdapterStatePoweredOff = AdapterState(iota)
+	// AdapterStatePoweredOn is the state of the adaptor when it is powered on.
+	AdapterStatePoweredOn
+	// AdapterStateResetting is the state of the adaptor when it is resetting.
+	AdapterStateResetting
+	// AdapterStateUnknown is the state of the adaptor when it is unknown.
+	AdapterStateUnknown
+)
+
+func (as *AdapterState) String() string {
+	switch *as {
+	case AdapterStatePoweredOff:
+		return "PoweredOff"
+	case AdapterStatePoweredOn:
+		return "PoweredOn"
+	case AdapterStateResetting:
+		return "Resetting"
+	case AdapterStateUnknown:
+		return "Unknown"
+	default:
+		return "Unknown"
+	}
+}
+
 // SetConnectHandler sets a handler function to be called whenever the adaptor connects
 // or disconnects. You must call this before you call adaptor.Connect() for centrals
 // or adaptor.Start() for peripherals in order for it to work.
 func (a *Adapter) SetConnectHandler(c func(device Address, connected bool)) {
 	a.connectHandler = c
+}
+
+// SetStateChangeHandler sets a handler function to be called whenever the adaptor's
+// state changes.
+// This is a no-op on bare metal.
+func (a *Adapter) SetStateChangeHandler(c func(newState AdapterState)) {
+	a.stateChangeHandler = c
 }

--- a/adapter.go
+++ b/adapter.go
@@ -34,10 +34,3 @@ func (as *AdapterState) String() string {
 func (a *Adapter) SetConnectHandler(c func(device Address, connected bool)) {
 	a.connectHandler = c
 }
-
-// SetStateChangeHandler sets a handler function to be called whenever the adaptor's
-// state changes.
-// This is a no-op on bare metal.
-func (a *Adapter) SetStateChangeHandler(c func(newState AdapterState)) {
-	a.stateChangeHandler = c
-}

--- a/adapter.go
+++ b/adapter.go
@@ -11,8 +11,6 @@ const (
 	AdapterStatePoweredOff = AdapterState(iota)
 	// AdapterStatePoweredOn is the state of the adaptor when it is powered on.
 	AdapterStatePoweredOn
-	// AdapterStateResetting is the state of the adaptor when it is resetting.
-	AdapterStateResetting
 	// AdapterStateUnknown is the state of the adaptor when it is unknown.
 	AdapterStateUnknown
 )
@@ -23,8 +21,6 @@ func (as *AdapterState) String() string {
 		return "PoweredOff"
 	case AdapterStatePoweredOn:
 		return "PoweredOn"
-	case AdapterStateResetting:
-		return "Resetting"
 	case AdapterStateUnknown:
 		return "Unknown"
 	default:

--- a/adapter.go
+++ b/adapter.go
@@ -1,5 +1,17 @@
 package bluetooth
 
+// AdapterState represents the state of the adaptor.
+type AdapterState int
+
+const (
+	// AdapterStatePoweredOff is the state of the adaptor when it is powered off.
+	AdapterStatePoweredOff = AdapterState(iota)
+	// AdapterStatePoweredOn is the state of the adaptor when it is powered on.
+	AdapterStatePoweredOn
+	// AdapterStateUnknown is the state of the adaptor when it is unknown.
+	AdapterStateUnknown
+)
+
 // BLEAdapter is the shared interface that all platform-specific Adapter types must implement.
 type BLEAdapter interface {
 	Connect(address Address, params ConnectionParams) (Device, error)

--- a/adapter_darwin.go
+++ b/adapter_darwin.go
@@ -101,9 +101,6 @@ func (cmd *centralManagerDelegate) CentralManagerDidUpdateState(cmgr cbgo.Centra
 	case cbgo.ManagerStatePoweredOff:
 		cmd.a.stateChangeHandler(AdapterStatePoweredOff)
 
-	case cbgo.ManagerStateResetting:
-		cmd.a.stateChangeHandler(AdapterStateResetting)
-
 	default:
 		cmd.a.stateChangeHandler(AdapterStateUnknown)
 	}

--- a/adapter_darwin.go
+++ b/adapter_darwin.go
@@ -85,6 +85,18 @@ func (a *Adapter) SetStateChangeHandler(c func(newState AdapterState)) {
 	a.stateChangeHandler = c
 }
 
+// State returns the current state of the adapter.
+func (a *Adapter) State() AdapterState {
+	switch a.cm.State() {
+	case cbgo.ManagerStatePoweredOn:
+		return AdapterStatePoweredOn
+	case cbgo.ManagerStatePoweredOff:
+		return AdapterStatePoweredOff
+	default:
+		return AdapterStateUnknown
+	}
+}
+
 // CentralManager delegate functions
 
 type centralManagerDelegate struct {

--- a/adapter_darwin.go
+++ b/adapter_darwin.go
@@ -79,6 +79,12 @@ func (a *Adapter) Enable() error {
 	return nil
 }
 
+// SetStateChangeHandler sets a handler function to be called whenever the adaptor's
+// state changes.
+func (a *Adapter) SetStateChangeHandler(c func(newState AdapterState)) {
+	a.stateChangeHandler = c
+}
+
 // CentralManager delegate functions
 
 type centralManagerDelegate struct {

--- a/adapter_darwin.go
+++ b/adapter_darwin.go
@@ -26,7 +26,8 @@ type Adapter struct {
 	// used to allow multiple callers to call Connect concurrently.
 	connectMap sync.Map
 
-	connectHandler func(device Device, connected bool)
+	connectHandler     func(device Device, connected bool)
+	stateChangeHandler func(newState AdapterState)
 }
 
 // DefaultAdapter is the default adapter on the system.
@@ -37,9 +38,8 @@ var DefaultAdapter = &Adapter{
 	pm:         cbgo.NewPeripheralManager(nil),
 	connectMap: sync.Map{},
 
-	connectHandler: func(device Device, connected bool) {
-		return
-	},
+	connectHandler:     func(device Device, connected bool) {},
+	stateChangeHandler: func(newState AdapterState) {},
 }
 
 // Enable configures the BLE stack. It must be called before any
@@ -121,6 +121,24 @@ func (a *Adapter) Reset() error {
 	return nil
 }
 
+// SetStateChangeHandler sets a handler function to be called whenever the adaptor's
+// state changes.
+func (a *Adapter) SetStateChangeHandler(c func(newState AdapterState)) {
+	a.stateChangeHandler = c
+}
+
+// State returns the current state of the adapter.
+func (a *Adapter) State() AdapterState {
+	switch a.cm.State() {
+	case cbgo.ManagerStatePoweredOn:
+		return AdapterStatePoweredOn
+	case cbgo.ManagerStatePoweredOff:
+		return AdapterStatePoweredOff
+	default:
+		return AdapterStateUnknown
+	}
+}
+
 // CentralManager delegate functions
 
 type centralManagerDelegate struct {
@@ -132,18 +150,25 @@ type centralManagerDelegate struct {
 // CentralManagerDidUpdateState when central manager state updated.
 func (cmd *centralManagerDelegate) CentralManagerDidUpdateState(cmgr cbgo.CentralManager) {
 	var event error
+	var newState AdapterState
 	switch cmgr.State() {
 	case cbgo.ManagerStatePoweredOn:
+		newState = AdapterStatePoweredOn
 		event = nil
 	case cbgo.ManagerStatePoweredOff:
+		newState = AdapterStatePoweredOff
 		event = errors.New("bluetooth is powered off")
 	case cbgo.ManagerStateUnsupported:
+		newState = AdapterStatePoweredOff
 		event = errors.New("bluetooth is not supported on this device")
 	case cbgo.ManagerStateUnauthorized:
+		newState = AdapterStatePoweredOff
 		event = errors.New("bluetooth is not authorized for this app")
 	default:
+		cmd.a.stateChangeHandler(AdapterStateUnknown)
 		return
 	}
+	cmd.a.stateChangeHandler(newState)
 	// Non-blocking send: poweredChan may be nil after Enable
 	// completes, or already buffered.
 	select {

--- a/adapter_linux.go
+++ b/adapter_linux.go
@@ -67,6 +67,16 @@ func (a *Adapter) Address() (MACAddress, error) {
 	return MACAddress{MAC: mac}, nil
 }
 
+// SetStateChangeHandler sets a handler function to be called whenever the adaptor's
+// state changes.
+func (a *Adapter) SetStateChangeHandler(c func(newState AdapterState)) {
+	a.stateChangeHandler = c
+}
+
+// watchForConnect watches for a signal from the bluez adapter interface that indicates a Powered/Unpowered event.
+//
+// We can add extra signals to watch for here,
+// see https://git.kernel.org/pub/scm/bluetooth/bluez.git/tree/doc/adapter-api.txt, for a full list
 func (a *Adapter) watchForStateChange() error {
 	var err error
 	a.propchanged, err = a.adapter.WatchProperties()

--- a/adapter_linux.go
+++ b/adapter_linux.go
@@ -73,6 +73,22 @@ func (a *Adapter) SetStateChangeHandler(c func(newState AdapterState)) {
 	a.stateChangeHandler = c
 }
 
+// State returns the current state of the adapter.
+func (a *Adapter) State() AdapterState {
+	if a.adapter == nil {
+		return AdapterStateUnknown
+	}
+
+	powered, err := a.adapter.GetPowered()
+	if err != nil {
+		return AdapterStateUnknown
+	}
+	if powered {
+		return AdapterStatePoweredOn
+	}
+	return AdapterStatePoweredOff
+}
+
 // watchForConnect watches for a signal from the bluez adapter interface that indicates a Powered/Unpowered event.
 //
 // We can add extra signals to watch for here,

--- a/adapter_linux.go
+++ b/adapter_linux.go
@@ -25,7 +25,8 @@ type Adapter struct {
 	address              string
 	defaultAdvertisement *Advertisement
 
-	connectHandler func(device Device, connected bool)
+	connectHandler     func(device Device, connected bool)
+	stateChangeHandler func(newState AdapterState)
 }
 
 // NewAdapter creates a new Adapter with the given ID.
@@ -33,8 +34,9 @@ type Adapter struct {
 // Make sure to call Enable() before using it to initialize the adapter.
 func NewAdapter(id string) *Adapter {
 	return &Adapter{
-		id:             id,
-		connectHandler: func(device Device, connected bool) {},
+		id:                 id,
+		connectHandler:     func(device Device, connected bool) {},
+		stateChangeHandler: func(newState AdapterState) {},
 	}
 }
 
@@ -63,6 +65,9 @@ func (a *Adapter) Enable() (err error) {
 	}
 	addr.Store(&a.address)
 
+	if err := a.watchForStateChange(); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -86,4 +91,76 @@ func (a *Adapter) Address() (MACAddress, error) {
 		return MACAddress{}, err
 	}
 	return MACAddress{MAC: mac}, nil
+}
+
+// SetStateChangeHandler sets a handler function to be called whenever the adaptor's
+// state changes.
+func (a *Adapter) SetStateChangeHandler(c func(newState AdapterState)) {
+	a.stateChangeHandler = c
+}
+
+// State returns the current state of the adapter.
+func (a *Adapter) State() AdapterState {
+	if a.adapter == nil {
+		return AdapterStateUnknown
+	}
+
+	prop, err := a.adapter.GetProperty("org.bluez.Adapter1.Powered")
+	if err != nil {
+		return AdapterStateUnknown
+	}
+	powered, ok := prop.Value().(bool)
+	if !ok {
+		return AdapterStateUnknown
+	}
+	if powered {
+		return AdapterStatePoweredOn
+	}
+	return AdapterStatePoweredOff
+}
+
+// watchForStateChange watches for D-Bus PropertiesChanged signals from the
+// BlueZ adapter interface and reports Powered/Unpowered transitions to the
+// registered state-change handler.
+//
+// We can watch for extra adapter properties here, see
+// https://git.kernel.org/pub/scm/bluetooth/bluez.git/tree/doc/org.bluez.Adapter.rst
+// for the full list.
+func (a *Adapter) watchForStateChange() error {
+	matchOptions := []dbus.MatchOption{
+		dbus.WithMatchInterface("org.freedesktop.DBus.Properties"),
+		dbus.WithMatchMember("PropertiesChanged"),
+		dbus.WithMatchArg(dbusPropertiesChangedInterfaceName, "org.bluez.Adapter1"),
+	}
+	if err := a.bus.AddMatchSignal(matchOptions...); err != nil {
+		return err
+	}
+
+	signal := make(chan *dbus.Signal)
+	a.bus.Signal(signal)
+
+	go func() {
+		for sig := range signal {
+			if sig.Name != dbusSignalPropertiesChanged {
+				continue
+			}
+			// Only react to property changes on the adapter interface.
+			if interfaceName, ok := sig.Body[dbusPropertiesChangedInterfaceName].(string); !ok || interfaceName != "org.bluez.Adapter1" {
+				continue
+			}
+			changes, ok := sig.Body[dbusPropertiesChangedDictionary].(map[string]dbus.Variant)
+			if !ok {
+				continue
+			}
+			if powered, ok := changes["Powered"].Value().(bool); ok {
+				if powered {
+					a.stateChangeHandler(AdapterStatePoweredOn)
+				} else {
+					a.stateChangeHandler(AdapterStatePoweredOff)
+				}
+			}
+		}
+	}()
+
+	return nil
 }


### PR DESCRIPTION
A simple PR to address some of the issues brought up in #184. In particular, this adds a state change handler to the adapter which calls a provided callback when the powered state changes.

On macos this uses the existing `CentralManagerDidUpdateState` process that is already used to know when the adapter has been correctly enabled. On linux this watches for the `Powered` adapter D-Bus property to change. 

This has been tested on an M1 Macbook Pro and a Raspberry Pi 4. 

This PR modifies the existing API by adding `(a *Adapter) SetStateChangeHandler(c func(newState AdapterState))`.  I also add some const states to provide generality between platforms, although these are probably unnecessary. 

Unknowns: 
- Does bare-metal have any comparable functionality that could be linked in? Or would this be a no-op?
- I do not have a windows machine handy so can not develop an implementation for that.


@xeanhort One additional note about #184, while this PR does not directly provide a mechanism to confirm if the adapter is scanning correctly or not. There is an adapter property called [`Discovering`](https://git.kernel.org/pub/scm/bluetooth/bluez.git/tree/doc/adapter-api.txt#:~:text=boolean%20Discovering%20%5Breadonly%5D) that can be watched to hopefully provide this insight. This can be easily integrated into the watching procedure added to `adapter_linux.go` in this PR. 

If we can find a similar signal on the other platforms perhaps we can add it to the state change callback in a future PR. 

