### PR TITLE
windows: check for error when scanning

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/go-ole/go-ole v1.2.6
 	github.com/godbus/dbus/v5 v5.1.0
-	github.com/saltosystems/winrt-go v0.0.0-20240110120258-ad49e9790c38
+	github.com/saltosystems/winrt-go v0.0.0-20240312144256-43a71786fba4
 	github.com/tinygo-org/cbgo v0.0.4
 	golang.org/x/crypto v0.12.0
 	tinygo.org/x/drivers v0.26.1-0.20230922160320-ed51435c2ef6

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/saltosystems/winrt-go v0.0.0-20240110120258-ad49e9790c38 h1:YcsdT0vhLMBWScwoO9FHZdjcFqjIWfQENMzq0PNxODs=
-github.com/saltosystems/winrt-go v0.0.0-20240110120258-ad49e9790c38/go.mod h1:CIltaIm7qaANUIvzr0Vmz71lmQMAIbGJ7cvgzX7FMfA=
+github.com/saltosystems/winrt-go v0.0.0-20240312144256-43a71786fba4 h1:3R7V8/xskRIAxAfHKDRWHu5pey0uiyf4wio2RwLXGyM=
+github.com/saltosystems/winrt-go v0.0.0-20240312144256-43a71786fba4/go.mod h1:CIltaIm7qaANUIvzr0Vmz71lmQMAIbGJ7cvgzX7FMfA=
 github.com/sirupsen/logrus v1.5.0/go.mod h1:+F7Ogzej0PZc/94MaYx/nvG9jOFMD2osvC3s+Squfpo=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=


### PR DESCRIPTION
This was my attempt to figure out why scanning doesn't work on my system. Sadly it still doesn't work, but at least I know there's no error in this place.

(Note: I'm doing this on Windows ARM in a VM, so it's a rather special setup).

This PR needs https://github.com/saltosystems/winrt-go/pull/84, so it's a draft until then.