### PR TITLE
Expose stop service advertisment on Windows

### DIFF
--- a/adapter_windows.go
+++ b/adapter_windows.go
@@ -7,6 +7,7 @@ import (
 	"github.com/go-ole/go-ole"
 	"github.com/saltosystems/winrt-go"
 	"github.com/saltosystems/winrt-go/windows/devices/bluetooth/advertisement"
+	"github.com/saltosystems/winrt-go/windows/devices/bluetooth/genericattributeprofile"
 	"github.com/saltosystems/winrt-go/windows/foundation"
 )
 
@@ -16,6 +17,8 @@ type Adapter struct {
 	connectHandler func(device Device, connected bool)
 
 	defaultAdvertisement *Advertisement
+
+	gattServiceProvider *genericattributeprofile.GattServiceProvider
 }
 
 // DefaultAdapter is the default adapter on the system.

--- a/gatts_linux.go
+++ b/gatts_linux.go
@@ -71,6 +71,12 @@ func (c *bluezChar) WriteValue(value []byte, options map[string]dbus.Variant) *d
 	return nil
 }
 
+func (a *Adapter) StopServiceAdvertisement() error {
+	// TODO: implement on linux
+
+	return nil
+}
+
 // AddService creates a new service with the characteristics listed in the
 // Service struct.
 func (a *Adapter) AddService(s *Service) error {

--- a/gatts_windows.go
+++ b/gatts_windows.go
@@ -49,6 +49,8 @@ func (a *Adapter) AddService(s *Service) error {
 		return err
 	}
 
+	a.gattServiceProvider = serviceProvider
+
 	localService, err := serviceProvider.GetService()
 	if err != nil {
 		return err
@@ -235,6 +237,10 @@ func (a *Adapter) AddService(s *Service) error {
 	}
 
 	return serviceProvider.StartAdvertisingWithParameters(params)
+}
+
+func (a *Adapter) StopServiceAdvertisement() error {
+	return a.gattServiceProvider.StopAdvertising()
 }
 
 // Write replaces the characteristic value with a new value.


### PR DESCRIPTION
It seems like you need to call `StopAdvertising` on the `GattServiceProvider` when you want to change the service being advertised or else Windows will just advertise both services. This just exposes that function on the adapter but only for Windows. I added a dummy function on the Linux implementation so apps that use it still build without having to make Linux and Windows specific files.

I'm not sure if a Linux implementation is needed or if BlueZ handles this differently.