### PR TITLE
hci: implement set random MAC address

### DIFF
--- a/adapter_hci.go
+++ b/adapter_hci.go
@@ -54,7 +54,7 @@ func (a *hciAdapter) Address() (MACAddress, error) {
 		return MACAddress{}, err
 	}
 
-	return MACAddress{MAC: makeAddress(a.hci.address)}, nil
+	return a.hci.address, nil
 }
 
 func newBLEStack(port hciTransport) (*hci, *att) {

--- a/adapter_hci.go
+++ b/adapter_hci.go
@@ -50,6 +50,11 @@ func (a *hciAdapter) enable() error {
 }
 
 func (a *hciAdapter) Address() (MACAddress, error) {
+	var empty MAC
+	if a.hci.address.MAC != empty {
+		return a.hci.address, nil
+	}
+
 	if err := a.hci.readBdAddr(); err != nil {
 		return MACAddress{}, err
 	}

--- a/adapter_hci.go
+++ b/adapter_hci.go
@@ -57,6 +57,15 @@ func (a *hciAdapter) Address() (MACAddress, error) {
 	return a.hci.address, nil
 }
 
+func (a *Adapter) SetRandomAddress(mac MAC) error {
+	if err := a.hci.sendCommandWithParams(ogfLECtrl<<ogfCommandPos|ocfLESetRandomAddress, mac[:]); err != nil {
+		return err
+	}
+	copy(a.hci.address.MAC[:], mac[:])
+	a.hci.address.SetRandom(true)
+	return nil
+}
+
 func newBLEStack(port hciTransport) (*hci, *att) {
 	h := newHCI(port)
 	a := newATT(h)

--- a/gap_hci.go
+++ b/gap_hci.go
@@ -160,22 +160,27 @@ func (a *Adapter) Connect(address Address, params ConnectionParams) (Device, err
 		println("Connect")
 	}
 
-	random := uint8(0)
+	peerRandom := uint8(0)
 	if address.isRandom {
-		random = 1
+		peerRandom = 1
+	}
+	localRandom := uint8(0)
+	if a.hci.address.isRandom {
+		localRandom = 1
 	}
 	if err := a.hci.leCreateConn(0x0060, // interval
 		0x0030,                       // window
 		0x00,                         // initiatorFilter
-		random,                       // peerBdaddrType
+		peerRandom,                   // peerBdaddrType
 		makeNINAAddress(address.MAC), // peerBdaddr
-		0x00,                         // ownBdaddrType
+		localRandom,                  // ownBdaddrType
 		0x0006,                       // minInterval
 		0x000c,                       // maxInterval
 		0x0000,                       // latency
 		0x00c8,                       // supervisionTimeout
 		0x0004,                       // minCeLength
 		0x0006); err != nil {         // maxCeLength
+
 		return Device{}, err
 	}
 

--- a/gap_hci.go
+++ b/gap_hci.go
@@ -358,8 +358,13 @@ func (a *Advertisement) Start() error {
 	// uint8_t type = (_connectable) ? 0x00 : (_localName ? 0x02 : 0x03);
 	typ := uint8(a.advertisementType)
 
+	localRandom := uint8(0)
+	if a.adapter.hci.address.isRandom {
+		localRandom = 1
+	}
+
 	if err := a.adapter.hci.leSetAdvertisingParameters(a.interval, a.interval,
-		typ, 0x00, 0x00, [6]byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, 0x07, 0); err != nil {
+		typ, localRandom, 0x00, [6]byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, 0x07, 0); err != nil {
 		return err
 	}
 

--- a/hci.go
+++ b/hci.go
@@ -140,7 +140,7 @@ type hci struct {
 	pos               int
 	end               int
 	writebuf          []byte
-	address           [6]byte
+	address           MACAddress
 	cmdCompleteOpcode uint16
 	cmdCompleteStatus uint8
 	cmdResponse       []byte
@@ -318,7 +318,7 @@ func (h *hci) readBdAddr() error {
 		return err
 	}
 
-	copy(h.address[:], h.cmdResponse[:7])
+	copy(h.address.MAC[:], h.cmdResponse[:7])
 
 	return nil
 }


### PR DESCRIPTION
This PR is based on https://github.com/tinygo-org/bluetooth/pull/229 but is rebased against the latest `dev` branch.

In addition, it adds another commit that allows Advertisers that use the HCI adaptor to support random addresses. This is needed for certain applications, such as "AirTag" style beacons.

