### PR TITLE
softdevice: don't send a notify/indicate without a CCCD

### DIFF
--- a/gatts_sd.go
+++ b/gatts_sd.go
@@ -118,7 +118,7 @@ func (c *Characteristic) Write(p []byte) (n int, err error) {
 	}
 
 	connHandle := currentConnection.Get()
-	if connHandle != C.BLE_CONN_HANDLE_INVALID {
+	if connHandle != C.BLE_CONN_HANDLE_INVALID && c.permissions&(CharacteristicNotifyPermission|CharacteristicIndicatePermission) != 0 {
 		// There is a connected central.
 		p_len := uint16(len(p))
 		errCode := C.sd_ble_gatts_hvx_noescape(connHandle,


### PR DESCRIPTION
`sd_ble_gatts_hvx_noescape` can only be called when the notify/indicate permission is set (and therefore a CCCD has been added). Without it, it will just return an error.

This fixes a problem I found on the PineTime, while implementing the battery service.