### PR TITLE
fix: reconnect connect/disconnect handlers for HCI, Linux, and Windows Centrals

### DIFF
--- a/gap_hci.go
+++ b/gap_hci.go
@@ -209,6 +209,10 @@ func (a *Adapter) Connect(address Address, params ConnectionParams) (Device, err
 			}
 			a.addConnection(d)
 
+			if a.connectHandler != nil {
+				a.connectHandler(d, true)
+			}
+
 			return d, nil
 
 		} else {
@@ -258,6 +262,11 @@ func (d Device) Disconnect() error {
 	}
 
 	d.adapter.removeConnection(d)
+
+	if d.adapter.connectHandler != nil {
+		d.adapter.connectHandler(d, false)
+	}
+
 	return nil
 }
 

--- a/gap_linux.go
+++ b/gap_linux.go
@@ -390,12 +390,20 @@ func (a *Adapter) Connect(address Address, params ConnectionParams) (Device, err
 		<-connectChan
 	}
 
+	if a.connectHandler != nil {
+		a.connectHandler(device, true)
+	}
+
 	return device, nil
 }
 
 // Disconnect from the BLE device. This method is non-blocking and does not
 // wait until the connection is fully gone.
 func (d Device) Disconnect() error {
+	if d.adapter.connectHandler != nil {
+		d.adapter.connectHandler(d, false)
+	}
+
 	// we don't call our cancel function here, instead we wait for the
 	// property change in `watchForConnect` and cancel things then
 	return d.device.Call("org.bluez.Device1.Disconnect", 0).Err

--- a/gap_windows.go
+++ b/gap_windows.go
@@ -342,7 +342,12 @@ func (a *Adapter) Connect(address Address, params ConnectionParams) (Device, err
 		return Device{}, err
 	}
 
-	return Device{address, bleDevice, newSession}, nil
+	device := Device{address, bleDevice, newSession}
+	if a.connectHandler != nil {
+		a.connectHandler(device, true)
+	}
+
+	return device, nil
 }
 
 // Disconnect from the BLE device. This method is non-blocking and does not
@@ -356,6 +361,10 @@ func (d Device) Disconnect() error {
 	}
 	if err := d.device.Close(); err != nil {
 		return err
+	}
+
+	if DefaultAdapter.connectHandler != nil {
+		DefaultAdapter.connectHandler(d, false)
 	}
 
 	return nil

--- a/hci.go
+++ b/hci.go
@@ -113,6 +113,7 @@ type leAdvertisingReport struct {
 
 type leConnectData struct {
 	connected      bool
+	disconnected   bool
 	status         uint8
 	handle         uint16
 	role           uint8
@@ -613,6 +614,9 @@ func (h *hci) handleEventData(buf []byte) error {
 		h.att.removeConnection(handle)
 		h.l2cap.removeConnection(handle)
 
+		h.connectData.disconnected = true
+		h.connectData.handle = handle
+
 		return h.leSetAdvertiseEnable(true)
 
 	case evtEncryptionChange:
@@ -818,6 +822,7 @@ func (h *hci) clearAdvData() error {
 
 func (h *hci) clearConnectData() error {
 	h.connectData.connected = false
+	h.connectData.disconnected = false
 	h.connectData.status = 0
 	h.connectData.handle = 0
 	h.connectData.role = 0


### PR DESCRIPTION
This PR is to reconnect connect/disconnect handlers for HCI, Linux, and Windows Centrals.

As mentioned in several different issues, somehow they got disconnected along the way.