### PR TITLE
Connection params

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,8 @@ smoketest-tinygo:
 	@md5sum test.hex
 	$(TINYGO) build -o test.uf2 -size=short -target=circuitplay-bluefruit ./examples/circuitplay
 	@md5sum test.hex
+	$(TINYGO) build -o test.hex -size=short -target=circuitplay-bluefruit ./examples/connparams
+	@md5sum test.hex
 	$(TINYGO) build -o test.uf2 -size=short -target=circuitplay-bluefruit ./examples/discover
 	@md5sum test.hex
 	$(TINYGO) build -o test.hex -size=short -target=pca10040-s132v6       ./examples/heartrate
@@ -40,6 +42,7 @@ smoketest-tinygo:
 smoketest-linux:
 	# Test on Linux.
 	GOOS=linux go build -o /tmp/go-build-discard ./examples/advertisement
+	GOOS=linux go build -o /tmp/go-build-discard ./examples/connparams
 	GOOS=linux go build -o /tmp/go-build-discard ./examples/heartrate
 	GOOS=linux go build -o /tmp/go-build-discard ./examples/heartrate-monitor
 	GOOS=linux go build -o /tmp/go-build-discard ./examples/nusserver

--- a/adapter.go
+++ b/adapter.go
@@ -6,6 +6,6 @@ const debug = false
 // SetConnectHandler sets a handler function to be called whenever the adaptor connects
 // or disconnects. You must call this before you call adaptor.Connect() for centrals
 // or adaptor.Start() for peripherals in order for it to work.
-func (a *Adapter) SetConnectHandler(c func(device Address, connected bool)) {
+func (a *Adapter) SetConnectHandler(c func(device Device, connected bool)) {
 	a.connectHandler = c
 }

--- a/adapter_darwin.go
+++ b/adapter_darwin.go
@@ -24,7 +24,7 @@ type Adapter struct {
 	// used to allow multiple callers to call Connect concurrently.
 	connectMap sync.Map
 
-	connectHandler func(device Address, connected bool)
+	connectHandler func(device Device, connected bool)
 }
 
 // DefaultAdapter is the default adapter on the system.
@@ -35,7 +35,7 @@ var DefaultAdapter = &Adapter{
 	pm:         cbgo.NewPeripheralManager(nil),
 	connectMap: sync.Map{},
 
-	connectHandler: func(device Address, connected bool) {
+	connectHandler: func(device Device, connected bool) {
 		return
 	},
 }
@@ -106,7 +106,7 @@ func (cmd *centralManagerDelegate) DidDisconnectPeripheral(cmgr cbgo.CentralMana
 	addr := Address{}
 	uuid, _ := ParseUUID(id)
 	addr.UUID = uuid
-	cmd.a.connectHandler(addr, false)
+	cmd.a.connectHandler(Device{Address: addr}, false)
 
 	// like with DidConnectPeripheral, check if we have a chan allocated for this and send through the peripheral
 	// this will only be true if the receiving side is still waiting for a connection to complete

--- a/adapter_linux.go
+++ b/adapter_linux.go
@@ -23,7 +23,7 @@ type Adapter struct {
 	address              string
 	defaultAdvertisement *Advertisement
 
-	connectHandler func(device Address, connected bool)
+	connectHandler func(device Device, connected bool)
 }
 
 // DefaultAdapter is the default adapter on the system. On Linux, it is the
@@ -32,7 +32,7 @@ type Adapter struct {
 // Make sure to call Enable() before using it to initialize the adapter.
 var DefaultAdapter = &Adapter{
 	id: defaultAdapter,
-	connectHandler: func(device Address, connected bool) {
+	connectHandler: func(device Device, connected bool) {
 	},
 }
 

--- a/adapter_ninafw.go
+++ b/adapter_ninafw.go
@@ -19,7 +19,7 @@ type Adapter struct {
 	isDefault bool
 	scanning  bool
 
-	connectHandler func(device Address, connected bool)
+	connectHandler func(device Device, connected bool)
 
 	connectedDevices     []Device
 	notificationsStarted bool
@@ -30,7 +30,7 @@ type Adapter struct {
 // Make sure to call Enable() before using it to initialize the adapter.
 var DefaultAdapter = &Adapter{
 	isDefault: true,
-	connectHandler: func(device Address, connected bool) {
+	connectHandler: func(device Device, connected bool) {
 		return
 	},
 	connectedDevices: make([]Device, 0, maxConnections),

--- a/adapter_ninafw.go
+++ b/adapter_ninafw.go
@@ -21,7 +21,7 @@ type Adapter struct {
 
 	connectHandler func(device Address, connected bool)
 
-	connectedDevices     []*Device
+	connectedDevices     []Device
 	notificationsStarted bool
 }
 
@@ -33,7 +33,7 @@ var DefaultAdapter = &Adapter{
 	connectHandler: func(device Address, connected bool) {
 		return
 	},
-	connectedDevices: make([]*Device, 0, maxConnections),
+	connectedDevices: make([]Device, 0, maxConnections),
 }
 
 // Enable configures the BLE stack. It must be called before any
@@ -170,7 +170,7 @@ func (a *Adapter) startNotifications() {
 				}
 
 				d := a.findDevice(not.connectionHandle)
-				if d == nil {
+				if d.deviceInternal == nil {
 					if _debug {
 						println("no device found for handle", not.connectionHandle)
 					}
@@ -197,7 +197,7 @@ func (a *Adapter) startNotifications() {
 	}()
 }
 
-func (a *Adapter) findDevice(handle uint16) *Device {
+func (a *Adapter) findDevice(handle uint16) Device {
 	for _, d := range a.connectedDevices {
 		if d.handle == handle {
 			if _debug {
@@ -208,5 +208,5 @@ func (a *Adapter) findDevice(handle uint16) *Device {
 		}
 	}
 
-	return nil
+	return Device{}
 }

--- a/adapter_nrf51.go
+++ b/adapter_nrf51.go
@@ -44,8 +44,11 @@ func handleEvent() {
 		case C.BLE_GAP_EVT_CONNECTED:
 			currentConnection.handle.Reg = uint16(gapEvent.conn_handle)
 			connectEvent := gapEvent.params.unionfield_connected()
-			address := Address{makeMACAddress(connectEvent.peer_addr)}
-			DefaultAdapter.connectHandler(address, true)
+			device := Device{
+				Address:          Address{makeMACAddress(connectEvent.peer_addr)},
+				connectionHandle: gapEvent.conn_handle,
+			}
+			DefaultAdapter.connectHandler(device, true)
 		case C.BLE_GAP_EVT_DISCONNECTED:
 			if defaultAdvertisement.isAdvertising.Get() != 0 {
 				// The advertisement was running but was automatically stopped
@@ -57,7 +60,10 @@ func handleEvent() {
 				defaultAdvertisement.start()
 			}
 			currentConnection.handle.Reg = C.BLE_CONN_HANDLE_INVALID
-			DefaultAdapter.connectHandler(Address{}, false)
+			device := Device{
+				connectionHandle: gapEvent.conn_handle,
+			}
+			DefaultAdapter.connectHandler(device, false)
 		case C.BLE_GAP_EVT_CONN_PARAM_UPDATE_REQUEST:
 			// Respond with the default PPCP connection parameters by passing
 			// nil:

--- a/adapter_nrf51.go
+++ b/adapter_nrf51.go
@@ -43,7 +43,9 @@ func handleEvent() {
 		switch id {
 		case C.BLE_GAP_EVT_CONNECTED:
 			currentConnection.handle.Reg = uint16(gapEvent.conn_handle)
-			DefaultAdapter.connectHandler(Address{}, true)
+			connectEvent := gapEvent.params.unionfield_connected()
+			address := Address{makeMACAddress(connectEvent.peer_addr)}
+			DefaultAdapter.connectHandler(address, true)
 		case C.BLE_GAP_EVT_DISCONNECTED:
 			if defaultAdvertisement.isAdvertising.Get() != 0 {
 				// The advertisement was running but was automatically stopped
@@ -110,4 +112,12 @@ func (a *Adapter) Address() (MACAddress, error) {
 		return MACAddress{}, Error(errCode)
 	}
 	return MACAddress{MAC: makeAddress(addr.addr)}, nil
+}
+
+// Convert a C.ble_gap_addr_t to a MACAddress struct.
+func makeMACAddress(addr C.ble_gap_addr_t) MACAddress {
+	return MACAddress{
+		MAC:      makeAddress(addr.addr),
+		isRandom: addr.addr_type != 0,
+	}
 }

--- a/adapter_nrf528xx-full.go
+++ b/adapter_nrf528xx-full.go
@@ -25,20 +25,21 @@ func handleEvent() {
 		switch id {
 		case C.BLE_GAP_EVT_CONNECTED:
 			connectEvent := gapEvent.params.unionfield_connected()
+			address := Address{makeMACAddress(connectEvent.peer_addr)}
 			switch connectEvent.role {
 			case C.BLE_GAP_ROLE_PERIPH:
 				if debug {
 					println("evt: connected in peripheral role")
 				}
 				currentConnection.handle.Reg = uint16(gapEvent.conn_handle)
-				DefaultAdapter.connectHandler(Address{}, true)
+				DefaultAdapter.connectHandler(address, true)
 			case C.BLE_GAP_ROLE_CENTRAL:
 				if debug {
 					println("evt: connected in central role")
 				}
 				connectionAttempt.connectionHandle = gapEvent.conn_handle
 				connectionAttempt.state.Set(2) // connection was successful
-				DefaultAdapter.connectHandler(Address{}, true)
+				DefaultAdapter.connectHandler(address, true)
 			}
 		case C.BLE_GAP_EVT_DISCONNECTED:
 			if debug {
@@ -81,8 +82,7 @@ func handleEvent() {
 			scanReportBuffer.len = byte(advReport.data.len)
 			globalScanResult.RSSI = int16(advReport.rssi)
 			globalScanResult.Address = Address{
-				MACAddress{MAC: makeAddress(advReport.peer_addr.addr),
-					isRandom: advReport.peer_addr.bitfield_addr_type() != 0},
+				makeMACAddress(advReport.peer_addr),
 			}
 			globalScanResult.AdvertisementPayload = &scanReportBuffer
 			// Signal to the main thread that there was a scan report.

--- a/adapter_nrf528xx-full.go
+++ b/adapter_nrf528xx-full.go
@@ -25,21 +25,24 @@ func handleEvent() {
 		switch id {
 		case C.BLE_GAP_EVT_CONNECTED:
 			connectEvent := gapEvent.params.unionfield_connected()
-			address := Address{makeMACAddress(connectEvent.peer_addr)}
+			device := Device{
+				Address:          Address{makeMACAddress(connectEvent.peer_addr)},
+				connectionHandle: gapEvent.conn_handle,
+			}
 			switch connectEvent.role {
 			case C.BLE_GAP_ROLE_PERIPH:
 				if debug {
 					println("evt: connected in peripheral role")
 				}
 				currentConnection.handle.Reg = uint16(gapEvent.conn_handle)
-				DefaultAdapter.connectHandler(address, true)
+				DefaultAdapter.connectHandler(device, true)
 			case C.BLE_GAP_ROLE_CENTRAL:
 				if debug {
 					println("evt: connected in central role")
 				}
 				connectionAttempt.connectionHandle = gapEvent.conn_handle
 				connectionAttempt.state.Set(2) // connection was successful
-				DefaultAdapter.connectHandler(address, true)
+				DefaultAdapter.connectHandler(device, true)
 			}
 		case C.BLE_GAP_EVT_DISCONNECTED:
 			if debug {
@@ -62,7 +65,10 @@ func handleEvent() {
 				// necessary.
 				C.sd_ble_gap_adv_start(defaultAdvertisement.handle, C.BLE_CONN_CFG_TAG_DEFAULT)
 			}
-			DefaultAdapter.connectHandler(Address{}, false)
+			device := Device{
+				connectionHandle: gapEvent.conn_handle,
+			}
+			DefaultAdapter.connectHandler(device, false)
 		case C.BLE_GAP_EVT_CONN_PARAM_UPDATE:
 			if debug {
 				// Print connection parameters for easy debugging.

--- a/adapter_nrf528xx-full.go
+++ b/adapter_nrf528xx-full.go
@@ -62,6 +62,14 @@ func handleEvent() {
 				C.sd_ble_gap_adv_start(defaultAdvertisement.handle, C.BLE_CONN_CFG_TAG_DEFAULT)
 			}
 			DefaultAdapter.connectHandler(Address{}, false)
+		case C.BLE_GAP_EVT_CONN_PARAM_UPDATE:
+			if debug {
+				// Print connection parameters for easy debugging.
+				params := gapEvent.params.unionfield_conn_param_update().conn_params
+				interval_ms := params.min_conn_interval * 125 / 100 // min and max are the same here
+				print("conn param update interval=", interval_ms, "ms latency=", params.slave_latency, " timeout=", params.conn_sup_timeout*10, "ms")
+				println()
+			}
 		case C.BLE_GAP_EVT_ADV_REPORT:
 			advReport := gapEvent.params.unionfield_adv_report()
 			if debug && &scanReportBuffer.data[0] != (*byte)(unsafe.Pointer(advReport.data.p_data)) {

--- a/adapter_nrf528xx-peripheral.go
+++ b/adapter_nrf528xx-peripheral.go
@@ -28,7 +28,8 @@ func handleEvent() {
 				println("evt: connected in peripheral role")
 			}
 			currentConnection.handle.Reg = uint16(gapEvent.conn_handle)
-			DefaultAdapter.connectHandler(Address{}, true)
+			connectEvent := gapEvent.params.unionfield_connected()
+			DefaultAdapter.connectHandler(Address{makeMACAddress(connectEvent.peer_addr)}, true)
 		case C.BLE_GAP_EVT_DISCONNECTED:
 			if debug {
 				println("evt: disconnected")

--- a/adapter_nrf528xx-peripheral.go
+++ b/adapter_nrf528xx-peripheral.go
@@ -29,7 +29,11 @@ func handleEvent() {
 			}
 			currentConnection.handle.Reg = uint16(gapEvent.conn_handle)
 			connectEvent := gapEvent.params.unionfield_connected()
-			DefaultAdapter.connectHandler(Address{makeMACAddress(connectEvent.peer_addr)}, true)
+			device := Device{
+				Address:          Address{makeMACAddress(connectEvent.peer_addr)},
+				connectionHandle: gapEvent.conn_handle,
+			}
+			DefaultAdapter.connectHandler(device, true)
 		case C.BLE_GAP_EVT_DISCONNECTED:
 			if debug {
 				println("evt: disconnected")
@@ -45,7 +49,10 @@ func handleEvent() {
 				// necessary.
 				C.sd_ble_gap_adv_start(defaultAdvertisement.handle, C.BLE_CONN_CFG_TAG_DEFAULT)
 			}
-			DefaultAdapter.connectHandler(Address{}, false)
+			device := Device{
+				connectionHandle: gapEvent.conn_handle,
+			}
+			DefaultAdapter.connectHandler(device, false)
 		case C.BLE_GAP_EVT_DATA_LENGTH_UPDATE_REQUEST:
 			// We need to respond with sd_ble_gap_data_length_update. Setting
 			// both parameters to nil will make sure we send the default values.

--- a/adapter_nrf528xx.go
+++ b/adapter_nrf528xx.go
@@ -59,3 +59,11 @@ func (a *Adapter) Address() (MACAddress, error) {
 	}
 	return MACAddress{MAC: makeAddress(addr.addr)}, nil
 }
+
+// Convert a C.ble_gap_addr_t to a MACAddress struct.
+func makeMACAddress(addr C.ble_gap_addr_t) MACAddress {
+	return MACAddress{
+		MAC:      makeAddress(addr.addr),
+		isRandom: addr.bitfield_addr_type() != 0,
+	}
+}

--- a/adapter_sd.go
+++ b/adapter_sd.go
@@ -48,7 +48,7 @@ type Adapter struct {
 	scanning          bool
 	charWriteHandlers []charWriteHandler
 
-	connectHandler func(device Address, connected bool)
+	connectHandler func(device Device, connected bool)
 }
 
 // DefaultAdapter is the default adapter on the current system. On Nordic chips,
@@ -56,7 +56,7 @@ type Adapter struct {
 //
 // Make sure to call Enable() before using it to initialize the adapter.
 var DefaultAdapter = &Adapter{isDefault: true,
-	connectHandler: func(device Address, connected bool) {
+	connectHandler: func(device Device, connected bool) {
 		return
 	}}
 

--- a/adapter_windows.go
+++ b/adapter_windows.go
@@ -12,14 +12,14 @@ import (
 type Adapter struct {
 	watcher *advertisement.BluetoothLEAdvertisementWatcher
 
-	connectHandler func(device Address, connected bool)
+	connectHandler func(device Device, connected bool)
 }
 
 // DefaultAdapter is the default adapter on the system.
 //
 // Make sure to call Enable() before using it to initialize the adapter.
 var DefaultAdapter = &Adapter{
-	connectHandler: func(device Address, connected bool) {
+	connectHandler: func(device Device, connected bool) {
 		return
 	},
 }

--- a/examples/circuitplay/main.go
+++ b/examples/circuitplay/main.go
@@ -38,7 +38,7 @@ func main() {
 	neo.Configure(machine.PinConfig{Mode: machine.PinOutput})
 	ws = ws2812.New(neo)
 
-	adapter.SetConnectHandler(func(d bluetooth.Address, c bool) {
+	adapter.SetConnectHandler(func(d bluetooth.Device, c bool) {
 		connected = c
 
 		if !connected && !disconnected {

--- a/examples/connparams/main.go
+++ b/examples/connparams/main.go
@@ -1,0 +1,84 @@
+// Test for setting connection parameters.
+//
+// To test this feature, run this either on a desktop OS or by flashing it to a
+// device with TinyGo. Then connect to it from a BLE connection debugger, for
+// example nRF Connect on Android. After a second, you should see in the log of
+// the BLE app that the connection latency has been updated. It might look
+// something like this:
+//
+//	Connection parameters updated (interval: 510.0ms, latency: 0, timeout: 10000ms)
+package main
+
+import (
+	"time"
+
+	"tinygo.org/x/bluetooth"
+)
+
+var (
+	adapter   = bluetooth.DefaultAdapter
+	newDevice chan bluetooth.Device
+)
+
+func main() {
+	must("enable BLE stack", adapter.Enable())
+
+	newDevice = make(chan bluetooth.Device, 1)
+	adapter.SetConnectHandler(func(device bluetooth.Device, connected bool) {
+		// If this is a new device, signal it to the separate goroutine.
+		if connected {
+			select {
+			case newDevice <- device:
+			default:
+			}
+		}
+	})
+
+	// Start advertising, so we can be found.
+	const name = "Go BLE test"
+	adv := adapter.DefaultAdvertisement()
+	adv.Configure(bluetooth.AdvertisementOptions{
+		LocalName: name,
+	})
+	adv.Start()
+	println("advertising:", name)
+
+	for device := range newDevice {
+		println("connection from device:", device.Address.String())
+
+		// Discover services and characteristics.
+		svcs, err := device.DiscoverServices(nil)
+		if err != nil {
+			println("  failed to resolve services:", err)
+		}
+		for _, svc := range svcs {
+			println("  service:", svc.UUID().String())
+			chars, err := svc.DiscoverCharacteristics(nil)
+			if err != nil {
+				println("    failed to resolve characteristics:", err)
+			}
+			for _, char := range chars {
+				println("    characteristic:", char.UUID().String())
+			}
+		}
+
+		// Update connection parameters (as a test).
+		time.Sleep(time.Second)
+		err = device.RequestConnectionParams(bluetooth.ConnectionParams{
+			MinInterval: bluetooth.NewDuration(495 * time.Millisecond),
+			MaxInterval: bluetooth.NewDuration(510 * time.Millisecond),
+			Timeout:     bluetooth.NewDuration(10 * time.Second),
+		})
+		if err != nil {
+			println("  failed to update connection parameters:", err)
+			continue
+		}
+		println("  updated connection parameters")
+	}
+}
+
+func must(action string, err error) {
+	if err != nil {
+		panic("failed to " + action + ": " + err.Error())
+	}
+}

--- a/examples/discover/main.go
+++ b/examples/discover/main.go
@@ -43,7 +43,7 @@ func main() {
 		}
 	})
 
-	var device *bluetooth.Device
+	var device bluetooth.Device
 	select {
 	case result := <-ch:
 		device, err = adapter.Connect(result.Address, bluetooth.ConnectionParams{})

--- a/examples/heartrate-monitor/main.go
+++ b/examples/heartrate-monitor/main.go
@@ -52,7 +52,7 @@ func main() {
 		}
 	})
 
-	var device *bluetooth.Device
+	var device bluetooth.Device
 	select {
 	case result := <-ch:
 		device, err = adapter.Connect(result.Address, bluetooth.ConnectionParams{})

--- a/examples/stop-advertisement/main.go
+++ b/examples/stop-advertisement/main.go
@@ -21,7 +21,7 @@ func main() {
 	must("config adv", adv.Configure(bluetooth.AdvertisementOptions{
 		LocalName: "Go Bluetooth",
 	}))
-	adapter.SetConnectHandler(func(device bluetooth.Address, connected bool) {
+	adapter.SetConnectHandler(func(device bluetooth.Device, connected bool) {
 		if connected {
 			println("connected, not advertising...")
 			advState = false

--- a/gap.go
+++ b/gap.go
@@ -391,7 +391,8 @@ func (buf *rawAdvertisementPayload) addServiceUUID(uuid UUID) (ok bool) {
 	}
 }
 
-// ConnectionParams are used when connecting to a peripherals.
+// ConnectionParams are used when connecting to a peripherals or when changing
+// the parameters of an active connection.
 type ConnectionParams struct {
 	// The timeout for the connection attempt. Not used during the rest of the
 	// connection. If no duration is specified, a default timeout will be used.
@@ -403,4 +404,9 @@ type ConnectionParams struct {
 	// will be used.
 	MinInterval Duration
 	MaxInterval Duration
+
+	// Connection Supervision Timeout. After this time has passed with no
+	// communication, the connection is considered lost. If no timeout is
+	// specified, the timeout will be unchanged.
+	Timeout Duration
 }

--- a/gap_darwin.go
+++ b/gap_darwin.go
@@ -85,6 +85,8 @@ func (a *Adapter) StopScan() error {
 
 // Device is a connection to a remote peripheral.
 type Device struct {
+	Address Address
+
 	*deviceInternal
 }
 
@@ -137,7 +139,8 @@ func (a *Adapter) Connect(address Address, params ConnectionParams) (Device, err
 			}
 
 			d := Device{
-				&deviceInternal{
+				Address: address,
+				deviceInternal: &deviceInternal{
 					cm:           a.cm,
 					prph:         p,
 					servicesChan: make(chan error),
@@ -148,7 +151,7 @@ func (a *Adapter) Connect(address Address, params ConnectionParams) (Device, err
 			d.delegate = &peripheralDelegate{d: d}
 			p.SetDelegate(d.delegate)
 
-			a.connectHandler(address, true)
+			a.connectHandler(d, true)
 
 			return d, nil
 

--- a/gap_darwin.go
+++ b/gap_darwin.go
@@ -176,6 +176,18 @@ func (d Device) Disconnect() error {
 	return nil
 }
 
+// RequestConnectionParams requests a different connection latency and timeout
+// of the given device connection. Fields that are unset will be left alone.
+// Whether or not the device will actually honor this, depends on the device and
+// on the specific parameters.
+//
+// This call has not yet been implemented on macOS.
+func (d Device) RequestConnectionParams(params ConnectionParams) error {
+	// TODO: implement this using setDesiredConnectionLatency, see:
+	// https://developer.apple.com/documentation/corebluetooth/cbperipheralmanager/1393277-setdesiredconnectionlatency
+	return nil
+}
+
 // Peripheral delegate functions
 
 type peripheralDelegate struct {

--- a/gap_linux.go
+++ b/gap_linux.go
@@ -292,9 +292,10 @@ func makeScanResult(props map[string]dbus.Variant) ScanResult {
 
 // Device is a connection to a remote peripheral.
 type Device struct {
+	Address Address // the MAC address of the device
+
 	device  dbus.BusObject // bluez device interface
 	adapter *Adapter       // the adapter that was used to form this device connection
-	address Address        // the address of the device
 }
 
 // Connect starts a connection attempt to the given peripheral device address.
@@ -303,9 +304,9 @@ type Device struct {
 func (a *Adapter) Connect(address Address, params ConnectionParams) (Device, error) {
 	devicePath := dbus.ObjectPath(string(a.adapter.Path()) + "/dev_" + strings.Replace(address.MAC.String(), ":", "_", -1))
 	device := Device{
+		Address: address,
 		device:  a.bus.Object("org.bluez", devicePath),
 		adapter: a,
-		address: address,
 	}
 
 	// Already start watching for property changes. We do this before reading

--- a/gap_linux.go
+++ b/gap_linux.go
@@ -366,3 +366,14 @@ func (d Device) Disconnect() error {
 	// property change in `watchForConnect` and cancel things then
 	return d.device.Call("org.bluez.Device1.Disconnect", 0).Err
 }
+
+// RequestConnectionParams requests a different connection latency and timeout
+// of the given device connection. Fields that are unset will be left alone.
+// Whether or not the device will actually honor this, depends on the device and
+// on the specific parameters.
+//
+// On Linux, this call doesn't do anything because BlueZ doesn't support
+// changing the connection latency.
+func (d Device) RequestConnectionParams(params ConnectionParams) error {
+	return nil
+}

--- a/gap_ninafw.go
+++ b/gap_ninafw.go
@@ -230,6 +230,16 @@ func (d Device) Disconnect() error {
 	return nil
 }
 
+// RequestConnectionParams requests a different connection latency and timeout
+// of the given device connection. Fields that are unset will be left alone.
+// Whether or not the device will actually honor this, depends on the device and
+// on the specific parameters.
+//
+// On NINA, this call hasn't been implemented yet.
+func (d Device) RequestConnectionParams(params ConnectionParams) error {
+	return nil
+}
+
 func (d Device) findNotificationRegistration(handle uint16) *notificationRegistration {
 	for _, n := range d.notificationRegistrations {
 		if n.handle == handle {

--- a/gap_ninafw.go
+++ b/gap_ninafw.go
@@ -133,7 +133,7 @@ type Address struct {
 }
 
 // Connect starts a connection attempt to the given peripheral device address.
-func (a *Adapter) Connect(address Address, params ConnectionParams) (*Device, error) {
+func (a *Adapter) Connect(address Address, params ConnectionParams) (Device, error) {
 	if _debug {
 		println("Connect")
 	}
@@ -145,14 +145,14 @@ func (a *Adapter) Connect(address Address, params ConnectionParams) (*Device, er
 	if err := a.hci.leCreateConn(0x0060, 0x0030, 0x00,
 		random, makeNINAAddress(address.MAC),
 		0x00, 0x0006, 0x000c, 0x0000, 0x00c8, 0x0004, 0x0006); err != nil {
-		return nil, err
+		return Device{}, err
 	}
 
 	// are we connected?
 	start := time.Now().UnixNano()
 	for {
 		if err := a.hci.poll(); err != nil {
-			return nil, err
+			return Device{}, err
 		}
 
 		if a.hci.connectData.connected {
@@ -163,15 +163,18 @@ func (a *Adapter) Connect(address Address, params ConnectionParams) (*Device, er
 				random = true
 			}
 
-			d := &Device{adapter: a,
-				handle: a.hci.connectData.handle,
+			d := Device{
 				Address: Address{
 					MACAddress{
 						MAC:      makeAddress(a.hci.connectData.peerBdaddr),
 						isRandom: random},
 				},
-				mtu:                       defaultMTU,
-				notificationRegistrations: make([]notificationRegistration, 0),
+				deviceInternal: &deviceInternal{
+					adapter:                   a,
+					handle:                    a.hci.connectData.handle,
+					mtu:                       defaultMTU,
+					notificationRegistrations: make([]notificationRegistration, 0),
+				},
 			}
 			a.connectedDevices = append(a.connectedDevices, d)
 
@@ -189,10 +192,10 @@ func (a *Adapter) Connect(address Address, params ConnectionParams) (*Device, er
 
 	// cancel connection attempt that failed
 	if err := a.hci.leCancelConn(); err != nil {
-		return nil, err
+		return Device{}, err
 	}
 
-	return nil, ErrConnect
+	return Device{}, ErrConnect
 }
 
 type notificationRegistration struct {
@@ -202,8 +205,12 @@ type notificationRegistration struct {
 
 // Device is a connection to a remote peripheral.
 type Device struct {
-	adapter *Adapter
 	Address Address
+	*deviceInternal
+}
+
+type deviceInternal struct {
+	adapter *Adapter
 	handle  uint16
 	mtu     uint16
 
@@ -211,7 +218,7 @@ type Device struct {
 }
 
 // Disconnect from the BLE device.
-func (d *Device) Disconnect() error {
+func (d Device) Disconnect() error {
 	if _debug {
 		println("Disconnect")
 	}
@@ -219,11 +226,11 @@ func (d *Device) Disconnect() error {
 		return err
 	}
 
-	d.adapter.connectedDevices = []*Device{}
+	d.adapter.connectedDevices = []Device{}
 	return nil
 }
 
-func (d *Device) findNotificationRegistration(handle uint16) *notificationRegistration {
+func (d Device) findNotificationRegistration(handle uint16) *notificationRegistration {
 	for _, n := range d.notificationRegistrations {
 		if n.handle == handle {
 			return &n
@@ -233,7 +240,7 @@ func (d *Device) findNotificationRegistration(handle uint16) *notificationRegist
 	return nil
 }
 
-func (d *Device) addNotificationRegistration(handle uint16, callback func([]byte)) {
+func (d Device) addNotificationRegistration(handle uint16, callback func([]byte)) {
 	d.notificationRegistrations = append(d.notificationRegistrations,
 		notificationRegistration{
 			handle:   handle,
@@ -241,6 +248,6 @@ func (d *Device) addNotificationRegistration(handle uint16, callback func([]byte
 		})
 }
 
-func (d *Device) startNotifications() {
+func (d Device) startNotifications() {
 	d.adapter.startNotifications()
 }

--- a/gap_nrf528xx-central.go
+++ b/gap_nrf528xx-central.go
@@ -92,11 +92,6 @@ func (a *Adapter) StopScan() error {
 	return nil
 }
 
-// Device is a connection to a remote peripheral.
-type Device struct {
-	connectionHandle C.uint16_t
-}
-
 // In-progress connection attempt.
 var connectionAttempt struct {
 	state            volatile.Register8 // 0 means unused, 1 means connecting, 2 means ready (connected or timeout)

--- a/gap_sd.go
+++ b/gap_sd.go
@@ -1,0 +1,15 @@
+//go:build softdevice
+
+package bluetooth
+
+/*
+#include "ble_gap.h"
+*/
+import "C"
+
+// Device is a connection to a remote peripheral or central.
+type Device struct {
+	Address Address
+
+	connectionHandle C.uint16_t
+}

--- a/gap_windows.go
+++ b/gap_windows.go
@@ -247,3 +247,15 @@ func (d Device) Disconnect() error {
 
 	return nil
 }
+
+// RequestConnectionParams requests a different connection latency and timeout
+// of the given device connection. Fields that are unset will be left alone.
+// Whether or not the device will actually honor this, depends on the device and
+// on the specific parameters.
+//
+// On Windows, this call doesn't do anything.
+func (d Device) RequestConnectionParams(params ConnectionParams) error {
+	// TODO: implement this using
+	// BluetoothLEDevice.RequestPreferredConnectionParameters.
+	return nil
+}

--- a/gattc_darwin.go
+++ b/gattc_darwin.go
@@ -14,7 +14,7 @@ import (
 //
 // Passing a nil slice of UUIDs will return a complete list of
 // services.
-func (d *Device) DiscoverServices(uuids []UUID) ([]DeviceService, error) {
+func (d Device) DiscoverServices(uuids []UUID) ([]DeviceService, error) {
 	d.prph.DiscoverServices([]cbgo.UUID{})
 
 	// clear cache of services
@@ -69,7 +69,7 @@ type DeviceService struct {
 type deviceService struct {
 	uuidWrapper
 
-	device *Device
+	device Device
 
 	service         cbgo.Service
 	characteristics []DeviceCharacteristic

--- a/gattc_ninafw.go
+++ b/gattc_ninafw.go
@@ -35,7 +35,7 @@ const (
 type DeviceService struct {
 	uuid UUID
 
-	device                 *Device
+	device                 Device
 	startHandle, endHandle uint16
 }
 
@@ -51,7 +51,7 @@ func (s DeviceService) UUID() UUID {
 //
 // Passing a nil slice of UUIDs will return a complete list of
 // services.
-func (d *Device) DiscoverServices(uuids []UUID) ([]DeviceService, error) {
+func (d Device) DiscoverServices(uuids []UUID) ([]DeviceService, error) {
 	if _debug {
 		println("DiscoverServices")
 	}

--- a/gattc_sd.go
+++ b/gattc_sd.go
@@ -59,7 +59,7 @@ func (s DeviceService) UUID() UUID {
 //
 // On the Nordic SoftDevice, only one service discovery procedure may be done at
 // a time.
-func (d *Device) DiscoverServices(uuids []UUID) ([]DeviceService, error) {
+func (d Device) DiscoverServices(uuids []UUID) ([]DeviceService, error) {
 	if discoveringService.state.Get() != 0 {
 		// Not concurrency safe, but should catch most concurrency misuses.
 		return nil, errAlreadyDiscovering

--- a/gattc_windows.go
+++ b/gattc_windows.go
@@ -30,7 +30,7 @@ var (
 //
 // Passing a nil slice of UUIDs will return a complete list of
 // services.
-func (d *Device) DiscoverServices(filterUUIDs []UUID) ([]DeviceService, error) {
+func (d Device) DiscoverServices(filterUUIDs []UUID) ([]DeviceService, error) {
 	// IAsyncOperation<GattDeviceServicesResult>
 	getServicesOperation, err := d.device.GetGattServicesWithCacheModeAsync(bluetooth.BluetoothCacheModeUncached)
 	if err != nil {
@@ -133,7 +133,7 @@ type DeviceService struct {
 	uuidWrapper
 
 	service *genericattributeprofile.GattDeviceService
-	device  *Device
+	device  Device
 }
 
 // UUID returns the UUID for this DeviceService.


### PR DESCRIPTION
~Work in progress: I haven't added macOS support yet.~ done

This is a PR that changes a few things to make `Device` objects usable in peripheral mode (when another device connects to it):

  * It changes `*Device` to `Device`. This is a breaking change, but makes things a lot easier to deal with on a SoftDevice (no difficult workarounds needed to avoid allocating a heap object in the interrupt handler).
  * It changes `SetConnectHandler` so that a `Device` is passed instead of just the address of the connecting device. This is another breaking change, but necessary to support this feature (without ugly hacks). Hopefully this is the last breaking change to `SetConnectHandler`.
  * It now loads the connecting device MAC address, which was previously empty.
  * It adds `SetConnectionLatency` which is necessary for battery operated devices to lower the connection latency and with that lower the current consumption (for example, it lowers the current consumed from 85µA to 10µA according to the [online power profiler](https://devzone.nordicsemi.com/power/w/opp/2/online-power-profiler-for-bluetooth-le)). This change was my original motivation for this PR.

Discovering services and characteristics was already implemented for central mode, and I've found it works just as well in peripheral mode on the SoftDevice.

Tested:

  * This works well on the Circuit Playground Bluefruit.
  * This doesn't work correctly on Linux (but it doesn't crash either): it doesn't seem to call the connection handler callback.
  * Same for macOS. I don't think it would be very difficult to implement, but preferably it would need advertising support first.
  * I haven't tested it on Windows because I don't have easy access to a Windows installation with Bluetooth access. Might try this in my Windows VM though. The smoke test says it compiles.