### PR TITLE
sd: Preventing panic when CGo calls in interrupt escape arguments to heap

### DIFF
--- a/gap_nrf51.go
+++ b/gap_nrf51.go
@@ -4,6 +4,11 @@ package bluetooth
 
 /*
 #include "ble_gap.h"
+
+// Workaround wrapper function to avoid pointer arguments escaping to heap
+static inline uint32_t sd_ble_gap_adv_start_noescape(ble_gap_adv_params_t const p_adv_params) {
+	return sd_ble_gap_adv_start(&p_adv_params);
+}
 */
 import "C"
 
@@ -75,5 +80,5 @@ func (a *Advertisement) start() uint32 {
 		interval: uint16(a.interval),
 		timeout:  0, // no timeout
 	}
-	return C.sd_ble_gap_adv_start(&params)
+	return C.sd_ble_gap_adv_start_noescape(params)
 }


### PR DESCRIPTION
This PR targets issue #176 

Some SD Cgo calls are unnecessarily causing variables to escape to heap, and if called from an interrupt are causing panics.
Local CGo wrappers are added to prevent this. 

This is a workaround until there is a proper way to prevent CGo calls escaping variables to heap (for example this Go proposal: [golang#56378](https://go.dev/issue/56378) )