### PR TITLE
enable setting MACAddr for cyw43439

### DIFF
--- a/hci_cyw43439.go
+++ b/hci_cyw43439.go
@@ -1,0 +1,27 @@
+//go:build cyw43439
+
+package bluetooth
+
+const (
+	ogfVendor = 0x3f
+
+	ocfSetBTMACAddr = 0x0001
+)
+
+func (a *Adapter) SetBdAddr(address Address) error {
+	return a.hci.setBdAddr(address)
+}
+
+func (h *hci) setBdAddr(address Address) error {
+	hciPacket := make([]byte, len(address.MACAddress.MAC))
+	// Reverse the byte order as per spec
+	for i := range address.MACAddress.MAC {
+		hciPacket[i] = address.MACAddress.MAC[len(address.MACAddress.MAC)-1-i]
+	}
+
+	if err := h.sendWithoutResponse(ogfVendor<<ogfCommandPos|ocfSetBTMACAddr, hciPacket); err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
cyw43439 boards don't seem to consistently set a MAC address from a seeded value, and always use a hardcoded MACAddr of `43:43:A2:12:1F:AC`

Therefore, in order to use two Picos near each other, it's necessary to provide a Set() call for changing the address.

This issue is highlighted by others as well below:
https://github.com/raspberrypi/pico-sdk/issues/1323

I initially opened an issue here:
https://github.com/soypat/cyw43439/issues/52

However, after implementing it I felt it made more sense to get the code into this repo with build tags.

This change has been tested and validated against my gopher2040-w badges from Gophercon 2024, which use a pico board. 

This is my first PR into this repo, so feel free to hit me with style nits or have me change my function names/signatures or just tell me it should go into the other repo.