### PR TITLE
add ServiceData advertising element

### DIFF
--- a/adapter_darwin.go
+++ b/adapter_darwin.go
@@ -156,15 +156,17 @@ func makeScanResult(prph cbgo.Peripheral, advFields cbgo.AdvFields, rssi int) Sc
 		})
 	}
 
-	serviceData := make(map[uint16][]byte)
+	var serviceData []ServiceDataElement
 	for _, svcData := range advFields.ServiceData {
 		cbgoUUID := svcData.UUID
 		uuid, err := ParseUUID(cbgoUUID.String())
 		if err != nil || uuid.String() != cbgoUUID.String() {
 			continue
 		}
-		svcID := uuid.Get16Bit()
-		serviceData[svcID] = svcData.Data[:]
+		serviceData = append(serviceData, ServiceDataElement{
+			UUID: uuid,
+			Data: svcData.Data,
+		})
 	}
 
 	// Peripheral UUID is randomized on macOS, which means to

--- a/adapter_darwin.go
+++ b/adapter_darwin.go
@@ -133,6 +133,17 @@ func makeScanResult(prph cbgo.Peripheral, advFields cbgo.AdvFields, rssi int) Sc
 		manufacturerData[manufacturerID] = advFields.ManufacturerData[2:]
 	}
 
+	serviceData := make(map[uint16][]byte)
+	for _, svcData := range advFields.ServiceData {
+		cbgoUUID := svcData.UUID
+		uuid, err := ParseUUID(cbgoUUID.String())
+		if err != nil || uuid.String() != cbgoUUID.String() {
+			continue
+		}
+		svcID := uuid.Get16Bit()
+		serviceData[svcID] = svcData.Data[:]
+	}
+
 	// Peripheral UUID is randomized on macOS, which means to
 	// different centrals it will appear to have a different UUID.
 	return ScanResult{
@@ -145,6 +156,7 @@ func makeScanResult(prph cbgo.Peripheral, advFields cbgo.AdvFields, rssi int) Sc
 				LocalName:        advFields.LocalName,
 				ServiceUUIDs:     serviceUUIDs,
 				ManufacturerData: manufacturerData,
+				ServiceData:      serviceData,
 			},
 		},
 	}

--- a/adapter_darwin.go
+++ b/adapter_darwin.go
@@ -160,7 +160,7 @@ func makeScanResult(prph cbgo.Peripheral, advFields cbgo.AdvFields, rssi int) Sc
 	for _, svcData := range advFields.ServiceData {
 		cbgoUUID := svcData.UUID
 		uuid, err := ParseUUID(cbgoUUID.String())
-		if err != nil || uuid.String() != cbgoUUID.String() {
+		if err != nil {
 			continue
 		}
 		serviceData = append(serviceData, ServiceDataElement{

--- a/gap.go
+++ b/gap.go
@@ -128,7 +128,7 @@ type AdvertisementPayload interface {
 	Bytes() []byte
 
 	// ManufacturerData returns a map with all the manufacturer data present in the
-	//advertising. IT may be empty.
+	// advertising. It may be empty.
 	ManufacturerData() map[uint16][]byte
 }
 

--- a/gap.go
+++ b/gap.go
@@ -319,28 +319,28 @@ func (buf *rawAdvertisementPayload) ServiceData() []ServiceDataElement {
 	for index := 0; index < int(buf.len)+4; index += int(buf.data[index]) + 1 {
 		fieldLength := int(buf.data[index+0])
 		if fieldLength < 3 { // field has only length and type and no data
-			continue 
+			continue
 		}
 		fieldType := buf.data[index+1]
 		switch fieldType {
 		case 0x16: // 16-bit uuid
 			serviceData = append(serviceData, ServiceDataElement{
-				UUID: New16BitUUID(uint16(buf.data[index+2])+(uint16(buf.data[index+3])<<8)),
+				UUID: New16BitUUID(uint16(buf.data[index+2]) + (uint16(buf.data[index+3]) << 8)),
 				Data: buf.data[index+4 : index+fieldLength+1],
 			})
 		case 0x20: // 32-bit uuid
 			serviceData = append(serviceData, ServiceDataElement{
-				UUID: New32BitUUID(uint32(buf.data[index+2])+(uint32(buf.data[index+3])<<8)+(uint32(buf.data[index+4])<<16)+(uint32(buf.data[index+5])<<24)),
+				UUID: New32BitUUID(uint32(buf.data[index+2]) + (uint32(buf.data[index+3]) << 8) + (uint32(buf.data[index+4]) << 16) + (uint32(buf.data[index+5]) << 24)),
 				Data: buf.data[index+6 : index+fieldLength+1],
 			})
 		case 0x21: // 128-bit uuid
 			var uuidArray [16]byte
-			copy(uuidArray[:], buf.data[index+2:index + 18])
+			copy(uuidArray[:], buf.data[index+2:index+18])
 			serviceData = append(serviceData, ServiceDataElement{
 				UUID: NewUUID(uuidArray),
 				Data: buf.data[index+18 : index+fieldLength+1],
 			})
-		default: 
+		default:
 			continue
 		}
 	}
@@ -412,42 +412,41 @@ func (buf *rawAdvertisementPayload) addManufacturerData(key uint16, value []byte
 // addServiceData adds service data ([]byte) entries to the advertisement payload.
 func (buf *rawAdvertisementPayload) addServiceData(uuid UUID, data []byte) (ok bool) {
 	switch {
-	case uuid.Is16Bit(): 
+	case uuid.Is16Bit():
 		// check if it fits
 		fieldLength := 1 + 1 + 2 + len(data) // 1 byte length, 1 byte ad type, 2 bytes uuid, actual service data
 		if int(buf.len)+fieldLength > len(buf.data) {
-			return false 
+			return false
 		}
 		// Add the data.
 		buf.data[buf.len+0] = byte(fieldLength - 1)
 		buf.data[buf.len+1] = 0x16
 		buf.data[buf.len+2] = byte(uuid.Get16Bit())
-		buf.data[buf.len+3] = byte(uuid.Get16Bit()>>8)
+		buf.data[buf.len+3] = byte(uuid.Get16Bit() >> 8)
 		copy(buf.data[buf.len+4:], data)
 		buf.len += uint8(fieldLength)
 
-	
-	case uuid.Is32Bit(): 
+	case uuid.Is32Bit():
 		// check if it fits
 		fieldLength := 1 + 1 + 4 + len(data) // 1 byte length, 1 byte ad type, 4 bytes uuid, actual service data
 		if int(buf.len)+fieldLength > len(buf.data) {
-			return false 
+			return false
 		}
 		// Add the data.
 		buf.data[buf.len+0] = byte(fieldLength - 1)
 		buf.data[buf.len+1] = 0x20
 		buf.data[buf.len+2] = byte(uuid.Get32Bit())
-		buf.data[buf.len+3] = byte(uuid.Get32Bit()>>8)
-		buf.data[buf.len+4] = byte(uuid.Get32Bit()>>16)
-		buf.data[buf.len+5] = byte(uuid.Get32Bit()>>24)
+		buf.data[buf.len+3] = byte(uuid.Get32Bit() >> 8)
+		buf.data[buf.len+4] = byte(uuid.Get32Bit() >> 16)
+		buf.data[buf.len+5] = byte(uuid.Get32Bit() >> 24)
 		copy(buf.data[buf.len+6:], data)
 		buf.len += uint8(fieldLength)
-	
-	default:  // must be 128-bit uuid
+
+	default: // must be 128-bit uuid
 		// check if it fits
 		fieldLength := 1 + 1 + 16 + len(data) // 1 byte length, 1 byte ad type, 16 bytes uuid, actual service data
 		if int(buf.len)+fieldLength > len(buf.data) {
-			return false 
+			return false
 		}
 		// Add the data.
 		buf.data[buf.len+0] = byte(fieldLength - 1)
@@ -456,7 +455,7 @@ func (buf *rawAdvertisementPayload) addServiceData(uuid UUID, data []byte) (ok b
 		copy(buf.data[buf.len+2:], uuid_bytes[:])
 		copy(buf.data[buf.len+2+16:], data)
 		buf.len += uint8(fieldLength)
-	
+
 	}
 	return true
 }

--- a/gap.go
+++ b/gap.go
@@ -292,6 +292,9 @@ func (buf *rawAdvertisementPayload) ManufacturerData() map[uint16][]byte {
 func (buf *rawAdvertisementPayload) ServiceData() map[uint16][]byte {
 	sData := make(map[uint16][]byte)
 	data := buf.findField(0x16)
+	if data == nil {
+		return sData
+	}
 	sData[uint16(data[0])+(uint16(data[1])<<8)]= data[2:]
 	
 	return sData

--- a/gap.go
+++ b/gap.go
@@ -218,11 +218,11 @@ func (buf *rawAdvertisementPayload) findField(fieldType byte) []byte {
 // LocalName returns the local name (complete or shortened) in the advertisement
 // payload.
 func (buf *rawAdvertisementPayload) LocalName() string {
-	b := buf.findField(9) // Complete Local Name
+	b := buf.findField(0x09) // Complete Local Name
 	if len(b) != 0 {
 		return string(b)
 	}
-	b = buf.findField(8) // Shortened Local Name
+	b = buf.findField(0x08) // Shortened Local Name
 	if len(b) != 0 {
 		return string(b)
 	}

--- a/gap.go
+++ b/gap.go
@@ -130,6 +130,10 @@ type AdvertisementPayload interface {
 	// ManufacturerData returns a map with all the manufacturer data present in the
 	// advertising. It may be empty.
 	ManufacturerData() map[uint16][]byte
+
+	// ServiceData returns a map with all the service data present in the
+	// advertising. It may be empty.
+	ServiceData() map[uint16][]byte
 }
 
 // AdvertisementFields contains advertisement fields in structured form.
@@ -145,6 +149,9 @@ type AdvertisementFields struct {
 
 	// ManufacturerData is the manufacturer data of the advertisement.
 	ManufacturerData map[uint16][]byte
+
+	// ServiceData is the service data of the advertisement.
+	ServiceData map[uint16][]byte
 }
 
 // advertisementFields wraps AdvertisementFields to implement the
@@ -180,6 +187,10 @@ func (p *advertisementFields) Bytes() []byte {
 // ManufacturerData returns the underlying ManufacturerData field.
 func (p *advertisementFields) ManufacturerData() map[uint16][]byte {
 	return p.AdvertisementFields.ManufacturerData
+}
+
+func (p *advertisementFields) ServiceData() map[uint16][]byte {
+	return p.AdvertisementFields.ServiceData
 }
 
 // rawAdvertisementPayload encapsulates a raw advertisement packet. Methods to

--- a/gap.go
+++ b/gap.go
@@ -241,11 +241,11 @@ func (buf *rawAdvertisementPayload) findField(fieldType byte) []byte {
 // LocalName returns the local name (complete or shortened) in the advertisement
 // payload.
 func (buf *rawAdvertisementPayload) LocalName() string {
-	b := buf.findField(0x09) // Complete Local Name
+	b := buf.findField(9) // Complete Local Name
 	if len(b) != 0 {
 		return string(b)
 	}
-	b = buf.findField(0x08) // Shortened Local Name
+	b = buf.findField(8) // Shortened Local Name
 	if len(b) != 0 {
 		return string(b)
 	}

--- a/gap.go
+++ b/gap.go
@@ -300,6 +300,11 @@ func (buf *rawAdvertisementPayload) ManufacturerData() map[uint16][]byte {
 	return mData
 }
 
+// ServiceData is not implemented yet.
+func (buf *rawAdvertisementPayload) ServiceData() map[uint16][]byte {
+	return map[uint16][]byte{}
+}
+
 // reset restores this buffer to the original state.
 func (buf *rawAdvertisementPayload) reset() {
 	// The data is not reset (only the length), because with a zero length the

--- a/gap_linux.go
+++ b/gap_linux.go
@@ -53,7 +53,7 @@ func (a *Advertisement) Configure(options AdvertisementOptions) error {
 	for _, uuid := range options.ServiceUUIDs {
 		serviceUUIDs = append(serviceUUIDs, uuid.String())
 	}
-	var serviceData = make(map[string][]byte)
+	var serviceData = make(map[string]interface{})
 	for uuid, data := range options.ServiceData {
 		serviceData[New16BitUUID(uuid).String()] = data.([]byte)
 	}

--- a/gap_linux.go
+++ b/gap_linux.go
@@ -255,6 +255,28 @@ func makeScanResult(props *device.Device1Properties) ScanResult {
 		}
 	}
 
+	sData := make(map[uint16][]byte)
+	for k, v := range props.ServiceData {
+		uuid, err := ParseUUID(k)
+		if err != nil || uuid.String() != k {
+			continue
+		}
+		svcID := uuid.Get16Bit()
+		switch data := v.(type) {
+		case []byte:
+			sData[svcID] = data[:]
+		case dbus.Variant:
+			switch dbusData := data.Value().(type) {
+			case []byte:
+				sData[svcID] = dbusData[:]
+			default:
+				continue
+			}
+		default:
+			continue
+		}
+	}
+
 	return ScanResult{
 		RSSI:    props.RSSI,
 		Address: a,
@@ -263,6 +285,7 @@ func makeScanResult(props *device.Device1Properties) ScanResult {
 				LocalName:        props.Name,
 				ServiceUUIDs:     serviceUUIDs,
 				ManufacturerData: mData,
+				ServiceData:      sData,
 			},
 		},
 	}

--- a/gap_linux.go
+++ b/gap_linux.go
@@ -102,13 +102,13 @@ func (a *Advertisement) Start() error {
 		if err, ok := err.(dbus.Error); ok && err.Name == "org.bluez.Error.AlreadyExists" {
 			return errAdvertisementAlreadyStarted
 		}
-		return fmt.Errorf("bluetooth: could not start advertisement (register): %w", err)
+		return fmt.Errorf("bluetooth: could not start advertisement: %w", err)
 	}
 
 	// Make us discoverable.
 	err = a.adapter.adapter.SetProperty("org.bluez.Adapter1.Discoverable", dbus.MakeVariant(true))
 	if err != nil {
-		return fmt.Errorf("bluetooth: could not start advertisement (make discoverable): %w", err)
+		return fmt.Errorf("bluetooth: could not start advertisement: %w", err)
 	}
 	return nil
 }

--- a/gap_linux.go
+++ b/gap_linux.go
@@ -63,6 +63,7 @@ func (a *Advertisement) Configure(options AdvertisementOptions) error {
 			"ServiceUUIDs":     {Value: serviceUUIDs},
 			"ManufacturerData": {Value: options.ManufacturerData},
 			"LocalName":        {Value: options.LocalName},
+			"ServiceData":		{Value: options.ServiceData},
 			// The documentation states:
 			// > Timeout of the advertisement in seconds. This defines the
 			// > lifetime of the advertisement.
@@ -89,13 +90,13 @@ func (a *Advertisement) Start() error {
 		if err, ok := err.(dbus.Error); ok && err.Name == "org.bluez.Error.AlreadyExists" {
 			return errAdvertisementAlreadyStarted
 		}
-		return fmt.Errorf("bluetooth: could not start advertisement: %w", err)
+		return fmt.Errorf("bluetooth: could not start advertisement (register): %w", err)
 	}
 
 	// Make us discoverable.
 	err = a.adapter.adapter.SetProperty("org.bluez.Adapter1.Discoverable", dbus.MakeVariant(true))
 	if err != nil {
-		return fmt.Errorf("bluetooth: could not start advertisement: %w", err)
+		return fmt.Errorf("bluetooth: could not start advertisement (make discoverable): %w", err)
 	}
 	return nil
 }

--- a/gap_linux.go
+++ b/gap_linux.go
@@ -75,7 +75,7 @@ func (a *Advertisement) Configure(options AdvertisementOptions) error {
 			"ServiceUUIDs":     {Value: serviceUUIDs},
 			"ManufacturerData": {Value: manufacturerData},
 			"LocalName":        {Value: options.LocalName},
-			"ServiceData":		{Value: serviceData},
+			"ServiceData":      {Value: serviceData},
 			// The documentation states:
 			// > Timeout of the advertisement in seconds. This defines the
 			// > lifetime of the advertisement.

--- a/gap_test.go
+++ b/gap_test.go
@@ -80,12 +80,37 @@ func TestCreateAdvertisementPayload(t *testing.T) {
 		},
 		{
 			raw: "\x02\x01\x06" + // flags
-				"\x0B\x09\x44\x49\x59\x2D\x73\x65\x6E\x73\x6F\x72" + // local name
-				"\x0A\x16\xD2\xFC\x40\x02\xC4\x09\x03\xBF\x13", // service UUID
+				"\x05\x16\xD2\xFC\x40\x02" + // service data 16-Bit UUID
+				"\x06\x20\xD2\xFC\x40\x02\xC4", // service data 32-Bit UUID
 			parsed: AdvertisementOptions{
-				LocalName: "DIY-sensor",
-				ServiceData: map[uint16]interface{}{
-					0xFCD2: []byte{0x40, 0x02, 0xC4, 0x09, 0x03, 0xBF, 0x13},
+				ServiceData: []ServiceDataElement{
+					{UUID: New16BitUUID(0xFCD2), Data: []byte{0x40, 0x02},  },
+					{UUID: New32BitUUID(0x0240FCD2), Data: []byte{0xC4},  },
+				},
+			},
+		},
+		{
+			raw: "\x02\x01\x06" + // flags
+				"\x05\x16\xD2\xFC\x40\x02" + // service data 16-Bit UUID
+				"\x05\x16\xD3\xFC\x40\x02" , // service data 16-Bit UUID
+			parsed: AdvertisementOptions{
+				ServiceData: []ServiceDataElement{
+					{UUID: New16BitUUID(0xFCD2), Data: []byte{0x40, 0x02},  },
+					{UUID: New16BitUUID(0xFCD3), Data: []byte{0x40, 0x02},  },
+				},
+			},
+		},
+		{
+			raw: "\x02\x01\x06" + // flags
+				"\x04\x16\xD2\xFC\x40" + // service data 16-Bit UUID
+				"\x12\x21\xB8\x6C\x75\x05\xE9\x25\xBD\x93\xA8\x42\x32\xC3\x00\x01\xAF\xAD\x09", // service data 128-Bit UUID
+			parsed: AdvertisementOptions{
+				ServiceData: []ServiceDataElement{
+					{UUID: New16BitUUID(0xFCD2), Data: []byte{0x40},  },
+					{
+						UUID: NewUUID([16]byte{0xad, 0xaf, 0x01, 0x00, 0xc3, 0x32, 0x42, 0xa8, 0x93, 0xbd, 0x25, 0xe9, 0x05, 0x75, 0x6c, 0xb8}), 
+						Data: []byte{0x09,},  
+					},
 				},
 			},
 		},

--- a/gap_test.go
+++ b/gap_test.go
@@ -55,6 +55,17 @@ func TestCreateAdvertisementPayload(t *testing.T) {
 				},
 			},
 		},
+		{
+			raw: "\x02\x01\x06" + // flags
+				"\x0B\x09\x44\x49\x59\x2D\x73\x65\x6E\x73\x6F\x72" + // local name
+				"\x0A\x16\xD2\xFC\x40\x02\xC4\x09\x03\xBF\x13", // service UUID
+			parsed: AdvertisementOptions{
+				LocalName: "DIY-sensor",
+				ServiceData: map[uint16]interface{}{
+					0xFCD2: []byte{0x40, 0x02, 0xC4, 0x09, 0x03, 0xBF, 0x13},
+				},
+			},
+		},
 	}
 	for _, tc := range tests {
 		var expectedRaw rawAdvertisementPayload

--- a/gap_test.go
+++ b/gap_test.go
@@ -84,19 +84,19 @@ func TestCreateAdvertisementPayload(t *testing.T) {
 				"\x06\x20\xD2\xFC\x40\x02\xC4", // service data 32-Bit UUID
 			parsed: AdvertisementOptions{
 				ServiceData: []ServiceDataElement{
-					{UUID: New16BitUUID(0xFCD2), Data: []byte{0x40, 0x02},  },
-					{UUID: New32BitUUID(0x0240FCD2), Data: []byte{0xC4},  },
+					{UUID: New16BitUUID(0xFCD2), Data: []byte{0x40, 0x02}},
+					{UUID: New32BitUUID(0x0240FCD2), Data: []byte{0xC4}},
 				},
 			},
 		},
 		{
 			raw: "\x02\x01\x06" + // flags
 				"\x05\x16\xD2\xFC\x40\x02" + // service data 16-Bit UUID
-				"\x05\x16\xD3\xFC\x40\x02" , // service data 16-Bit UUID
+				"\x05\x16\xD3\xFC\x40\x02", // service data 16-Bit UUID
 			parsed: AdvertisementOptions{
 				ServiceData: []ServiceDataElement{
-					{UUID: New16BitUUID(0xFCD2), Data: []byte{0x40, 0x02},  },
-					{UUID: New16BitUUID(0xFCD3), Data: []byte{0x40, 0x02},  },
+					{UUID: New16BitUUID(0xFCD2), Data: []byte{0x40, 0x02}},
+					{UUID: New16BitUUID(0xFCD3), Data: []byte{0x40, 0x02}},
 				},
 			},
 		},
@@ -106,10 +106,10 @@ func TestCreateAdvertisementPayload(t *testing.T) {
 				"\x12\x21\xB8\x6C\x75\x05\xE9\x25\xBD\x93\xA8\x42\x32\xC3\x00\x01\xAF\xAD\x09", // service data 128-Bit UUID
 			parsed: AdvertisementOptions{
 				ServiceData: []ServiceDataElement{
-					{UUID: New16BitUUID(0xFCD2), Data: []byte{0x40},  },
+					{UUID: New16BitUUID(0xFCD2), Data: []byte{0x40}},
 					{
-						UUID: NewUUID([16]byte{0xad, 0xaf, 0x01, 0x00, 0xc3, 0x32, 0x42, 0xa8, 0x93, 0xbd, 0x25, 0xe9, 0x05, 0x75, 0x6c, 0xb8}), 
-						Data: []byte{0x09,},  
+						UUID: NewUUID([16]byte{0xad, 0xaf, 0x01, 0x00, 0xc3, 0x32, 0x42, 0xa8, 0x93, 0xbd, 0x25, 0xe9, 0x05, 0x75, 0x6c, 0xb8}),
+						Data: []byte{0x09},
 					},
 				},
 			},

--- a/uuid.go
+++ b/uuid.go
@@ -81,6 +81,7 @@ func (uuid UUID) Get16Bit() uint16 {
 	// with a number.
 	return uint16(uuid[3])
 }
+
 // Get32Bit returns the 32-bit version of this UUID. This is only valid if it
 // actually is a 32-bit UUID, see Is32Bit.
 func (uuid UUID) Get32Bit() uint32 {

--- a/uuid.go
+++ b/uuid.go
@@ -38,6 +38,20 @@ func New16BitUUID(shortUUID uint16) UUID {
 	return uuid
 }
 
+// New32BitUUID returns a new 128-bit UUID based on a 32-bit UUID.
+//
+// Note: only use registered UUIDs. See
+// https://www.bluetooth.com/specifications/gatt/services/ for a list.
+func New32BitUUID(shortUUID uint32) UUID {
+	// https://stackoverflow.com/questions/36212020/how-can-i-convert-a-bluetooth-16-bit-service-uuid-into-a-128-bit-uuid
+	var uuid UUID
+	uuid[0] = 0x5F9B34FB
+	uuid[1] = 0x80000080
+	uuid[2] = 0x00001000
+	uuid[3] = shortUUID
+	return uuid
+}
+
 // Replace16BitComponent returns a new UUID where bits 16..32 have been replaced
 // with the bits given in the argument. These bits are the same bits that vary
 // in the 16-bit compressed UUID form.
@@ -66,6 +80,13 @@ func (uuid UUID) Get16Bit() uint16 {
 	// Note: using a Get* function as a getter because method names can't start
 	// with a number.
 	return uint16(uuid[3])
+}
+// Get32Bit returns the 32-bit version of this UUID. This is only valid if it
+// actually is a 32-bit UUID, see Is32Bit.
+func (uuid UUID) Get32Bit() uint32 {
+	// Note: using a Get* function as a getter because method names can't start
+	// with a number.
+	return uuid[3]
 }
 
 // Bytes returns a 16-byte array containing the raw UUID.


### PR DESCRIPTION
this PR add support for ServiceData advertising elements (0x16: Service Data - 16-bit UUID)
It is based on the work of #123 of which I merged all commits.
fixes #241 

I added
 - handling of advertising (sd, linux)
 - handling of scan (sd, linux)
 - bugfixes
 - testcase

I tested successfully 
 - advertise with ServiceData from softdevice
 - scan with ServiceData from softdevice
 - scan with ServiceData from linux

There is an error I can not figure out when advertising with ServiceData on linux. I keep getting:
```
panic: failed to start adv: bluetooth: could not start advertisement (register): Failed to parse advertisement.
```
Maybe s.th. is wrong with the formating of the ServiceData fields. Do you know what this should look like? Could you test on your end?
