### PR TITLE
build: remove macOS 11 build since it has been removed, and run macOS 14 instead

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -12,31 +12,16 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  macos-11:
-    name: macos-11
-    runs-on: macos-11
-    steps:
-      - name: Install Go
-        uses: actions/setup-go@v4.1.0
-        with:
-          go-version: '1.18.3'
-      - name: Checkout
-        uses: actions/checkout@v3.6.0
-      - name: Run unit tests
-        run: go test
-      - name: "Run macOS smoke tests"
-        run: make smoketest-macos
-
   macos-12:
     name: macos-12
     runs-on: macos-12
     steps:
       - name: Install Go
-        uses: actions/setup-go@v4.1.0
+        uses: actions/setup-go@v5
         with:
-          go-version: '1.21.0'
+          go-version: '1.20'
       - name: Checkout
-        uses: actions/checkout@v3.6.0
+        uses: actions/checkout@v4
       - name: Run unit tests
         run: go test
       - name: "Run macOS smoke tests"
@@ -47,11 +32,26 @@ jobs:
     runs-on: macos-13
     steps:
       - name: Install Go
-        uses: actions/setup-go@v4.1.0
+        uses: actions/setup-go@v5
         with:
-          go-version: '1.21.0'
+          go-version: '1.21'
       - name: Checkout
-        uses: actions/checkout@v3.6.0
+        uses: actions/checkout@v4
+      - name: Run unit tests
+        run: go test
+      - name: "Run macOS smoke tests"
+        run: make smoketest-macos
+  
+  macos-14:
+    name: macos-14
+    runs-on: macos-14
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.23'
+      - name: Checkout
+        uses: actions/checkout@v4
       - name: Run unit tests
         run: go test
       - name: "Run macOS smoke tests"


### PR DESCRIPTION
This PR updates the CI build by removing the macOS 11 build since it has been removed from GH (see https://github.blog/changelog/2024-05-20-actions-upcoming-changes-to-github-hosted-macos-runners/#macos-11-deprecation-and-removal), and run macOS 14 instead.