### PR TITLE
ninafw: implement BLE Peripheral support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,8 @@ smoketest-tinygo:
 	@md5sum test.hex
 	$(TINYGO) build -o test.uf2 -size=short -target=pyportal	          ./examples/discover
 	@md5sum test.hex
+	$(TINYGO) build -o test.uf2 -size=short -target=nano-rp2040 		  ./examples/advertisement
+	@md5sum test.hex
 
 smoketest-linux:
 	# Test on Linux.

--- a/README.md
+++ b/README.md
@@ -99,10 +99,10 @@ func must(action string, err error) {
 | Connect to peripheral            | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | Write peripheral characteristics | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | Receive notifications            | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
-| Advertisement                    | :heavy_check_mark: | :x:                | :x:                | :heavy_check_mark: | :x:                |
-| Local services                   | :heavy_check_mark: | :x:                | :x:                | :heavy_check_mark: | :x:                |
-| Local characteristics            | :heavy_check_mark: | :x:                | :x:                | :heavy_check_mark: | :x:                |
-| Send notifications               | :heavy_check_mark: | :x:                | :x:                | :heavy_check_mark: | :x:                |
+| Advertisement                    | :heavy_check_mark: | :x:                | :x:                | :heavy_check_mark: | :heavy_check_mark: |
+| Local services                   | :heavy_check_mark: | :x:                | :x:                | :heavy_check_mark: | :heavy_check_mark: |
+| Local characteristics            | :heavy_check_mark: | :x:                | :x:                | :heavy_check_mark: | :heavy_check_mark: |
+| Send notifications               | :heavy_check_mark: | :x:                | :x:                | :heavy_check_mark: | :heavy_check_mark: |
 
 ## Linux
 
@@ -268,11 +268,23 @@ Flashing will normally reset the board.
 
 Go Bluetooth has bare metal support for boards that include a separate ESP32 Bluetooth Low Energy radio co-processor. The ESP32 must be running the Arduino or Adafruit `nina_fw` firmware.
 
-See https://github.com/arduino/nina-fw for more information.
+Several boards created by Adafruit and Arduino already have the `nina-fw` firmware pre-loaded. This means you can use TinyGo and the Go Bluetooth package without any additional steps required.
 
-The only currently supported board is the Arduino Nano RP2040 Connect.
+Currently supported boards include:
 
-More info soon...
+* [Adafruit Metro M4 AirLift](https://www.adafruit.com/product/4000)
+* [Adafruit PyBadge](https://www.adafruit.com/product/4200) with [AirLift WiFi FeatherWing](https://www.adafruit.com/product/4264)
+* [Adafruit PyPortal](https://www.adafruit.com/product/4116)
+* [Arduino Nano 33 IoT](https://docs.arduino.cc/hardware/nano-33-iot)
+* [Arduino Nano RP2040 Connect](https://docs.arduino.cc/hardware/nano-rp2040-connect)
+
+After you have installed TinyGo and the Go Bluetooth package, you should be able to compile/run code for your device.
+
+For example, this command can be used to compile and flash an Arduino Nano RP2040 Connect board with the example we provide that turns it into a BLE peripheral to act like a heart rate monitor:
+
+	tinygo flash -target nano-rp2040 ./examples/heartrate
+
+If you want more information about the `nina-fw` firmware, or want to add support for other ESP32-equipped boards, please see https://github.com/arduino/nina-fw
 
 ## API stability
 

--- a/att_ninafw.go
+++ b/att_ninafw.go
@@ -62,10 +62,11 @@ const (
 	attErrorUnsupportedGroupType   = 0x10
 	attErrorInsufficientResources  = 0x11
 
-	gattUnknownUUID        = 0x0000
-	gattServiceUUID        = 0x2800
-	gattCharacteristicUUID = 0x2803
-	gattDescriptorUUID     = 0x2900
+	gattUnknownUUID                    = 0x0000
+	gattServiceUUID                    = 0x2800
+	gattCharacteristicUUID             = 0x2803
+	gattDescriptorUUID                 = 0x2900
+	gattClientCharacteristicConfigUUID = 0x2902
 )
 
 var (
@@ -81,22 +82,174 @@ type rawService struct {
 	uuid        UUID
 }
 
+func (s *rawService) Write(buf []byte) (int, error) {
+	s.startHandle = binary.LittleEndian.Uint16(buf[0:])
+	s.endHandle = binary.LittleEndian.Uint16(buf[2:])
+
+	sz := 4
+	switch len(buf) - 4 {
+	case 2:
+		s.uuid = New16BitUUID(binary.LittleEndian.Uint16(buf[4:]))
+		sz += 2
+	case 16:
+		var uuid [16]byte
+		copy(uuid[:], buf[4:])
+		slices.Reverse(uuid[:])
+		s.uuid = NewUUID(uuid)
+		sz += 16
+	}
+
+	return sz, nil
+}
+
+func (s *rawService) Read(p []byte) (int, error) {
+	binary.LittleEndian.PutUint16(p[0:], s.startHandle)
+	binary.LittleEndian.PutUint16(p[2:], s.endHandle)
+
+	sz := 4
+	switch {
+	case s.uuid.Is16Bit():
+		binary.LittleEndian.PutUint16(p[4:], s.uuid.Get16Bit())
+		sz += 2
+	default:
+		uuid := s.uuid.Bytes()
+		copy(p[4:], uuid[:])
+		sz += 16
+	}
+
+	return sz, nil
+}
+
 type rawCharacteristic struct {
 	startHandle uint16
 	properties  uint8
 	valueHandle uint16
 	uuid        UUID
+	chr         *Characteristic
+}
+
+func (c *rawCharacteristic) Write(buf []byte) (int, error) {
+	c.startHandle = binary.LittleEndian.Uint16(buf[0:])
+	c.properties = buf[2]
+	c.valueHandle = binary.LittleEndian.Uint16(buf[3:])
+
+	sz := 5
+	switch len(buf) - 5 {
+	case 2:
+		c.uuid = New16BitUUID(binary.LittleEndian.Uint16(buf[5:]))
+		sz += 2
+	case 16:
+		var uuid [16]byte
+		copy(uuid[:], buf[5:])
+		slices.Reverse(uuid[:])
+		c.uuid = NewUUID(uuid)
+		sz += 16
+	}
+
+	return sz, nil
+}
+
+func (c *rawCharacteristic) Read(p []byte) (int, error) {
+	binary.LittleEndian.PutUint16(p[0:], c.startHandle)
+	p[2] = c.properties
+	binary.LittleEndian.PutUint16(p[3:], c.valueHandle)
+
+	sz := 5
+	switch {
+	case c.uuid.Is16Bit():
+		binary.LittleEndian.PutUint16(p[5:], c.uuid.Get16Bit())
+		sz += 2
+	default:
+		uuid := c.uuid.Bytes()
+		copy(p[5:], uuid[:])
+		sz += 16
+	}
+
+	return sz, nil
 }
 
 type rawDescriptor struct {
 	handle uint16
-	uuid   UUID
+	data   []byte
+}
+
+func (d *rawDescriptor) Write(buf []byte) (int, error) {
+	d.handle = binary.LittleEndian.Uint16(buf[0:])
+	d.data = append(d.data, buf[2:]...)
+
+	return len(d.data) + 2, nil
+}
+
+func (d *rawDescriptor) Read(p []byte) (int, error) {
+	binary.LittleEndian.PutUint16(p[0:], d.handle)
+	copy(p[2:], d.data)
+
+	return len(d.data) + 2, nil
 }
 
 type rawNotification struct {
 	connectionHandle uint16
 	handle           uint16
 	data             []byte
+}
+
+type attributeType int
+
+const (
+	attributeTypeService attributeType = iota
+	attributeTypeCharacteristic
+	attributeTypeCharacteristicValue
+	attributeTypeDescriptor
+)
+
+type rawAttribute struct {
+	typ         attributeType
+	parent      uint16
+	handle      uint16
+	uuid        UUID
+	permissions CharacteristicPermissions
+	value       []byte
+}
+
+func (a *rawAttribute) Write(buf []byte) (int, error) {
+	return 0, errNotYetImplemented
+}
+
+func (a *rawAttribute) Read(p []byte) (int, error) {
+	binary.LittleEndian.PutUint16(p[0:], a.handle)
+	sz := 2
+
+	switch a.typ {
+	case attributeTypeCharacteristicValue, attributeTypeDescriptor:
+		switch {
+		case a.uuid.Is16Bit():
+			binary.LittleEndian.PutUint16(p[sz:], a.uuid.Get16Bit())
+			sz += 2
+		default:
+			uuid := a.uuid.Bytes()
+			copy(p[sz:], uuid[:])
+			sz += 16
+		}
+	default:
+		copy(p[sz:], a.value)
+		sz += len(a.value)
+	}
+
+	return sz, nil
+}
+
+func (a *rawAttribute) length() int {
+	switch a.typ {
+	case attributeTypeCharacteristicValue, attributeTypeDescriptor:
+		switch {
+		case a.uuid.Is16Bit():
+			return 2
+		default:
+			return 16
+		}
+	default:
+		return len(a.value)
+	}
 }
 
 type att struct {
@@ -113,6 +266,11 @@ type att struct {
 	descriptors     []rawDescriptor
 	value           []byte
 	notifications   chan rawNotification
+
+	connections   []uint16
+	lastHandle    uint16
+	attributes    []rawAttribute
+	localServices []rawService
 }
 
 func newATT(hci *hci) *att {
@@ -122,6 +280,10 @@ func newATT(hci *hci) *att {
 		characteristics: []rawCharacteristic{},
 		value:           []byte{},
 		notifications:   make(chan rawNotification, 32),
+		connections:     []uint16{},
+		lastHandle:      0x0001,
+		attributes:      []rawAttribute{},
+		localServices:   []rawService{},
 	}
 }
 
@@ -277,6 +439,51 @@ func (a *att) sendReq(handle uint16, data []byte) error {
 	return nil
 }
 
+func (a *att) sendNotification(handle uint16, data []byte) error {
+	if _debug {
+		println("att.sendNotifications:", handle, "data:", hex.EncodeToString(data))
+	}
+
+	a.busy.Lock()
+	defer a.busy.Unlock()
+
+	var b [3]byte
+	b[0] = attOpHandleNotify
+	binary.LittleEndian.PutUint16(b[1:], handle)
+
+	for connection := range a.connections {
+		if _debug {
+			println("att.sendNotifications: sending to", connection)
+		}
+
+		if err := a.hci.sendAclPkt(uint16(connection), attCID, append(b[:], data...)); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (a *att) sendError(handle uint16, opcode uint8, hdl uint16, code uint8) error {
+	a.clearResponse()
+
+	if _debug {
+		println("att.sendError:", handle, "data:", opcode, hdl, code)
+	}
+
+	var b [5]byte
+	b[0] = attOpError
+	b[1] = opcode
+	binary.LittleEndian.PutUint16(b[2:], hdl)
+	b[4] = code
+
+	if err := a.hci.sendAclPkt(handle, attCID, b[:]); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (a *att) handleData(handle uint16, buf []byte) error {
 	if _debug {
 		println("att.handleData:", handle, "data:", hex.EncodeToString(buf))
@@ -299,6 +506,11 @@ func (a *att) handleData(handle uint16, buf []byte) error {
 		if _debug {
 			println("att.handleData: attOpMTUReq")
 		}
+		a.mtu = binary.LittleEndian.Uint16(buf[1:])
+		response := [3]byte{attOpMTUResponse, buf[1], buf[2]}
+		if err := a.hci.sendAclPkt(handle, attCID, response[:]); err != nil {
+			return err
+		}
 
 	case attOpMTUResponse:
 		if _debug {
@@ -312,6 +524,11 @@ func (a *att) handleData(handle uint16, buf []byte) error {
 			println("att.handleData: attOpFindInfoReq")
 		}
 
+		startHandle := binary.LittleEndian.Uint16(buf[1:])
+		endHandle := binary.LittleEndian.Uint16(buf[3:])
+
+		return a.handleFindInfoReq(handle, startHandle, endHandle)
+
 	case attOpFindInfoResponse:
 		if _debug {
 			println("att.handleData: attOpFindInfoResponse")
@@ -319,23 +536,13 @@ func (a *att) handleData(handle uint16, buf []byte) error {
 		a.responded = true
 
 		lengthPerDescriptor := int(buf[1])
-		var uuid [16]byte
 
 		for i := 2; i < len(buf); i += lengthPerDescriptor {
-			d := rawDescriptor{
-				handle: binary.LittleEndian.Uint16(buf[i:]),
-			}
-			switch lengthPerDescriptor - 2 {
-			case 2:
-				d.uuid = New16BitUUID(binary.LittleEndian.Uint16(buf[i+2:]))
-			case 16:
-				copy(uuid[:], buf[i+2:])
-				slices.Reverse(uuid[:])
-				d.uuid = NewUUID(uuid)
-			}
+			d := rawDescriptor{}
+			d.Write(buf[i : i+lengthPerDescriptor])
 
 			if _debug {
-				println("att.handleData: descriptor", d.handle, d.uuid.String())
+				println("att.handleData: descriptor", d.handle, hex.EncodeToString(d.data))
 			}
 
 			a.descriptors = append(a.descriptors, d)
@@ -351,6 +558,12 @@ func (a *att) handleData(handle uint16, buf []byte) error {
 			println("att.handleData: attOpReadByTypeReq")
 		}
 
+		startHandle := binary.LittleEndian.Uint16(buf[1:])
+		endHandle := binary.LittleEndian.Uint16(buf[3:])
+		uuid := shortUUID(binary.LittleEndian.Uint16(buf[5:]))
+
+		return a.handleReadByTypeReq(handle, startHandle, endHandle, uuid)
+
 	case attOpReadByTypeResponse:
 		if _debug {
 			println("att.handleData: attOpReadByTypeResponse")
@@ -358,22 +571,10 @@ func (a *att) handleData(handle uint16, buf []byte) error {
 		a.responded = true
 
 		lengthPerCharacteristic := int(buf[1])
-		var uuid [16]byte
 
 		for i := 2; i < len(buf); i += lengthPerCharacteristic {
-			c := rawCharacteristic{
-				startHandle: binary.LittleEndian.Uint16(buf[i:]),
-				properties:  buf[i+2],
-				valueHandle: binary.LittleEndian.Uint16(buf[i+3:]),
-			}
-			switch lengthPerCharacteristic - 5 {
-			case 2:
-				c.uuid = New16BitUUID(binary.LittleEndian.Uint16(buf[i+5:]))
-			case 16:
-				copy(uuid[:], buf[i+5:])
-				slices.Reverse(uuid[:])
-				c.uuid = NewUUID(uuid)
-			}
+			c := rawCharacteristic{}
+			c.Write(buf[i : i+lengthPerCharacteristic])
 
 			if _debug {
 				println("att.handleData: characteristic", c.startHandle, c.properties, c.valueHandle, c.uuid.String())
@@ -389,32 +590,11 @@ func (a *att) handleData(handle uint16, buf []byte) error {
 			println("att.handleData: attOpReadByGroupReq")
 		}
 
-		// return generic services
-		var response [14]byte
-		response[0] = attOpReadByGroupResponse
-		response[1] = 0x06 // length per service
+		startHandle := binary.LittleEndian.Uint16(buf[1:])
+		endHandle := binary.LittleEndian.Uint16(buf[3:])
+		uuid := shortUUID(binary.LittleEndian.Uint16(buf[5:]))
 
-		genericAccessService := rawService{
-			startHandle: 0,
-			endHandle:   1,
-			uuid:        ServiceUUIDGenericAccess,
-		}
-		binary.LittleEndian.PutUint16(response[2:], genericAccessService.startHandle)
-		binary.LittleEndian.PutUint16(response[4:], genericAccessService.endHandle)
-		binary.LittleEndian.PutUint16(response[6:], genericAccessService.uuid.Get16Bit())
-
-		genericAttributeService := rawService{
-			startHandle: 2,
-			endHandle:   5,
-			uuid:        ServiceUUIDGenericAttribute,
-		}
-		binary.LittleEndian.PutUint16(response[8:], genericAttributeService.startHandle)
-		binary.LittleEndian.PutUint16(response[10:], genericAttributeService.endHandle)
-		binary.LittleEndian.PutUint16(response[12:], genericAttributeService.uuid.Get16Bit())
-
-		if err := a.hci.sendAclPkt(handle, attCID, response[:]); err != nil {
-			return err
-		}
+		return a.handleReadByGroupReq(handle, startHandle, endHandle, uuid)
 
 	case attOpReadByGroupResponse:
 		if _debug {
@@ -423,21 +603,10 @@ func (a *att) handleData(handle uint16, buf []byte) error {
 		a.responded = true
 
 		lengthPerService := int(buf[1])
-		var uuid [16]byte
 
 		for i := 2; i < len(buf); i += lengthPerService {
-			service := rawService{
-				startHandle: binary.LittleEndian.Uint16(buf[i:]),
-				endHandle:   binary.LittleEndian.Uint16(buf[i+2:]),
-			}
-			switch lengthPerService - 4 {
-			case 2:
-				service.uuid = New16BitUUID(binary.LittleEndian.Uint16(buf[i+4:]))
-			case 16:
-				copy(uuid[:], buf[i+4:])
-				slices.Reverse(uuid[:])
-				service.uuid = NewUUID(uuid)
-			}
+			service := rawService{}
+			service.Write(buf[i : i+lengthPerService])
 
 			if _debug {
 				println("att.handleData: service", service.startHandle, service.endHandle, service.uuid.String())
@@ -452,6 +621,9 @@ func (a *att) handleData(handle uint16, buf []byte) error {
 		if _debug {
 			println("att.handleData: attOpReadReq")
 		}
+
+		attrHandle := binary.LittleEndian.Uint16(buf[1:])
+		return a.handleReadReq(handle, attrHandle)
 
 	case attOpReadBlobReq:
 		if _debug {
@@ -469,6 +641,9 @@ func (a *att) handleData(handle uint16, buf []byte) error {
 		if _debug {
 			println("att.handleData: attOpWriteReq")
 		}
+
+		attrHandle := binary.LittleEndian.Uint16(buf[1:])
+		return a.handleWriteReq(handle, attrHandle, buf[3:])
 
 	case attOpWriteCmd:
 		if _debug {
@@ -538,6 +713,295 @@ func (a *att) handleData(handle uint16, buf []byte) error {
 	return nil
 }
 
+func (a *att) handleReadByGroupReq(handle, start, end uint16, uuid shortUUID) error {
+	var response [64]byte
+	response[0] = attOpReadByGroupResponse
+	response[1] = 0x0 // length per service
+	pos := 2
+
+	switch uuid {
+	case shortUUID(gattServiceUUID):
+		for _, s := range a.localServices {
+			if s.startHandle >= start && s.endHandle <= end {
+				if _debug {
+					println("attOpReadByGroupReq: replying with service", s.startHandle, s.endHandle, s.uuid.String())
+				}
+
+				length := 20
+				if s.uuid.Is16Bit() {
+					length = 6
+				}
+
+				if response[1] == 0 {
+					response[1] = byte(length)
+				} else if response[1] != byte(length) {
+					// change of UUID size
+					break
+				}
+
+				s.Read(response[pos : pos+length])
+				pos += length
+
+				if uint16(pos+length) > a.mtu {
+					break
+				}
+			}
+		}
+
+		switch {
+		case pos > 2:
+			if err := a.hci.sendAclPkt(handle, attCID, response[:pos]); err != nil {
+				return err
+			}
+		default:
+			if err := a.sendError(handle, attOpReadByGroupReq, start, attErrorAttrNotFound); err != nil {
+				return err
+			}
+		}
+
+		return nil
+
+	default:
+		if _debug {
+			println("handleReadByGroupReq: unknown uuid", New16BitUUID(uint16(uuid)).String())
+		}
+		if err := a.sendError(handle, attOpReadByGroupReq, start, attErrorAttrNotFound); err != nil {
+			return err
+		}
+
+		return nil
+	}
+}
+
+func (a *att) handleReadByTypeReq(handle, start, end uint16, uuid shortUUID) error {
+	var response [64]byte
+	response[0] = attOpReadByTypeResponse
+	pos := 0
+
+	switch uuid {
+	case shortUUID(gattCharacteristicUUID):
+		pos = 2
+		response[1] = 0
+
+		for _, c := range a.characteristics {
+			if _debug {
+				println("handleReadByTypeReq: looking at characteristic", c.startHandle, c.uuid.String())
+			}
+
+			if c.startHandle >= start && c.valueHandle <= end {
+				if _debug {
+					println("handleReadByTypeReq: replying with characteristic", c.startHandle, c.uuid.String())
+				}
+
+				length := 21
+				if c.uuid.Is16Bit() {
+					length = 7
+				}
+
+				if response[1] == 0 {
+					response[1] = byte(length)
+				} else if response[1] != byte(length) {
+					// change of UUID size
+					break
+				}
+
+				c.Read(response[pos : pos+length])
+				pos += length
+
+				if uint16(pos+length) > a.mtu {
+					break
+				}
+			}
+		}
+		switch {
+		case pos > 2:
+			if err := a.hci.sendAclPkt(handle, attCID, response[:pos]); err != nil {
+				return err
+			}
+		default:
+			if err := a.sendError(handle, attOpReadByTypeReq, start, attErrorAttrNotFound); err != nil {
+				return err
+			}
+		}
+
+		return nil
+
+	default:
+		if _debug {
+			println("handleReadByTypeReq: unknown uuid", New16BitUUID(uint16(uuid)).String())
+		}
+		if err := a.sendError(handle, attOpReadByTypeReq, start, attErrorAttrNotFound); err != nil {
+			return err
+		}
+
+		return nil
+	}
+}
+
+func (a *att) handleFindInfoReq(handle, start, end uint16) error {
+	var response [64]byte
+	response[0] = attOpFindInfoResponse
+	pos := 0
+
+	pos = 2
+	infoType := 0
+	response[1] = 0
+
+	for _, attr := range a.attributes {
+		if _debug {
+			println("handleFindInfoReq: looking at attribute")
+		}
+
+		if attr.handle >= start && attr.handle <= end {
+			if _debug {
+				println("handleFindInfoReq: replying with attribute", attr.handle, attr.uuid.String(), attr.typ)
+			}
+
+			if attr.typ == attributeTypeCharacteristicValue || attr.typ == attributeTypeDescriptor {
+				infoType = 1
+			} else {
+				infoType = 2
+			}
+
+			length := attr.length() + 2
+			if response[1] == 0 {
+				response[1] = byte(infoType)
+			} else if response[1] != byte(infoType) {
+				// change of info type
+				break
+			}
+
+			attr.Read(response[pos : pos+length])
+			pos += length
+
+			if uint16(pos+length) >= a.mtu {
+				break
+			}
+		}
+	}
+	switch {
+	case pos > 2:
+		if err := a.hci.sendAclPkt(handle, attCID, response[:pos]); err != nil {
+			return err
+		}
+	default:
+		if err := a.sendError(handle, attOpFindInfoReq, start, attErrorAttrNotFound); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (a *att) handleReadReq(handle, attrHandle uint16) error {
+	attr := a.findAttribute(attrHandle)
+	if attr == nil {
+		if _debug {
+			println("att.handleReadReq: attribute not found", attrHandle)
+		}
+		return a.sendError(handle, attOpReadReq, attrHandle, attErrorAttrNotFound)
+	}
+
+	var response [64]byte
+	response[0] = attOpReadResponse
+	pos := 1
+
+	switch attr.typ {
+	case attributeTypeCharacteristicValue:
+		if _debug {
+			println("att.handleReadReq: reading characteristic value", attrHandle)
+		}
+
+		c := a.findCharacteristic(attr.parent)
+		if c != nil && c.chr != nil {
+			value, err := c.chr.readValue()
+			if err != nil {
+				return a.sendError(handle, attOpReadReq, attrHandle, attErrorReadNotPermitted)
+			}
+
+			copy(response[pos:], value)
+			pos += len(value)
+
+			if err := a.hci.sendAclPkt(handle, attCID, response[:pos]); err != nil {
+				return err
+			}
+		}
+
+	case attributeTypeDescriptor:
+		if _debug {
+			println("att.handleReadReq: reading descriptor", attrHandle)
+		}
+
+		c := a.findCharacteristic(attr.parent)
+		if c != nil && c.chr != nil {
+			cccd, err := c.chr.readCCCD()
+			if err != nil {
+				return a.sendError(handle, attOpReadReq, attrHandle, attErrorReadNotPermitted)
+			}
+
+			binary.LittleEndian.PutUint16(response[pos:], cccd)
+			pos += 2
+
+			if err := a.hci.sendAclPkt(handle, attCID, response[:pos]); err != nil {
+				return err
+			}
+		}
+	}
+
+	return a.sendError(handle, attOpReadReq, attrHandle, attErrorReadNotPermitted)
+}
+
+func (a *att) handleWriteReq(handle, attrHandle uint16, data []byte) error {
+	attr := a.findAttribute(attrHandle)
+	if attr == nil {
+		if _debug {
+			println("att.handleWriteReq: attribute not found", attrHandle)
+		}
+		return a.sendError(handle, attOpWriteReq, attrHandle, attErrorAttrNotFound)
+	}
+
+	switch attr.typ {
+	case attributeTypeCharacteristicValue:
+		if _debug {
+			println("att.handleWriteReq: writing characteristic value", attrHandle, hex.EncodeToString(data))
+		}
+
+		c := a.findCharacteristic(attr.parent)
+		if c != nil && c.chr != nil {
+			if _, err := c.chr.Write(data); err != nil {
+				return a.sendError(handle, attOpWriteReq, attrHandle, attErrorWriteNotPermitted)
+			}
+
+			if err := a.hci.sendAclPkt(handle, attCID, []byte{attOpWriteResponse}); err != nil {
+				return err
+			}
+
+			return nil
+		}
+
+	case attributeTypeDescriptor:
+		if _debug {
+			println("att.handleWriteReq: writing descriptor", attrHandle, hex.EncodeToString(data))
+		}
+
+		c := a.findCharacteristic(attr.parent)
+		if c != nil && c.chr != nil {
+			if err := c.chr.writeCCCD(binary.LittleEndian.Uint16(data)); err != nil {
+				return a.sendError(handle, attOpWriteReq, attrHandle, attErrorWriteNotPermitted)
+			}
+
+			if err := a.hci.sendAclPkt(handle, attCID, []byte{attOpWriteResponse}); err != nil {
+				return err
+			}
+
+			return nil
+
+		}
+	}
+
+	return a.sendError(handle, attOpWriteReq, attrHandle, attErrorWriteNotPermitted)
+}
+
 func (a *att) clearResponse() {
 	a.responded = false
 	a.errored = false
@@ -577,6 +1041,74 @@ func (a *att) poll() error {
 
 	if err := a.hci.poll(); err != nil {
 		return err
+	}
+
+	return nil
+}
+
+func (a *att) addConnection(handle uint16) {
+	a.connections = append(a.connections, handle)
+}
+
+func (a *att) removeConnection(handle uint16) {
+	for i := range a.connections {
+		if a.connections[i] == handle {
+			a.connections = append(a.connections[:i], a.connections[i+1:]...)
+			return
+		}
+	}
+}
+
+func (a *att) addLocalAttribute(typ attributeType, parent uint16, uuid UUID, permissions CharacteristicPermissions, value []byte) uint16 {
+	handle := a.lastHandle
+	a.attributes = append(a.attributes,
+		rawAttribute{
+			typ:         typ,
+			parent:      parent,
+			handle:      handle,
+			uuid:        uuid,
+			permissions: permissions,
+			value:       append([]byte{}, value...),
+		})
+	a.lastHandle++
+
+	return handle
+}
+
+func (a *att) addLocalService(start, end uint16, uuid UUID) {
+	a.localServices = append(a.localServices, rawService{
+		startHandle: start,
+		endHandle:   end,
+		uuid:        uuid,
+	})
+}
+
+func (a *att) addLocalCharacteristic(startHandle uint16, properties CharacteristicPermissions, valueHandle uint16, uuid UUID, chr *Characteristic) {
+	a.characteristics = append(a.characteristics,
+		rawCharacteristic{
+			startHandle: startHandle,
+			properties:  uint8(properties),
+			valueHandle: valueHandle,
+			uuid:        uuid,
+			chr:         chr,
+		})
+}
+
+func (a *att) findAttribute(hdl uint16) *rawAttribute {
+	for i := range a.attributes {
+		if a.attributes[i].handle == hdl {
+			return &a.attributes[i]
+		}
+	}
+
+	return nil
+}
+
+func (a *att) findCharacteristic(hdl uint16) *rawCharacteristic {
+	for i := range a.characteristics {
+		if a.characteristics[i].startHandle == hdl {
+			return &a.characteristics[i]
+		}
 	}
 
 	return nil

--- a/gatts.go
+++ b/gatts.go
@@ -61,3 +61,8 @@ func (p CharacteristicPermissions) WriteWithoutResponse() bool {
 func (p CharacteristicPermissions) Notify() bool {
 	return p&CharacteristicNotifyPermission != 0
 }
+
+// Indicate returns whether indications are permitted.
+func (p CharacteristicPermissions) Indicate() bool {
+	return p&CharacteristicIndicatePermission != 0
+}

--- a/gatts_ninafw.go
+++ b/gatts_ninafw.go
@@ -3,4 +3,106 @@
 package bluetooth
 
 type Characteristic struct {
+	adapter     *Adapter
+	handle      uint16
+	permissions CharacteristicPermissions
+	value       []byte
+	cccd        uint16
+}
+
+// AddService creates a new service with the characteristics listed in the
+// Service struct.
+func (a *Adapter) AddService(service *Service) error {
+	uuid := service.UUID.Bytes()
+	serviceHandle := a.att.addLocalAttribute(attributeTypeService, 0, shortUUID(gattServiceUUID).UUID(), 0, uuid[:])
+	valueHandle := serviceHandle
+	endHandle := serviceHandle
+
+	for i := range service.Characteristics {
+		data := service.Characteristics[i].UUID.Bytes()
+		cuuid := append([]byte{}, data[:]...)
+
+		// add characteristic declaration
+		charHandle := a.att.addLocalAttribute(attributeTypeCharacteristic, serviceHandle, shortUUID(gattCharacteristicUUID).UUID(), CharacteristicReadPermission, cuuid[:])
+
+		// add characteristic value
+		vf := CharacteristicPermissions(0)
+		if service.Characteristics[i].Flags.Read() {
+			vf |= CharacteristicReadPermission
+		}
+		if service.Characteristics[i].Flags.Write() {
+			vf |= CharacteristicWritePermission
+		}
+		valueHandle = a.att.addLocalAttribute(attributeTypeCharacteristicValue, charHandle, service.Characteristics[i].UUID, vf, service.Characteristics[i].Value)
+		endHandle = valueHandle
+
+		// add characteristic descriptor
+		if service.Characteristics[i].Flags.Notify() ||
+			service.Characteristics[i].Flags.Indicate() {
+			endHandle = a.att.addLocalAttribute(attributeTypeDescriptor, charHandle, shortUUID(gattClientCharacteristicConfigUUID).UUID(), CharacteristicReadPermission|CharacteristicWritePermission, []byte{0, 0})
+		}
+
+		if service.Characteristics[i].Handle != nil {
+			service.Characteristics[i].Handle.adapter = a
+			service.Characteristics[i].Handle.handle = valueHandle
+			service.Characteristics[i].Handle.permissions = service.Characteristics[i].Flags
+			service.Characteristics[i].Handle.value = service.Characteristics[i].Value
+		}
+
+		if _debug {
+			println("added characteristic", charHandle, valueHandle, service.Characteristics[i].UUID.String())
+		}
+
+		a.att.addLocalCharacteristic(charHandle, service.Characteristics[i].Flags, valueHandle, service.Characteristics[i].UUID, service.Characteristics[i].Handle)
+	}
+
+	if _debug {
+		println("added service", serviceHandle, endHandle, service.UUID.String())
+	}
+
+	a.att.addLocalService(serviceHandle, endHandle, service.UUID)
+
+	return nil
+}
+
+// Write replaces the characteristic value with a new value.
+func (c *Characteristic) Write(p []byte) (n int, err error) {
+	if !c.permissions.Notify() {
+		return 0, errNoNotify
+	}
+
+	c.value = append([]byte{}, p...)
+
+	if c.cccd&0x01 != 0 {
+		// send notification
+		c.adapter.att.sendNotification(c.handle, c.value)
+	}
+
+	return len(c.value), nil
+}
+
+func (c *Characteristic) readCCCD() (uint16, error) {
+	if !c.permissions.Notify() {
+		return 0, errNoNotify
+	}
+
+	return c.cccd, nil
+}
+
+func (c *Characteristic) writeCCCD(val uint16) error {
+	if !c.permissions.Notify() {
+		return errNoNotify
+	}
+
+	c.cccd = val
+
+	return nil
+}
+
+func (c *Characteristic) readValue() ([]byte, error) {
+	if !c.permissions.Read() {
+		return nil, errNoRead
+	}
+
+	return c.value, nil
 }


### PR DESCRIPTION
This PR adds BLE Peripheral support to the `nina-fw` implementation.

For example, this now works:

```
$ tinygo flash -size short -target nano-rp2040 -monitor ./examples/heartrate                                                                      
   code    data     bss |   flash     ram                                                                                                         
  50372    1000    3408 |   51372    4408                                
Connected to /dev/ttyACM0. Press Ctrl-C to exit.                         
tick 00:01.301                                                           
tick 00:02.101
tick 00:02.850
tick 00:03.565
...
```

Note that this requires the latest TinyGo `dev` branch for the correct board definitions.