### PR TITLE
all: don't use a pointer receiver for many method calls

### DIFF
--- a/gattc_darwin.go
+++ b/gattc_darwin.go
@@ -76,7 +76,7 @@ type deviceService struct {
 }
 
 // UUID returns the UUID for this DeviceService.
-func (s *DeviceService) UUID() UUID {
+func (s DeviceService) UUID() UUID {
 	return s.uuidWrapper
 }
 
@@ -89,7 +89,7 @@ func (s *DeviceService) UUID() UUID {
 //
 // Passing a nil slice of UUIDs will return a complete list of
 // characteristics.
-func (s *DeviceService) DiscoverCharacteristics(uuids []UUID) ([]DeviceCharacteristic, error) {
+func (s DeviceService) DiscoverCharacteristics(uuids []UUID) ([]DeviceCharacteristic, error) {
 	cbuuids := []cbgo.UUID{}
 
 	s.device.prph.DiscoverCharacteristics(cbuuids, s.service)
@@ -142,7 +142,7 @@ func (s *DeviceService) DiscoverCharacteristics(uuids []UUID) ([]DeviceCharacter
 }
 
 // Small helper to create a DeviceCharacteristic object.
-func (s *DeviceService) makeCharacteristic(uuid UUID, dchar cbgo.Characteristic) DeviceCharacteristic {
+func (s DeviceService) makeCharacteristic(uuid UUID, dchar cbgo.Characteristic) DeviceCharacteristic {
 	char := DeviceCharacteristic{
 		deviceCharacteristic: &deviceCharacteristic{
 			uuidWrapper:    uuid,
@@ -163,7 +163,7 @@ type DeviceCharacteristic struct {
 type deviceCharacteristic struct {
 	uuidWrapper
 
-	service *DeviceService
+	service DeviceService
 
 	characteristic cbgo.Characteristic
 	callback       func(buf []byte)
@@ -171,7 +171,7 @@ type deviceCharacteristic struct {
 }
 
 // UUID returns the UUID for this DeviceCharacteristic.
-func (c *DeviceCharacteristic) UUID() UUID {
+func (c DeviceCharacteristic) UUID() UUID {
 	return c.uuidWrapper
 }
 

--- a/gattc_linux.go
+++ b/gattc_linux.go
@@ -29,7 +29,7 @@ type DeviceService struct {
 }
 
 // UUID returns the UUID for this DeviceService.
-func (s *DeviceService) UUID() UUID {
+func (s DeviceService) UUID() UUID {
 	return s.uuidWrapper
 }
 
@@ -43,7 +43,7 @@ func (s *DeviceService) UUID() UUID {
 //
 // On Linux with BlueZ, this just waits for the ServicesResolved signal (if
 // services haven't been resolved yet) and uses this list of cached services.
-func (d *Device) DiscoverServices(uuids []UUID) ([]DeviceService, error) {
+func (d Device) DiscoverServices(uuids []UUID) ([]DeviceService, error) {
 	start := time.Now()
 
 	for {
@@ -140,7 +140,7 @@ type DeviceCharacteristic struct {
 }
 
 // UUID returns the UUID for this DeviceCharacteristic.
-func (c *DeviceCharacteristic) UUID() UUID {
+func (c DeviceCharacteristic) UUID() UUID {
 	return c.uuidWrapper
 }
 
@@ -153,7 +153,7 @@ func (c *DeviceCharacteristic) UUID() UUID {
 //
 // Passing a nil slice of UUIDs will return a complete
 // list of characteristics.
-func (s *DeviceService) DiscoverCharacteristics(uuids []UUID) ([]DeviceCharacteristic, error) {
+func (s DeviceService) DiscoverCharacteristics(uuids []UUID) ([]DeviceCharacteristic, error) {
 	var chars []DeviceCharacteristic
 	if len(uuids) > 0 {
 		// The caller wants to get a list of characteristics in a specific
@@ -244,7 +244,7 @@ func (c DeviceCharacteristic) WriteWithoutResponse(p []byte) (n int, err error) 
 // changes.
 //
 // Users may call EnableNotifications with a nil callback to disable notifications.
-func (c *DeviceCharacteristic) EnableNotifications(callback func(buf []byte)) error {
+func (c DeviceCharacteristic) EnableNotifications(callback func(buf []byte)) error {
 	switch callback {
 	default:
 		if c.property != nil {
@@ -308,7 +308,7 @@ func (c DeviceCharacteristic) GetMTU() (uint16, error) {
 }
 
 // Read reads the current characteristic value.
-func (c *DeviceCharacteristic) Read(data []byte) (int, error) {
+func (c DeviceCharacteristic) Read(data []byte) (int, error) {
 	options := make(map[string]interface{})
 	result, err := c.characteristic.ReadValue(options)
 	if err != nil {

--- a/gattc_sd.go
+++ b/gattc_sd.go
@@ -45,7 +45,7 @@ type DeviceService struct {
 }
 
 // UUID returns the UUID for this DeviceService.
-func (s *DeviceService) UUID() UUID {
+func (s DeviceService) UUID() UUID {
 	return s.uuid.UUID()
 }
 
@@ -167,7 +167,7 @@ type DeviceCharacteristic struct {
 }
 
 // UUID returns the UUID for this DeviceCharacteristic.
-func (c *DeviceCharacteristic) UUID() UUID {
+func (c DeviceCharacteristic) UUID() UUID {
 	return c.uuid.UUID()
 }
 
@@ -188,7 +188,7 @@ var discoveringCharacteristic struct {
 //
 // Passing a nil slice of UUIDs will return a complete
 // list of characteristics.
-func (s *DeviceService) DiscoverCharacteristics(uuids []UUID) ([]DeviceCharacteristic, error) {
+func (s DeviceService) DiscoverCharacteristics(uuids []UUID) ([]DeviceCharacteristic, error) {
 	if discoveringCharacteristic.handle_value.Get() != 0 {
 		return nil, errAlreadyDiscovering
 	}
@@ -424,7 +424,7 @@ var readingCharacteristic struct {
 // Read reads the current characteristic value up to MTU length.
 // A future enhancement would be to be able to retrieve a longer
 // value by making multiple calls.
-func (c *DeviceCharacteristic) Read(data []byte) (n int, err error) {
+func (c DeviceCharacteristic) Read(data []byte) (n int, err error) {
 	// global will copy bytes from read operation into data slice
 	readingCharacteristic.value = data
 

--- a/gattc_windows.go
+++ b/gattc_windows.go
@@ -137,7 +137,7 @@ type DeviceService struct {
 }
 
 // UUID returns the UUID for this DeviceService.
-func (s *DeviceService) UUID() UUID {
+func (s DeviceService) UUID() UUID {
 	return s.uuidWrapper
 }
 
@@ -150,7 +150,7 @@ func (s *DeviceService) UUID() UUID {
 //
 // Passing a nil slice of UUIDs will return a complete
 // list of characteristics.
-func (s *DeviceService) DiscoverCharacteristics(filterUUIDs []UUID) ([]DeviceCharacteristic, error) {
+func (s DeviceService) DiscoverCharacteristics(filterUUIDs []UUID) ([]DeviceCharacteristic, error) {
 	getCharacteristicsOp, err := s.service.GetCharacteristicsWithCacheModeAsync(bluetooth.BluetoothCacheModeUncached)
 	if err != nil {
 		return nil, err
@@ -234,20 +234,20 @@ type DeviceCharacteristic struct {
 	characteristic *genericattributeprofile.GattCharacteristic
 	properties     genericattributeprofile.GattCharacteristicProperties
 
-	service *DeviceService
+	service DeviceService
 }
 
 // UUID returns the UUID for this DeviceCharacteristic.
-func (c *DeviceCharacteristic) UUID() UUID {
+func (c DeviceCharacteristic) UUID() UUID {
 	return c.uuidWrapper
 }
 
-func (c *DeviceCharacteristic) Properties() uint32 {
+func (c DeviceCharacteristic) Properties() uint32 {
 	return uint32(c.properties)
 }
 
 // GetMTU returns the MTU for the characteristic.
-func (c *DeviceCharacteristic) GetMTU() (uint16, error) {
+func (c DeviceCharacteristic) GetMTU() (uint16, error) {
 	return c.service.device.session.GetMaxPduSize()
 }
 
@@ -314,7 +314,7 @@ func (c DeviceCharacteristic) write(p []byte, mode genericattributeprofile.GattW
 }
 
 // Read reads the current characteristic value.
-func (c *DeviceCharacteristic) Read(data []byte) (int, error) {
+func (c DeviceCharacteristic) Read(data []byte) (int, error) {
 	if c.properties&genericattributeprofile.GattCharacteristicPropertiesRead == 0 {
 		return 0, errNoRead
 	}


### PR DESCRIPTION
This is unnecessary because the values are passed by value in other cases, and can in some cases lead to more (heap or stack) allocation than is necessary.

This could, in theory, be a breaking change for some, but I don't think normal usage would be broken with this change (as evidenced by the fact that none of the examples need an update).