### PR TITLE
fix: corrections for HCI GAP Advertiser

### DIFF
--- a/gap_hci.go
+++ b/gap_hci.go
@@ -342,10 +342,13 @@ func (a *Advertisement) Configure(options AdvertisementOptions) error {
 	}
 
 	a.serviceUUIDs = append([]UUID{}, options.ServiceUUIDs...)
-	a.interval = uint16(options.Interval)
-	if a.interval == 0 {
-		a.interval = 0x0800 // default interval is 1.28 seconds
+	if options.Interval == 0 {
+		// Pick an advertisement interval recommended by Apple (section 35.5
+		// Advertising Interval):
+		// https://developer.apple.com/accessories/Accessory-Design-Guidelines.pdf
+		options.Interval = NewDuration(152500 * time.Microsecond) // 152.5ms
 	}
+	a.interval = uint16(options.Interval)
 	a.manufacturerData = append([]ManufacturerDataElement{}, options.ManufacturerData...)
 	a.serviceData = append([]ServiceDataElement{}, options.ServiceData...)
 


### PR DESCRIPTION
This PR contains 2 corrections for HCI GAP Advertiser.

The first one is to not send the ADFlags when acting as a beacon to save bytes. Needed by FindMy manufacturer data.

The second is to set a more reasonable default value for HCI Interval, based on https://developer.apple.com/accessories/Accessory-Design-Guidelines.pdf as we do in other parts of the code.