### PR TITLE
Fix several goroutine leaks

### DIFF
--- a/gap_linux.go
+++ b/gap_linux.go
@@ -345,6 +345,7 @@ func (a *Adapter) Connect(address Address, params ConnectionParams) (Device, err
 	// were connected between the two calls the signal wouldn't be picked up.
 	signal := make(chan *dbus.Signal)
 	a.bus.Signal(signal)
+	defer close(signal)
 	defer a.bus.RemoveSignal(signal)
 	propertiesChangedMatchOptions := []dbus.MatchOption{dbus.WithMatchInterface("org.freedesktop.DBus.Properties")}
 	a.bus.AddMatchSignal(propertiesChangedMatchOptions...)

--- a/gattc_linux.go
+++ b/gattc_linux.go
@@ -262,18 +262,17 @@ func (c DeviceCharacteristic) EnableNotifications(callback func(buf []byte)) err
 				if sig.Name == "org.freedesktop.DBus.Properties.PropertiesChanged" {
 					interfaceName := sig.Body[0].(string)
 
-					if interfaceName == "org.bluez.Device1" && sig.Path == devicePath {
+					switch {
+					case interfaceName == "org.bluez.Device1" && sig.Path == devicePath:
 						changes := sig.Body[1].(map[string]dbus.Variant)
 
 						if connected, ok := changes["Connected"].Value().(bool); ok && !connected {
 							c.EnableNotifications(nil)
 							return
 						}
-					} else if interfaceName != "org.bluez.GattCharacteristic1" {
+					case interfaceName != "org.bluez.GattCharacteristic1":
 						continue
-					}
-
-					if sig.Path != c.characteristic.Path() {
+					case sig.Path != c.characteristic.Path():
 						continue
 					}
 


### PR DESCRIPTION
This PR fixes several goroutine leaks that I've found:

- When `EnableNotifications(nil)` is called on a `DeviceCharacteristic`, the property channel is now closed, which releases the notification handler goroutine and allows it to exit.
- When an adapter connects to a device, the `signal` channel is now closed, releasing the goroutine that waits for the device to connect.
- When a device disconnects, all characteristics now close their property channels and release their notification handler goroutines. 

Fixes #260