### PR TITLE
[WIP] ble pairing for SD nrf528xx

### DIFF
--- a/adapter_nrf528xx-full.go
+++ b/adapter_nrf528xx-full.go
@@ -99,8 +99,30 @@ func handleEvent() {
 		case C.BLE_GAP_EVT_PHY_UPDATE_REQUEST:
 			phyUpdateRequest := gapEvent.params.unionfield_phy_update_request()
 			C.sd_ble_gap_phy_update(gapEvent.conn_handle, &phyUpdateRequest.peer_preferred_phys)
+		case C.BLE_GAP_EVT_AUTH_STATUS:
+			// here we get auth response
+			// TODO: save keys to flash for pairing/bonding
 		case C.BLE_GAP_EVT_PHY_UPDATE:
-			// ignore confirmation of phy successfully updated
+		// ignore confirmation of phy successfully updated
+		case C.BLE_GAP_EVT_SEC_PARAMS_REQUEST:
+			if debug {
+				println("evt: security parameters request")
+			}
+			// would assume this depends on the role,
+			// as for central we need to call sd_ble_gap_authenticate after connection esteblished instead
+			errCode := C.sd_ble_gap_sec_params_reply(gapEvent.conn_handle, C.BLE_GAP_SEC_STATUS_SUCCESS, &secParams, &secKeySet)
+			if errCode != 0 {
+				println("security parameters response failed:", Error(errCode).Error())
+				return
+			}
+			if debug {
+				println("successfully established security parameters exchange")
+			}
+
+		case C.BLE_GAP_EVT_LESC_DHKEY_REQUEST:
+			// TODO: for LESC connection implementation
+		// 	peerPk := eventBuf.evt.unionfield_gatts_evt()
+		// 	sd_ble_gap_lesc_dhkey_reply(gapEvent.conn_handle, ble_gap_lesc_dhkey_t const *p_dhkey))
 		default:
 			if debug {
 				println("unknown GAP event:", id)

--- a/adapter_nrf528xx-full.go
+++ b/adapter_nrf528xx-full.go
@@ -110,6 +110,9 @@ func handleEvent() {
 			}
 			// would assume this depends on the role,
 			// as for central we need to call sd_ble_gap_authenticate after connection esteblished instead
+
+			// in general key can be null, i would assume in our case we need to read it from flash here
+			// so we we do not reapprove bonding
 			errCode := C.sd_ble_gap_sec_params_reply(gapEvent.conn_handle, C.BLE_GAP_SEC_STATUS_SUCCESS, &secParams, &secKeySet)
 			if errCode != 0 {
 				println("security parameters response failed:", Error(errCode).Error())
@@ -120,7 +123,7 @@ func handleEvent() {
 			}
 
 		case C.BLE_GAP_EVT_LESC_DHKEY_REQUEST:
-			// TODO: for LESC connection implementation
+		// TODO: for LESC connection implementation
 		// 	peerPk := eventBuf.evt.unionfield_gatts_evt()
 		// 	sd_ble_gap_lesc_dhkey_reply(gapEvent.conn_handle, ble_gap_lesc_dhkey_t const *p_dhkey))
 		default:

--- a/adapter_nrf528xx.go
+++ b/adapter_nrf528xx.go
@@ -19,6 +19,50 @@ import (
 	"unsafe"
 )
 
+// TODO: Probably it should be in adapter_sd, but as it's usage is added only for nrf528xx-full.go
+// as well as i do not have other machines to test, adding it here for now
+
+type GapIOCapability uint8
+
+const (
+	DisplayOnlyGapIOCapability     = C.BLE_GAP_IO_CAPS_DISPLAY_ONLY
+	DisplayYesNoGapIOCapability    = C.BLE_GAP_IO_CAPS_DISPLAY_YESNO
+	KeyboardOnlyGapIOCapability    = C.BLE_GAP_IO_CAPS_KEYBOARD_ONLY
+	NoneGapIOCapability            = C.BLE_GAP_IO_CAPS_NONE
+	KeyboardDisplayGapIOCapability = C.BLE_GAP_IO_CAPS_KEYBOARD_DISPLAY
+)
+
+var (
+	secParams = C.ble_gap_sec_params_t{
+		min_key_size: 7, // not sure if those are the best default length
+		max_key_size: 16,
+	}
+
+	secKeySet C.ble_gap_sec_keyset_t = C.ble_gap_sec_keyset_t{
+		keys_peer: C.ble_gap_sec_keys_t{
+			p_enc_key:  &C.ble_gap_enc_key_t{},   /**< Encryption Key, or NULL. */
+			p_id_key:   &C.ble_gap_id_key_t{},    /**< Identity Key, or NULL. */
+			p_sign_key: &C.ble_gap_sign_info_t{}, /**< Signing Key, or NULL. */
+			p_pk:       &C.ble_gap_lesc_p256_pk_t{},
+		},
+		keys_own: C.ble_gap_sec_keys_t{
+			p_enc_key:  &C.ble_gap_enc_key_t{},   /**< Encryption Key, or NULL. */
+			p_id_key:   &C.ble_gap_id_key_t{},    /**< Identity Key, or NULL. */
+			p_sign_key: &C.ble_gap_sign_info_t{}, /**< Signing Key, or NULL. */
+			p_pk:       &C.ble_gap_lesc_p256_pk_t{},
+		},
+	}
+)
+
+// are those should be methods for adapter as they are relevant for sd only
+func SetSecParamsBonding() {
+	secParams.set_bitfield_bond(1)
+}
+
+func SetSecCapabilities(cap GapIOCapability) {
+	secParams.set_bitfield_io_caps(uint8(cap))
+}
+
 //export assertHandler
 func assertHandler() {
 	println("SoftDevice assert")

--- a/error_sd.go
+++ b/error_sd.go
@@ -4,6 +4,7 @@ package bluetooth
 
 // #include "nrf_error.h"
 // #include "nrf_error_sdm.h"
+// #include "ble_err.h"
 import "C"
 
 // Error is an error from within the SoftDevice.
@@ -74,7 +75,22 @@ func (e Error) Error() string {
 		return "other SoC error"
 	case e >= C.NRF_ERROR_STK_BASE_NUM && e < 0x4000:
 		// STK errors.
-		return "other STK error"
+		switch e {
+		case C.BLE_ERROR_NOT_ENABLED:
+			return "sd_ble_enable has not been called"
+		case C.BLE_ERROR_INVALID_CONN_HANDLE:
+			return "invalid connection handle"
+		case C.BLE_ERROR_INVALID_ATTR_HANDLE:
+			return "invalid attribute handle"
+		case C.BLE_ERROR_INVALID_ADV_HANDLE:
+			return "invalid advertising handle"
+		case C.BLE_ERROR_INVALID_ROLE:
+			return "invalid role"
+		case C.BLE_ERROR_BLOCKED_BY_OTHER_LINKS:
+			return "the attempt to change link settings failed due to the scheduling of other links"
+		default:
+			return "other STK error"
+		}
 	default:
 		// Other errors.
 		return "other error"

--- a/error_sd.go
+++ b/error_sd.go
@@ -4,7 +4,6 @@ package bluetooth
 
 // #include "nrf_error.h"
 // #include "nrf_error_sdm.h"
-// #include "ble_err.h"
 import "C"
 
 // Error is an error from within the SoftDevice.
@@ -75,22 +74,7 @@ func (e Error) Error() string {
 		return "other SoC error"
 	case e >= C.NRF_ERROR_STK_BASE_NUM && e < 0x4000:
 		// STK errors.
-		switch e {
-		case C.BLE_ERROR_NOT_ENABLED:
-			return "sd_ble_enable has not been called"
-		case C.BLE_ERROR_INVALID_CONN_HANDLE:
-			return "invalid connection handle"
-		case C.BLE_ERROR_INVALID_ATTR_HANDLE:
-			return "invalid attribute handle"
-		case C.BLE_ERROR_INVALID_ADV_HANDLE:
-			return "invalid advertising handle"
-		case C.BLE_ERROR_INVALID_ROLE:
-			return "invalid role"
-		case C.BLE_ERROR_BLOCKED_BY_OTHER_LINKS:
-			return "the attempt to change link settings failed due to the scheduling of other links"
-		default:
-			return "other STK error"
-		}
+		return "other STK error"
 	default:
 		// Other errors.
 		return "other error"


### PR DESCRIPTION
following discussion on #200 
the example of utilization with nicenano on corne keyboard can be found [here](https://github.com/funkycode/tinygo-corne/blob/poc/nicenano/left/main.go#L79) 
in order for it to work though you would need to change max value to `len(reportMap)` [here](https://github.com/tinygo-org/bluetooth/blob/d0c7887b81e136df90b732d1162cdb335633aafa/gatts_sd.go#L60) otherwise the reportmap characteristic would not be available 