### PR TITLE
ninafw: add support for Arduino Nano IoT 33

### DIFF
--- a/adapter_ninafw.go
+++ b/adapter_ninafw.go
@@ -19,7 +19,6 @@ type Adapter struct {
 	isDefault bool
 	scanning  bool
 
-	reset          func()
 	connectHandler func(device Address, connected bool)
 
 	connectedDevices     []*Device
@@ -31,7 +30,6 @@ type Adapter struct {
 // Make sure to call Enable() before using it to initialize the adapter.
 var DefaultAdapter = &Adapter{
 	isDefault: true,
-	reset:     resetNINAInverted,
 	connectHandler: func(device Address, connected bool) {
 		return
 	},
@@ -45,14 +43,19 @@ func (a *Adapter) Enable() error {
 	machine.NINA_CS.Configure(machine.PinConfig{Mode: machine.PinOutput})
 	machine.NINA_RESETN.Configure(machine.PinConfig{Mode: machine.PinOutput})
 	machine.NINA_CS.Low()
-	a.reset()
+
+	if machine.NINA_RESET_INVERTED {
+		resetNINAInverted()
+	} else {
+		resetNINA()
+	}
 
 	// serial port for nina chip
 	uart := machine.UART1
 	uart.Configure(machine.UARTConfig{
 		TX:       machine.NINA_TX,
 		RX:       machine.NINA_RX,
-		BaudRate: 115200,
+		BaudRate: machine.NINA_BAUDRATE,
 		CTS:      machine.NINA_CTS,
 		RTS:      machine.NINA_RTS,
 	})


### PR DESCRIPTION
This PR adds `ninafw` support for the Arduino Nano IoT 33.

It requires that both PR https://github.com/tinygo-org/tinygo/pull/4073 and PR https://github.com/tinygo-org/tinygo/pull/4074 are merged into the TinyGo `dev` branch before it can be merged.

Tested on actual board:

```
$ tinygo flash -size short -target arduino-nano33 -monitor -ldflags="-X main.DeviceAddress=76:41:F2:F9:24:95" ./examples/discover/      [351/1806]
   code    data     bss |   flash     ram                                                                                                         
  29396     288    4772 |   29684    5060                                                                                                         
Device       : ATSAMD21x18                                                                                                                        
Version      : v2.0 [Arduino:XYZ] Apr 19 2019 14:38:48                                                                                            
Address      : 0x0                                                                                                                                
Pages        : 4096                                                                                                                               
Page Size    : 64 bytes                                                                                                                           
Total Size   : 256KB                                                                                                                              
Planes       : 1                                                                                                                                  
Lock Regions : 16                                                                                                                                 
Locked       : none                                                                                                                               
Security     : false                                                                                                                              
BOD          : true                                                                                                                               
BOR          : true                                                                                                                               
Erase flash                                                                                                                                       
                                                                                                                                                  
Done in 0.808 seconds                                                                                                                             
Write 29684 bytes to flash (464 pages)                                                                                                            
[==============================] 100% (464/464 pages)                                                                                             
Done in 0.195 seconds                                                                                                                             
Verify 29684 bytes of flash                                                                                                                       
[==============================] 100% (464/464 pages)                                                                                             
Verify successful                                                                                                                                 
Done in 0.102 seconds                                                                                                                             
Connected to /dev/ttyACM0. Press Ctrl-C to exit.                                                                                                  
enabling                                                                                                                                          
scanning...                                                                                                                                       
found device: 76:41:F2:F9:24:95 -94 Pixel 4a                                                                                                      
connected to  76:41:F2:F9:24:95                                                                                                                   
discovering services/characteristics
- service 00001800-0000-1000-8000-00805f9b34fb
-- characteristic 00002a00-0000-1000-8000-00805f9b34fb
    mtu: 23
    data bytes 8
...
```