### PR TITLE
Fixes and improvements to connection timeouts on SoftDevices

### DIFF
--- a/adapter_nrf528xx-full.go
+++ b/adapter_nrf528xx-full.go
@@ -115,6 +115,21 @@ func handleEvent() {
 			C.sd_ble_gap_phy_update(gapEvent.conn_handle, &phyUpdateRequest.peer_preferred_phys)
 		case C.BLE_GAP_EVT_PHY_UPDATE:
 			// ignore confirmation of phy successfully updated
+		case C.BLE_GAP_EVT_TIMEOUT:
+			timeoutEvt := gapEvent.params.unionfield_timeout()
+			switch timeoutEvt.src {
+			case C.BLE_GAP_TIMEOUT_SRC_CONN:
+				// Failed to connect to a peripheral.
+				if debug {
+					println("gap timeout: conn")
+				}
+				connectionAttempt.state.Set(3) // connection timed out
+			default:
+				// For example a scan timeout.
+				if debug {
+					println("gap timeout: other")
+				}
+			}
 		default:
 			if debug {
 				println("unknown GAP event:", id)

--- a/gap_nrf528xx-central.go
+++ b/gap_nrf528xx-central.go
@@ -141,7 +141,7 @@ func (a *Adapter) Connect(address Address, params ConnectionParams) (Device, err
 	scanParams.set_bitfield_active(0)
 	scanParams.interval = C.uint16_t(NewDuration(40 * time.Millisecond))
 	scanParams.window = C.uint16_t(NewDuration(30 * time.Millisecond))
-	scanParams.timeout = C.uint16_t(params.ConnectionTimeout)
+	scanParams.timeout = C.uint16_t(params.ConnectionTimeout / 16) // timeout in 10ms units
 
 	connectionParams := C.ble_gap_conn_params_t{
 		min_conn_interval: C.uint16_t(params.MinInterval) / 2,

--- a/gap_nrf528xx-central.go
+++ b/gap_nrf528xx-central.go
@@ -149,6 +149,9 @@ func (a *Adapter) Connect(address Address, params ConnectionParams) (Device, err
 		slave_latency:     0,   // mostly relevant to connected keyboards etc
 		conn_sup_timeout:  200, // 2 seconds (in 10ms units), the minimum recommended by Apple
 	}
+	if params.Timeout != 0 {
+		connectionParams.conn_sup_timeout = uint16(params.Timeout / 16)
+	}
 
 	// Flag to the event handler that we are waiting for incoming connections.
 	// This should be safe as long as Connect is not called concurrently. And


### PR DESCRIPTION
This PR fixes a few things to better deal with connection timeouts when connecting to a peripheral from a nrf52 chip.

This depends on #211 and needs to be rebased once it is ready.