### PR TITLE
ninafw: fix connection timeout

### DIFF
--- a/gap_ninafw.go
+++ b/gap_ninafw.go
@@ -155,8 +155,7 @@ func (a *Adapter) Connect(address Address, params ConnectionParams) (*Device, er
 			return nil, err
 		}
 
-		switch {
-		case a.hci.connectData.connected:
+		if a.hci.connectData.connected {
 			defer a.hci.clearConnectData()
 
 			random := false
@@ -178,7 +177,7 @@ func (a *Adapter) Connect(address Address, params ConnectionParams) (*Device, er
 
 			return d, nil
 
-		default:
+		} else {
 			// check for timeout
 			if (time.Now().UnixNano()-start)/int64(time.Second) > 5 {
 				break


### PR DESCRIPTION
The break statement didn't actually break the for loop, it just exited the switch case.

Discovered because VS Code flagged the code after the loop as dead code.

This is **untested** because I don't have the Nano RP2040.