### PR TITLE
examples: add examples showing Battery Service and Device Information Service

### DIFF
--- a/examples/battery/main.go
+++ b/examples/battery/main.go
@@ -1,0 +1,64 @@
+// example that demonstrates how to create a BLE peripheral device with the Battery Service.
+package main
+
+import (
+	"math/rand"
+	"time"
+
+	"tinygo.org/x/bluetooth"
+)
+
+var adapter = bluetooth.DefaultAdapter
+
+var (
+	localName = "TinyGo Battery"
+
+	batteryLevel uint8 = 75 // 75%
+	battery      bluetooth.Characteristic
+)
+
+func main() {
+	println("starting")
+	must("enable BLE stack", adapter.Enable())
+	adv := adapter.DefaultAdvertisement()
+	must("config adv", adv.Configure(bluetooth.AdvertisementOptions{
+		LocalName:    localName,
+		ServiceUUIDs: []bluetooth.UUID{bluetooth.ServiceUUIDBattery},
+	}))
+	must("start adv", adv.Start())
+
+	must("add service", adapter.AddService(&bluetooth.Service{
+		UUID: bluetooth.ServiceUUIDBattery,
+		Characteristics: []bluetooth.CharacteristicConfig{
+			{
+				Handle: &battery,
+				UUID:   bluetooth.CharacteristicUUIDBatteryLevel,
+				Value:  []byte{byte(batteryLevel)},
+				Flags:  bluetooth.CharacteristicReadPermission | bluetooth.CharacteristicNotifyPermission,
+			},
+		},
+	}))
+
+	for {
+		println("tick", time.Now().Format("04:05.000"))
+
+		// random variation in batteryLevel
+		batteryLevel = randomInt(65, 85)
+
+		// and push the next notification
+		battery.Write([]byte{batteryLevel})
+
+		time.Sleep(time.Second)
+	}
+}
+
+func must(action string, err error) {
+	if err != nil {
+		panic("failed to " + action + ": " + err.Error())
+	}
+}
+
+// Returns an int >= min, < max
+func randomInt(min, max int) uint8 {
+	return uint8(min + rand.Intn(max-min))
+}

--- a/examples/device-information/main.go
+++ b/examples/device-information/main.go
@@ -1,0 +1,95 @@
+// example that demonstrates how to create a BLE peripheral device with the Device Information Service.
+package main
+
+import (
+	"time"
+
+	"tinygo.org/x/bluetooth"
+)
+
+var adapter = bluetooth.DefaultAdapter
+
+var (
+	localName = "TinyGo Device"
+
+	manufacturerName               = "TinyGo"
+	manufacturerNameCharacteristic bluetooth.Characteristic
+
+	modelNumber               = "Model 1"
+	modelNumberCharacteristic bluetooth.Characteristic
+
+	serialNumber               = "123456"
+	serialNumberCharacteristic bluetooth.Characteristic
+
+	softwareVersion               = "1.0.0"
+	softwareVersionCharacteristic bluetooth.Characteristic
+
+	firmwareVersion               = "1.0.0"
+	firmwareVersionCharacteristic bluetooth.Characteristic
+
+	hardwareVersion               = "1.0.0"
+	hardwareVersionCharacteristic bluetooth.Characteristic
+)
+
+func main() {
+	println("starting")
+	must("enable BLE stack", adapter.Enable())
+	adv := adapter.DefaultAdvertisement()
+	must("config adv", adv.Configure(bluetooth.AdvertisementOptions{
+		LocalName:    localName,
+		ServiceUUIDs: []bluetooth.UUID{bluetooth.ServiceUUIDDeviceInformation},
+	}))
+	must("start adv", adv.Start())
+
+	must("add service", adapter.AddService(&bluetooth.Service{
+		UUID: bluetooth.ServiceUUIDDeviceInformation,
+		Characteristics: []bluetooth.CharacteristicConfig{
+			{
+				Handle: &manufacturerNameCharacteristic,
+				UUID:   bluetooth.CharacteristicUUIDManufacturerNameString,
+				Value:  []byte(manufacturerName),
+				Flags:  bluetooth.CharacteristicReadPermission,
+			},
+			{
+				Handle: &modelNumberCharacteristic,
+				UUID:   bluetooth.CharacteristicUUIDModelNumberString,
+				Value:  []byte(modelNumber),
+				Flags:  bluetooth.CharacteristicReadPermission,
+			},
+			{
+				Handle: &serialNumberCharacteristic,
+				UUID:   bluetooth.CharacteristicUUIDSerialNumberString,
+				Value:  []byte(serialNumber),
+				Flags:  bluetooth.CharacteristicReadPermission,
+			},
+			{
+				Handle: &softwareVersionCharacteristic,
+				UUID:   bluetooth.CharacteristicUUIDSoftwareRevisionString,
+				Value:  []byte(softwareVersion),
+				Flags:  bluetooth.CharacteristicReadPermission,
+			},
+			{
+				Handle: &firmwareVersionCharacteristic,
+				UUID:   bluetooth.CharacteristicUUIDFirmwareRevisionString,
+				Value:  []byte(firmwareVersion),
+				Flags:  bluetooth.CharacteristicReadPermission,
+			},
+			{
+				Handle: &hardwareVersionCharacteristic,
+				UUID:   bluetooth.CharacteristicUUIDHardwareRevisionString,
+				Value:  []byte(hardwareVersion),
+				Flags:  bluetooth.CharacteristicReadPermission,
+			},
+		},
+	}))
+
+	for {
+		time.Sleep(time.Second)
+	}
+}
+
+func must(action string, err error) {
+	if err != nil {
+		panic("failed to " + action + ": " + err.Error())
+	}
+}


### PR DESCRIPTION
This PR adds two new examples, one showing the Battery Service and another showing the Device Information Service.