### PR TITLE
Add Write command to the gattc implementaitons (windows hat already one)

### DIFF
--- a/gattc_darwin.go
+++ b/gattc_darwin.go
@@ -175,6 +175,14 @@ func (c *DeviceCharacteristic) UUID() UUID {
 	return c.uuidWrapper
 }
 
+// Write replaces the characteristic value with a new value. The
+// call will return after all data has been written.
+func (c DeviceCharacteristic) Write(p []byte) (n int, err error) {
+	c.service.device.prph.WriteCharacteristic(p, c.characteristic, true)
+
+	return len(p), nil
+}
+
 // WriteWithoutResponse replaces the characteristic value with a new value. The
 // call will return before all data has been written. A limited number of such
 // writes can be in flight at any given time. This call is also known as a

--- a/gattc_linux.go
+++ b/gattc_linux.go
@@ -226,6 +226,16 @@ func (s *DeviceService) DiscoverCharacteristics(uuids []UUID) ([]DeviceCharacter
 	return chars, nil
 }
 
+// Write replaces the characteristic value with a new value. The
+// call will return after all data has been written.
+func (c DeviceCharacteristic) Write(p []byte) (n int, err error) {
+	err = c.characteristic.WriteValue(p, map[string]interface{}{"type": "request"})
+    if err != nil {
+    	return 0, err
+	}
+	return len(p), nil
+}
+
 // WriteWithoutResponse replaces the characteristic value with a new value. The
 // call will return before all data has been written. A limited number of such
 // writes can be in flight at any given time. This call is also known as a

--- a/gattc_sd.go
+++ b/gattc_sd.go
@@ -311,6 +311,26 @@ func (s *DeviceService) DiscoverCharacteristics(uuids []UUID) ([]DeviceCharacter
 	return characteristics, nil
 }
 
+// Write replaces the characteristic value with a new value. The
+// call will return after all data has been written.
+func (c DeviceCharacteristic) Write(p []byte) (n int, err error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+
+	errCode := C.sd_ble_gattc_write(c.connectionHandle, &C.ble_gattc_write_params_t{
+		write_op: C.BLE_GATT_OP_WRITE_REQ,
+		handle:   c.valueHandle,
+		offset:   0,
+		len:      uint16(len(p)),
+		p_value:  &p[0],
+		})
+	if errCode != 0 {
+		return 0, Error(errCode)
+	}
+	return len(p), nil
+}
+
 // WriteWithoutResponse replaces the characteristic value with a new value. The
 // call will return before all data has been written. A limited number of such
 // writes can be in flight at any given time. This call is also known as a


### PR DESCRIPTION
This tries to solve issue #153 and add a Write function to all gattc implementations (windows hat already one).

I am on a Mac and the Darwin implementation works fine for me.
The linux implementation is taken form @aykevl comment.
For sd implementation I have looked in the api reference and it seems like the simple change form `WRITE_CMD` to `WRITE_REQ` does the trick.

However, I have no possibility to test the linux or sd implementation properly.
Thus, it would be welcome if somebody else could verify that they work es attended.
