### PR TITLE
gap: fix ServiceDataElement.UUID comment

### DIFF
--- a/gap.go
+++ b/gap.go
@@ -77,9 +77,8 @@ type ManufacturerDataElement struct {
 
 // ServiceDataElement strores a uuid/byte-array pair used as ServiceData advertisment elements
 type ServiceDataElement struct {
-	// service uuid or company uuid
+	// Service UUID.
 	// The list can also be viewed here:
-	// https://bitbucket.org/bluetooth-SIG/public/src/main/assigned_numbers/company_identifiers/company_identifiers.yaml
 	// https://bitbucket.org/bluetooth-SIG/public/src/main/assigned_numbers/uuids/service_uuids.yaml
 	UUID UUID
 	// the data byte array


### PR DESCRIPTION
I can't find anything that says the service UUID can also be a company UUID (though the UUID number ranges don't overlap, so it could be possible). Maybe I'm wrong, considering the size of the Bluetooth specification I could easily have missed something.