### PR TITLE
nrf528xx: add advertiser random address

### DIFF
--- a/gap.go
+++ b/gap.go
@@ -376,7 +376,10 @@ func (buf *rawAdvertisementPayload) reset() {
 // before the call) from the advertisement options. It returns true if it fits,
 // false otherwise.
 func (buf *rawAdvertisementPayload) addFromOptions(options AdvertisementOptions) (ok bool) {
-	buf.addFlags(0x06)
+	// do not add flags for non-connectable advertisements
+	if options.AdvertisementType != AdvertisingTypeNonConnInd {
+		buf.addFlags(0x06)
+	}
 	if options.LocalName != "" {
 		if !buf.addCompleteLocalName(options.LocalName) {
 			return false

--- a/gap_nrf528xx-advertisement.go
+++ b/gap_nrf528xx-advertisement.go
@@ -56,6 +56,18 @@ func (a *Advertisement) Configure(options AdvertisementOptions) error {
 		return errAdvertisementPacketTooBig
 	}
 
+	var typ uint8
+	switch options.AdvertisementType {
+	case AdvertisingTypeInd:
+		typ = C.BLE_GAP_ADV_TYPE_CONNECTABLE_SCANNABLE_UNDIRECTED
+	case AdvertisingTypeDirectInd:
+		typ = C.BLE_GAP_ADV_TYPE_CONNECTABLE_NONSCANNABLE_DIRECTED
+	case AdvertisingTypeScanInd:
+		typ = C.BLE_GAP_ADV_TYPE_NONCONNECTABLE_SCANNABLE_UNDIRECTED
+	case AdvertisingTypeNonConnInd:
+		typ = C.BLE_GAP_ADV_TYPE_NONCONNECTABLE_NONSCANNABLE_UNDIRECTED
+	}
+
 	data := C.ble_gap_adv_data_t{}
 	data.adv_data = C.ble_data_t{
 		p_data: (*C.uint8_t)(unsafe.Pointer(&a.payload.data[0])),
@@ -63,7 +75,7 @@ func (a *Advertisement) Configure(options AdvertisementOptions) error {
 	}
 	params := C.ble_gap_adv_params_t{
 		properties: C.ble_gap_adv_properties_t{
-			_type: C.BLE_GAP_ADV_TYPE_CONNECTABLE_SCANNABLE_UNDIRECTED,
+			_type: typ,
 		},
 		interval: C.uint32_t(options.Interval),
 	}

--- a/gap_nrf528xx-advertisement.go
+++ b/gap_nrf528xx-advertisement.go
@@ -84,3 +84,16 @@ func (a *Advertisement) Stop() error {
 	errCode := C.sd_ble_gap_adv_stop(a.handle)
 	return makeError(errCode)
 }
+
+// SetRandomAddress sets the random address to be used for advertising.
+func (a *Adapter) SetRandomAddress(mac MAC) error {
+	var addr C.ble_gap_addr_t
+	addr.addr = makeSDAddress(mac)
+	addr.set_bitfield_addr_type(C.BLE_GAP_ADDR_TYPE_RANDOM_STATIC)
+
+	errCode := C.sd_ble_gap_addr_set(&addr)
+	if errCode != 0 {
+		return Error(errCode)
+	}
+	return nil
+}


### PR DESCRIPTION
This PR adds an Advertiser `SetRandomAddress()` function to the nrf528xx in the same way that it was added in the PR https://github.com/tinygo-org/bluetooth/pull/325 that this PR is based on.

This is needed in order to implement the `FindMy` style beacons.