### PR TITLE
ninafw: add support for software RTS/CTS flow control

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,9 +32,11 @@ smoketest-tinygo:
 	@md5sum test.hex
 	$(TINYGO) build -o test.hex -size=short -target=microbit-v2-s113v7    ./examples/nusserver
 	@md5sum test.hex
-	$(TINYGO) build -o test.uf2 -size=short -target=nano-rp2040 		  ./examples/scanner
-	@md5sum test.hex
 	$(TINYGO) build -o test.uf2 -size=short -target=nano-rp2040 		  ./examples/discover
+	@md5sum test.hex
+	$(TINYGO) build -o test.uf2 -size=short -target=arduino-nano33 		  ./examples/discover
+	@md5sum test.hex
+	$(TINYGO) build -o test.uf2 -size=short -target=pyportal	          ./examples/discover
 	@md5sum test.hex
 
 smoketest-linux:


### PR DESCRIPTION
This PR adds to the `ninafw` support for software RTS/CTS flow control for boards where hardware support is not available, such as the Adafruit PyPortal.

The processor itself can support the hardware flow control, however due to how the pins on the board are laid out, the SAMD51 pads cannot be setup correctly for full hardware support.

See https://github.com/tinygo-org/tinygo/pull/4076