### PR TITLE
Issue #311 Clean resources properly when disable notifications

### DIFF
--- a/gattc_linux.go
+++ b/gattc_linux.go
@@ -235,7 +235,7 @@ func (c DeviceCharacteristic) WriteWithoutResponse(p []byte) (n int, err error) 
 // changes.
 //
 // Users may call EnableNotifications with a nil callback to disable notifications.
-func (c DeviceCharacteristic) EnableNotifications(callback func(buf []byte)) error {
+func (c *DeviceCharacteristic) EnableNotifications(callback func(buf []byte)) error {
 	switch callback {
 	default:
 		if c.property != nil {
@@ -280,6 +280,7 @@ func (c DeviceCharacteristic) EnableNotifications(callback func(buf []byte)) err
 
 		err := c.adapter.bus.RemoveMatchSignal(c.propertiesChangedMatchOption)
 		c.adapter.bus.RemoveSignal(c.property)
+		close(c.property)
 		c.property = nil
 		return err
 	}


### PR DESCRIPTION
Aimed to fix issue #311 "Duplicating data stream from a device (server) after disconnecting and reconnecting the same device in Linux OS". The gattc_linux.go file has been modified as suggested in the issue description.