### PR TITLE
windows: Remove requirement to use cgo

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -26,8 +26,5 @@ jobs:
         run: make smoketest-tinygo
       - name: Run Linux smoke tests
         run: make smoketest-linux
-      - name: Install Windows cross compiler
-        run: |
-          apt-get install -y gcc-mingw-w64-x86-64
-      - name: "Run Windows smoke tests"
+      - name: "Run Windows cross-compiled smoke tests"
         run: make smoketest-windows

--- a/Makefile
+++ b/Makefile
@@ -44,9 +44,9 @@ smoketest-linux:
 
 smoketest-windows:
 	# Test on Windows.
-	GOOS=windows CGO_ENABLED=1 CC=x86_64-w64-mingw32-gcc go build -o /tmp/go-build-discard ./examples/scanner
-	GOOS=windows CGO_ENABLED=1 CC=x86_64-w64-mingw32-gcc go build -o /tmp/go-build-discard ./examples/discover
-	GOOS=windows CGO_ENABLED=1 CC=x86_64-w64-mingw32-gcc go build -o /tmp/go-build-discard ./examples/heartrate-monitor
+	GOOS=windows go build -o /tmp/go-build-discard ./examples/scanner
+	GOOS=windows go build -o /tmp/go-build-discard ./examples/discover
+	GOOS=windows go build -o /tmp/go-build-discard ./examples/heartrate-monitor
 
 smoketest-macos:
 	# Test on macos.

--- a/README.md
+++ b/README.md
@@ -165,11 +165,9 @@ The Windows support only can only act as a BLE Central at this time, with some a
 
 ### Installation
 
-In order to compile Go Bluetooth code targeting Windows, you must have a GCC compiler installed.
+Only the Go compiler itself is needed to compile Go Bluetooth code targeting Windows.
 
-On Windows, you can download and install mingw-w64 (https://github.com/mingw-w64/mingw-w64)
-
-Once you have done this, you can obtain the Go Bluetooth package using Git:
+You can obtain the Go Bluetooth package using Git:
 
 	git clone https://github.com/tinygo-org/bluetooth.git
 

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/go-ole/go-ole v1.2.6
 	github.com/godbus/dbus/v5 v5.1.0
 	github.com/muka/go-bluetooth v0.0.0-20221213043340-85dc80edc4e1
-	github.com/saltosystems/winrt-go v0.0.0-20230710111611-a39229b5054c
+	github.com/saltosystems/winrt-go v0.0.0-20230921082907-2ab5b7d431e1
 	github.com/tinygo-org/cbgo v0.0.4
 	golang.org/x/crypto v0.12.0
 	tinygo.org/x/drivers v0.25.0

--- a/go.sum
+++ b/go.sum
@@ -29,8 +29,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/sago35/go-bdf v0.0.0-20200313142241-6c17821c91c4/go.mod h1:rOebXGuMLsXhZAC6mF/TjxONsm45498ZyzVhel++6KM=
-github.com/saltosystems/winrt-go v0.0.0-20230710111611-a39229b5054c h1:GmnSNqDHyCqwGT5a3cOhMO8+yXzQW7VUdUGFAOSaEkw=
-github.com/saltosystems/winrt-go v0.0.0-20230710111611-a39229b5054c/go.mod h1:UvKm1lyhg+8ehk99i8g5Q7AX1LXUJgks0lRyAkG/ahQ=
+github.com/saltosystems/winrt-go v0.0.0-20230921082907-2ab5b7d431e1 h1:L2YoWezgwpAZ2SEKjXk6yLnwOkM3u7mXq/mKuJeEpFM=
+github.com/saltosystems/winrt-go v0.0.0-20230921082907-2ab5b7d431e1/go.mod h1:CIltaIm7qaANUIvzr0Vmz71lmQMAIbGJ7cvgzX7FMfA=
 github.com/sirupsen/logrus v1.5.0/go.mod h1:+F7Ogzej0PZc/94MaYx/nvG9jOFMD2osvC3s+Squfpo=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=


### PR DESCRIPTION
This PR is an attempt to remove the requirement for CGo when using Windows.

Based entirely on the fine work of @jagobagascon including the hack to get around https://github.com/golang/go/issues/55015