### PR TITLE
Write event infinite loop fix

### DIFF
--- a/gatts_windows.go
+++ b/gatts_windows.go
@@ -216,6 +216,7 @@ func (a *Adapter) AddService(s *Service) error {
 			char.Handle.value = char.Value
 			char.Handle.valueMtx = &sync.Mutex{}
 			char.Handle.flags = char.Flags
+			char.Handle.writeEvent = char.WriteEvent
 			goChars[uuid] = char.Handle
 		}
 	}

--- a/gatts_windows.go
+++ b/gatts_windows.go
@@ -245,10 +245,6 @@ func (c *Characteristic) Write(p []byte) (n int, err error) {
 		return 0, nil // nothing to do
 	}
 
-	if c.writeEvent != nil {
-		c.writeEvent(0, 0, p)
-	}
-
 	// writes are only actually processed on read events from clients, we just set a variable here.
 	c.valueMtx.Lock()
 	defer c.valueMtx.Unlock()


### PR DESCRIPTION
- removed write event being called from the internal Characteristic.Write(), which was leading to an infinite loop when attempting to write to the characteristic in it's own write event

Not sure if the second point is intended behavour? In gatts_linux.go it calls a characterisit writeEvent, but I'm assuming bluez is writing to the characterisitic for you, whereas in winrt we have to write to it manually... One of these is probably not intended..!

(cloned description from https://github.com/tinygo-org/bluetooth/pull/274)