### PR TITLE
examples: update MCU central examples to use ldflags to pass the desired device to connect to

### DIFF
--- a/examples/discover/mcu.go
+++ b/examples/discover/mcu.go
@@ -6,11 +6,15 @@ import (
 	"time"
 )
 
-// replace this with the MAC address of the Bluetooth peripheral you want to connect to.
-const deviceAddress = "E4:B7:F4:11:8D:33"
+// DeviceAddress is the MAC address of the Bluetooth peripheral you want to connect to.
+// Replace this by using -ldflags="-X main.DeviceAddress=[MAC ADDRESS]"
+// where [MAC ADDRESS] is the actual MAC address of the peripheral.
+// For example:
+// tinygo flash -target circuitplay-bluefruit -ldflags="-X main.DeviceAddress=7B:36:98:8C:41:1C" ./examples/discover/
+var DeviceAddress string
 
 func connectAddress() string {
-	return deviceAddress
+	return DeviceAddress
 }
 
 // wait on baremetal, proceed immediately on desktop OS.

--- a/examples/heartrate-monitor/mcu.go
+++ b/examples/heartrate-monitor/mcu.go
@@ -6,11 +6,15 @@ import (
 	"time"
 )
 
-// replace this with the MAC address of the Bluetooth peripheral you want to connect to.
-const deviceAddress = "E4:B7:F4:11:8D:33"
+// DeviceAddress is the MAC address of the Bluetooth peripheral you want to connect to.
+// Replace this by using -ldflags="-X main.DeviceAddress=[MAC ADDRESS]"
+// where [MAC ADDRESS] is the actual MAC address of the peripheral.
+// For example:
+// tinygo flash -target circuitplay-bluefruit -ldflags="-X main.DeviceAddress=7B:36:98:8C:41:1C" ./examples/heartrate-monitor/
+var DeviceAddress string
 
 func connectAddress() string {
-	return deviceAddress
+	return DeviceAddress
 }
 
 // done just blocks forever, allows USB CDC reset for flashing new software.


### PR DESCRIPTION
This PR modifies the MCU central examples to use ldflags to pass the desired device to connect to.

For example:

```
tinygo flash -target circuitplay-bluefruit -ldflags="-X main.DeviceAddress=60:B7:27:9B:A7:AC" ./examples/heartrate-monitor/
```

The code previously needed to be modified for the correct MAC address to connect to. This is a lot easier to use.