### PR TITLE
winrt: bump to latest

### DIFF
--- a/gap_windows.go
+++ b/gap_windows.go
@@ -150,7 +150,7 @@ func getScanResultFromArgs(args *advertisement.BluetoothLEAdvertisementReceivedE
 }
 
 func bufferToSlice(buffer *streams.IBuffer) []byte {
-	dataReader, _ := streams.FromBuffer(buffer)
+	dataReader, _ := streams.DataReaderFromBuffer(buffer)
 	defer dataReader.Release()
 	bufferSize, _ := buffer.GetLength()
 	if bufferSize == 0 {
@@ -186,7 +186,7 @@ func (a *Adapter) Connect(address Address, params ConnectionParams) (Device, err
 	}
 
 	// IAsyncOperation<BluetoothLEDevice>
-	bleDeviceOp, err := bluetooth.FromBluetoothAddressAsync(winAddr)
+	bleDeviceOp, err := bluetooth.BluetoothLEDeviceFromBluetoothAddressAsync(winAddr)
 	if err != nil {
 		return Device{}, err
 	}
@@ -219,7 +219,7 @@ func (a *Adapter) Connect(address Address, params ConnectionParams) (Device, err
 	// Windows does not support explicitly connecting to a device.
 	// Instead it has the concept of a GATT session that is owned
 	// by the calling program.
-	gattSessionOp, err := genericattributeprofile.FromDeviceIdAsync(dID) // IAsyncOperation<GattSession>
+	gattSessionOp, err := genericattributeprofile.GattSessionFromDeviceIdAsync(dID) // IAsyncOperation<GattSession>
 	if err != nil {
 		return Device{}, err
 	}

--- a/gattc_windows.go
+++ b/gattc_windows.go
@@ -341,7 +341,7 @@ func (c DeviceCharacteristic) Read(data []byte) (int, error) {
 		return 0, err
 	}
 
-	datareader, err := streams.FromBuffer(buffer)
+	datareader, err := streams.DataReaderFromBuffer(buffer)
 	if err != nil {
 		return 0, err
 	}
@@ -381,7 +381,7 @@ func (c DeviceCharacteristic) EnableNotifications(callback func(buf []byte)) err
 			return
 		}
 
-		reader, err := streams.FromBuffer(buf)
+		reader, err := streams.DataReaderFromBuffer(buf)
 		if err != nil {
 			return
 		}

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/go-ole/go-ole v1.2.6
 	github.com/godbus/dbus/v5 v5.1.0
-	github.com/saltosystems/winrt-go v0.0.0-20240312144256-43a71786fba4
+	github.com/saltosystems/winrt-go v0.0.0-20240320113951-a2e4fc03f5f4
 	github.com/tinygo-org/cbgo v0.0.4
 	golang.org/x/crypto v0.12.0
 	tinygo.org/x/drivers v0.26.1-0.20230922160320-ed51435c2ef6

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/saltosystems/winrt-go v0.0.0-20240312144256-43a71786fba4 h1:3R7V8/xskRIAxAfHKDRWHu5pey0uiyf4wio2RwLXGyM=
-github.com/saltosystems/winrt-go v0.0.0-20240312144256-43a71786fba4/go.mod h1:CIltaIm7qaANUIvzr0Vmz71lmQMAIbGJ7cvgzX7FMfA=
+github.com/saltosystems/winrt-go v0.0.0-20240320113951-a2e4fc03f5f4 h1:zurEWtOr/OYiTb5bcD7eeHLOfj6vCR30uldlwse1cSM=
+github.com/saltosystems/winrt-go v0.0.0-20240320113951-a2e4fc03f5f4/go.mod h1:CIltaIm7qaANUIvzr0Vmz71lmQMAIbGJ7cvgzX7FMfA=
 github.com/sirupsen/logrus v1.5.0/go.mod h1:+F7Ogzej0PZc/94MaYx/nvG9jOFMD2osvC3s+Squfpo=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=


### PR DESCRIPTION
The latest version of winrt-go fixes an error that could cause function name collisions for static methods.

Diff: https://github.com/saltosystems/winrt-go/compare/43a71786fba4...a2e4fc03f5f4

---

There's nothing new added to the library, but since this was a breaking change (we renamed a few functions) I decided to update myself. 
See https://github.com/saltosystems/winrt-go/pull/85 and https://github.com/saltosystems/winrt-go/pull/86 for more info.