### PR TITLE
Release AsyncOperationCompletedHandler

### DIFF
--- a/adapter_windows.go
+++ b/adapter_windows.go
@@ -40,11 +40,14 @@ func awaitAsyncOperation(asyncOperation *foundation.IAsyncOperation, genericPara
 
 	// Wait until the async operation completes.
 	waitChan := make(chan struct{})
-	asyncOperation.SetCompleted(foundation.NewAsyncOperationCompletedHandler(ole.NewGUID(iid), func(instance *foundation.AsyncOperationCompletedHandler, asyncInfo *foundation.IAsyncOperation, asyncStatus foundation.AsyncStatus) {
-		instance.Release()
+	handler := foundation.NewAsyncOperationCompletedHandler(ole.NewGUID(iid), func(instance *foundation.AsyncOperationCompletedHandler, asyncInfo *foundation.IAsyncOperation, asyncStatus foundation.AsyncStatus) {
 		status = asyncStatus
 		close(waitChan)
-	}))
+	})
+	defer handler.Release()
+
+	asyncOperation.SetCompleted(handler)
+
 	// Wait until async operation has stopped, and finish.
 	<-waitChan
 

--- a/adapter_windows.go
+++ b/adapter_windows.go
@@ -41,6 +41,7 @@ func awaitAsyncOperation(asyncOperation *foundation.IAsyncOperation, genericPara
 	// Wait until the async operation completes.
 	waitChan := make(chan struct{})
 	asyncOperation.SetCompleted(foundation.NewAsyncOperationCompletedHandler(ole.NewGUID(iid), func(instance *foundation.AsyncOperationCompletedHandler, asyncInfo *foundation.IAsyncOperation, asyncStatus foundation.AsyncStatus) {
+		instance.Release()
 		status = asyncStatus
 		close(waitChan)
 	}))


### PR DESCRIPTION
I was working on a home-automation project that involves Switchbots, actually 2 of them. I do quite many calls to them and I faced a crash after about 20 minutes of work. The stack trace was so big that I couldn't see the error, but what I could see is that there was over 500 goroutines spawned by NewAsyncOperationCompletedHandler. And then I noticed that a channel for the handler is never released.

This PR simply releases channel for AsyncOperationCompletedHandler.