### PR TITLE
all: change ManufacturerData from a map to a slice

### DIFF
--- a/adapter_darwin.go
+++ b/adapter_darwin.go
@@ -141,11 +141,19 @@ func makeScanResult(prph cbgo.Peripheral, advFields cbgo.AdvFields, rssi int) Sc
 		serviceUUIDs = append(serviceUUIDs, parsedUUID)
 	}
 
-	manufacturerData := make(map[uint16][]byte)
+	var manufacturerData []ManufacturerDataElement
 	if len(advFields.ManufacturerData) > 2 {
+		// Note: CoreBluetooth seems to assume there can be only one
+		// manufacturer data fields in an advertisement packet, while the
+		// specification allows multiple such fields. See the Bluetooth Core
+		// Specification Supplement, table 1.1:
+		// https://www.bluetooth.com/specifications/css-11/
 		manufacturerID := uint16(advFields.ManufacturerData[0])
 		manufacturerID += uint16(advFields.ManufacturerData[1]) << 8
-		manufacturerData[manufacturerID] = advFields.ManufacturerData[2:]
+		manufacturerData = append(manufacturerData, ManufacturerDataElement{
+			CompanyID: manufacturerID,
+			Data:      advFields.ManufacturerData[2:],
+		})
 	}
 
 	// Peripheral UUID is randomized on macOS, which means to

--- a/examples/advertisement/main.go
+++ b/examples/advertisement/main.go
@@ -13,6 +13,9 @@ func main() {
 	adv := adapter.DefaultAdvertisement()
 	must("config adv", adv.Configure(bluetooth.AdvertisementOptions{
 		LocalName: "Go Bluetooth",
+		ManufacturerData: []bluetooth.ManufacturerDataElement{
+			{CompanyID: 0xffff, Data: []byte{0x01, 0x02}},
+		},
 	}))
 	must("start adv", adv.Start())
 

--- a/gap_linux.go
+++ b/gap_linux.go
@@ -54,14 +54,22 @@ func (a *Advertisement) Configure(options AdvertisementOptions) error {
 		serviceUUIDs = append(serviceUUIDs, uuid.String())
 	}
 
+	// Convert map[uint16][]byte to map[uint16]any because that's what BlueZ needs.
+	manufacturerData := map[uint16]any{}
+	for _, element := range options.ManufacturerData {
+		manufacturerData[element.CompanyID] = element.Data
+	}
+
 	// Build an org.bluez.LEAdvertisement1 object, to be exported over DBus.
+	// See:
+	// https://git.kernel.org/pub/scm/bluetooth/bluez.git/tree/doc/org.bluez.LEAdvertisement.rst
 	id := atomic.AddUint64(&advertisementID, 1)
 	a.path = dbus.ObjectPath(fmt.Sprintf("/org/tinygo/bluetooth/advertisement%d", id))
 	propsSpec := map[string]map[string]*prop.Prop{
 		"org.bluez.LEAdvertisement1": {
 			"Type":             {Value: "broadcast"},
 			"ServiceUUIDs":     {Value: serviceUUIDs},
-			"ManufacturerData": {Value: options.ManufacturerData},
+			"ManufacturerData": {Value: manufacturerData},
 			"LocalName":        {Value: options.LocalName},
 			// The documentation states:
 			// > Timeout of the advertisement in seconds. This defines the
@@ -266,10 +274,13 @@ func makeScanResult(props map[string]dbus.Variant) ScanResult {
 	a := Address{MACAddress{MAC: addr}}
 	a.SetRandom(props["AddressType"].Value().(string) == "random")
 
-	manufacturerData := make(map[uint16][]byte)
+	var manufacturerData []ManufacturerDataElement
 	if mdata, ok := props["ManufacturerData"].Value().(map[uint16]dbus.Variant); ok {
 		for k, v := range mdata {
-			manufacturerData[k] = v.Value().([]byte)
+			manufacturerData = append(manufacturerData, ManufacturerDataElement{
+				CompanyID: k,
+				Data:      v.Value().([]byte),
+			})
 		}
 	}
 

--- a/gap_test.go
+++ b/gap_test.go
@@ -1,6 +1,7 @@
 package bluetooth
 
 import (
+	"reflect"
 	"testing"
 	"time"
 )
@@ -55,6 +56,28 @@ func TestCreateAdvertisementPayload(t *testing.T) {
 				},
 			},
 		},
+		{
+			raw: "\x02\x01\x06" + // flags
+				"\a\xff\x34\x12asdf", // manufacturer data
+			parsed: AdvertisementOptions{
+				ManufacturerData: []ManufacturerDataElement{
+					{0x1234, []byte("asdf")},
+				},
+			},
+		},
+		{
+			raw: "\x02\x01\x06" + // flags
+				"\x04\xff\x34\x12\x05" + // manufacturer data 1
+				"\x05\xff\xff\xff\x03\x07" + // manufacturer data 2
+				"\x03\xff\x11\x00", // manufacturer data 3
+			parsed: AdvertisementOptions{
+				ManufacturerData: []ManufacturerDataElement{
+					{0x1234, []byte{5}},
+					{0xffff, []byte{3, 7}},
+					{0x0011, []byte{}},
+				},
+			},
+		},
 	}
 	for _, tc := range tests {
 		var expectedRaw rawAdvertisementPayload
@@ -65,6 +88,10 @@ func TestCreateAdvertisementPayload(t *testing.T) {
 		raw.addFromOptions(tc.parsed)
 		if raw != expectedRaw {
 			t.Errorf("error when serializing options: %#v\nexpected: %#v\nactual:   %#v\n", tc.parsed, tc.raw, string(raw.data[:raw.len]))
+		}
+		mdata := raw.ManufacturerData()
+		if !reflect.DeepEqual(mdata, tc.parsed.ManufacturerData) {
+			t.Errorf("ManufacturerData was not parsed as expected:\nexpected: %#v\nactual:   %#v", tc.parsed.ManufacturerData, mdata)
 		}
 	}
 }

--- a/gap_windows.go
+++ b/gap_windows.go
@@ -114,7 +114,7 @@ func getScanResultFromArgs(args *advertisement.BluetoothLEAdvertisementReceivedE
 		Address: adr,
 	}
 
-	var manufacturerData map[uint16][]byte = make(map[uint16][]byte)
+	var manufacturerData []ManufacturerDataElement
 	if winAdv, err := args.GetAdvertisement(); err == nil && winAdv != nil {
 		vector, _ := winAdv.GetManufacturerData()
 		size, _ := vector.GetSize()
@@ -123,7 +123,10 @@ func getScanResultFromArgs(args *advertisement.BluetoothLEAdvertisementReceivedE
 			manData := (*advertisement.BluetoothLEManufacturerData)(element)
 			companyID, _ := manData.GetCompanyId()
 			buffer, _ := manData.GetData()
-			manufacturerData[companyID] = bufferToSlice(buffer)
+			manufacturerData = append(manufacturerData, ManufacturerDataElement{
+				CompanyID: companyID,
+				Data:      bufferToSlice(buffer),
+			})
 		}
 	}
 


### PR DESCRIPTION
This is a breaking change, but I believe it is necessary for correctness. Because maps have an undefined iteration order, the actual advertised packet could change each time which I think is a bad thing. In addition to that, using a slice should be much more lightweight than using a map.

I've also added some tests (that should have been there in the first place) and added some manufacturer data to the advertisement example.

Furthermore, I've optimized the code that constructs manufacturer data for raw advertisement payloads, it should now be entirely free of heap allocations.

See: https://github.com/tinygo-org/bluetooth/pull/243#issuecomment-1955024593