### PR TITLE
hci: refactor to separate HCI transport implementation from interface

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,8 @@ smoketest-tinygo:
 	@md5sum test.hex
 	$(TINYGO) build -o test.uf2 -size=short -target=nano-rp2040 		  ./examples/advertisement
 	@md5sum test.hex
+	$(TINYGO) build -o test.uf2 -size=short -target=circuitplay-express -tags="hci hci_uart" ./examples/advertisement
+	@md5sum test.hex
 
 smoketest-linux:
 	# Test on Linux.

--- a/adapter_hci.go
+++ b/adapter_hci.go
@@ -3,17 +3,16 @@
 package bluetooth
 
 import (
-	"machine"
 	"runtime"
 
 	"time"
 )
 
-// hciAdapter represents the implementation for the UART connection to the HCI controller.
+// hciAdapter represents the implementation for the connection to the HCI controller.
 type hciAdapter struct {
-	uart *machine.UART
-	hci  *hci
-	att  *att
+	hciport hciTransport
+	hci     *hci
+	att     *att
 
 	isDefault bool
 	scanning  bool
@@ -49,8 +48,8 @@ func (a *hciAdapter) Address() (MACAddress, error) {
 	return MACAddress{MAC: makeAddress(a.hci.address)}, nil
 }
 
-func newBLEStack(uart *machine.UART) (*hci, *att) {
-	h := newHCI(uart)
+func newBLEStack(port hciTransport) (*hci, *att) {
+	h := newHCI(port)
 	a := newATT(h)
 	h.att = a
 

--- a/l2cap_hci.go
+++ b/l2cap_hci.go
@@ -1,4 +1,4 @@
-//go:build ninafw
+//go:build ninafw || hci
 
 package bluetooth
 


### PR DESCRIPTION
This PR is to refactor the HCI to separate the HCI transport implementation from the interface to not always assume UART. 

In addition to clarifying the code, it is also in part to prepare for alternative HCI transport implementations such as over SPI.