### PR TITLE
build: add macOS 12/13 to GH actions build jobs

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -12,16 +12,46 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
-    name: build
+  macos-11:
+    name: macos-11
     runs-on: macos-11
     steps:
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4.1.0
         with:
           go-version: '1.18.3'
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.6.0
+      - name: Run unit tests
+        run: go test
+      - name: "Run macOS smoke tests"
+        run: make smoketest-macos
+
+  macos-12:
+    name: macos-12
+    runs-on: macos-12
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v4.1.0
+        with:
+          go-version: '1.21.0'
+      - name: Checkout
+        uses: actions/checkout@v3.6.0
+      - name: Run unit tests
+        run: go test
+      - name: "Run macOS smoke tests"
+        run: make smoketest-macos
+
+  macos-13:
+    name: macos-13
+    runs-on: macos-13
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v4.1.0
+        with:
+          go-version: '1.21.0'
+      - name: Checkout
+        uses: actions/checkout@v3.6.0
       - name: Run unit tests
         run: go test
       - name: "Run macOS smoke tests"


### PR DESCRIPTION
This PR adds macOS 12/13 to the GH actions build jobs.