### PR TITLE
Windows Write Event Fix

### DIFF
--- a/gatts_windows.go
+++ b/gatts_windows.go
@@ -216,6 +216,7 @@ func (a *Adapter) AddService(s *Service) error {
 			char.Handle.value = char.Value
 			char.Handle.valueMtx = &sync.Mutex{}
 			char.Handle.flags = char.Flags
+			char.Handle.writeEvent = char.WriteEvent
 			goChars[uuid] = char.Handle
 		}
 	}


### PR DESCRIPTION
- ~~fixed issue where the WriteEvent from CharacteristicConfig was not being set to the internal winrt characteristic~~
- removed write event being called from the internal Characteristic.Write(), which was leading to an infinite loop when attempting to write to the characteristic in it's own write event

~~Not sure if the second point is intended behavour? In gatts_linux.go it calls a characterisit writeEvent, but I'm assuming bluez is writing to the characterisitic for you, whereas in winrt we have to write to it manually... One of these is probably not intended..!~~