### PR TITLE
hci: add advertiser support for ManufacturerData and ServiceData

### DIFF
--- a/att_hci.go
+++ b/att_hci.go
@@ -1170,6 +1170,12 @@ func (a *att) addLocalCharacteristic(startHandle uint16, properties Characterist
 		})
 }
 
+func (a *att) clearLocalData() {
+	a.attributes = []rawAttribute{}
+	a.localServices = []rawService{}
+	a.localCharacteristics = []rawCharacteristic{}
+}
+
 func (a *att) findAttribute(hdl uint16) *rawAttribute {
 	for i := range a.attributes {
 		if a.attributes[i].handle == hdl {

--- a/examples/beacon/main.go
+++ b/examples/beacon/main.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"encoding/binary"
+	"math/rand"
+	"time"
+
+	"tinygo.org/x/bluetooth"
+)
+
+var adapter = bluetooth.DefaultAdapter
+
+var (
+	temperatureData [2]byte
+	sd              = []bluetooth.ServiceDataElement{
+		{
+			UUID: bluetooth.CharacteristicUUIDTemperature,
+			Data: temperatureData[:],
+		},
+	}
+
+	opts = bluetooth.AdvertisementOptions{
+		LocalName:         "Go Bluetooth",
+		ServiceData:       sd,
+		AdvertisementType: bluetooth.AdvertisingTypeScanInd,
+	}
+)
+
+func main() {
+	must("enable BLE stack", adapter.Enable())
+	adv := adapter.DefaultAdvertisement()
+
+	println("advertising...")
+	address, _ := adapter.Address()
+	for {
+		setServiceData(randomInt(100, 500))
+		must("config adv", adv.Configure(opts))
+		must("start adv", adv.Start())
+
+		println("Go Bluetooth /", address.MAC.String())
+		time.Sleep(time.Second)
+		adv.Stop()
+	}
+}
+
+func setServiceData(m1 uint16) {
+	binary.LittleEndian.PutUint16(temperatureData[:], m1)
+}
+
+// Returns an int >= min, < max
+func randomInt(min, max int) uint16 {
+	return uint16(min + rand.Intn(max-min))
+}
+
+func must(action string, err error) {
+	if err != nil {
+		panic("failed to " + action + ": " + err.Error())
+	}
+}

--- a/gap.go
+++ b/gap.go
@@ -9,6 +9,7 @@ var (
 	errScanning                  = errors.New("bluetooth: a scan is already in progress")
 	errNotScanning               = errors.New("bluetooth: there is no scan in progress")
 	errAdvertisementPacketTooBig = errors.New("bluetooth: advertisement packet overflows")
+	errNotYetImplmented          = errors.New("bluetooth: not implemented")
 )
 
 // MACAddress contains a Bluetooth address which is a MAC address.
@@ -39,9 +40,27 @@ func (mac *MACAddress) Set(val string) {
 	mac.MAC = m
 }
 
+type AdvertisingType int
+
+const (
+	// AdvertisingTypeInd - connectable undirected.
+	AdvertisingTypeInd AdvertisingType = iota
+
+	// AdvertisingTypeDirectInd - connectable directed.
+	AdvertisingTypeDirectInd
+
+	// AdvertisingTypeScanInd - scannable undirected.
+	AdvertisingTypeScanInd
+
+	// AdvertisingTypeNonConnInd - non-connectable undirected.
+	AdvertisingTypeNonConnInd
+)
+
 // AdvertisementOptions configures an advertisement instance. More options may
 // be added over time.
 type AdvertisementOptions struct {
+	AdvertisementType AdvertisingType
+
 	// The (complete) local name that will be advertised. Optional, omitted if
 	// this is a zero-length string.
 	LocalName string

--- a/gap_hci.go
+++ b/gap_hci.go
@@ -333,6 +333,9 @@ func (a *Advertisement) Configure(options AdvertisementOptions) error {
 
 	a.serviceUUIDs = append([]UUID{}, options.ServiceUUIDs...)
 	a.interval = uint16(options.Interval)
+	if a.interval == 0 {
+		a.interval = 0x0800 // default interval is 1.28 seconds
+	}
 	a.manufacturerData = append([]ManufacturerDataElement{}, options.ManufacturerData...)
 	a.serviceData = append([]ServiceDataElement{}, options.ServiceData...)
 

--- a/gap_linux.go
+++ b/gap_linux.go
@@ -75,7 +75,7 @@ func (a *Advertisement) Configure(options AdvertisementOptions) error {
 			"ServiceUUIDs":     {Value: serviceUUIDs},
 			"ManufacturerData": {Value: manufacturerData},
 			"LocalName":        {Value: options.LocalName},
-			"ServiceData":      {Value: serviceData},
+			"ServiceData":      {Value: serviceData, Writable: true},
 			// The documentation states:
 			// > Timeout of the advertisement in seconds. This defines the
 			// > lifetime of the advertisement.

--- a/gap_linux.go
+++ b/gap_linux.go
@@ -12,8 +12,8 @@ import (
 	"github.com/godbus/dbus/v5/prop"
 )
 
-var errAdvertisementNotStarted = errors.New("bluetooth: stop advertisement that was not started")
-var errAdvertisementAlreadyStarted = errors.New("bluetooth: start advertisement that was already started")
+var errAdvertisementNotStarted = errors.New("bluetooth: advertisement is not started")
+var errAdvertisementAlreadyStarted = errors.New("bluetooth: advertisement is already started")
 
 // Unique ID per advertisement (to generate a unique object path).
 var advertisementID uint64
@@ -28,6 +28,7 @@ type Advertisement struct {
 	adapter    *Adapter
 	properties *prop.Properties
 	path       dbus.ObjectPath
+	started    bool
 }
 
 // DefaultAdvertisement returns the default advertisement instance but does not
@@ -45,8 +46,8 @@ func (a *Adapter) DefaultAdvertisement() *Advertisement {
 //
 // On Linux with BlueZ, it is not possible to set the advertisement interval.
 func (a *Advertisement) Configure(options AdvertisementOptions) error {
-	if a.properties != nil {
-		panic("todo: configure advertisement a second time")
+	if a.started {
+		return errAdvertisementAlreadyStarted
 	}
 
 	var serviceUUIDs []string
@@ -110,6 +111,7 @@ func (a *Advertisement) Start() error {
 	if err != nil {
 		return fmt.Errorf("bluetooth: could not start advertisement: %w", err)
 	}
+	a.started = true
 	return nil
 }
 
@@ -122,6 +124,7 @@ func (a *Advertisement) Stop() error {
 		}
 		return fmt.Errorf("bluetooth: could not stop advertisement: %w", err)
 	}
+	a.started = false
 	return nil
 }
 


### PR DESCRIPTION
This PR adds advertiser support for ManufacturerData and ServiceData to the HCI implementation.

Addresses #306 