### PR TITLE
feature: add SetRandomAddress()

### DIFF
--- a/gap_linux.go
+++ b/gap_linux.go
@@ -419,3 +419,24 @@ func (d Device) Disconnect() error {
 func (d Device) RequestConnectionParams(params ConnectionParams) error {
 	return nil
 }
+
+// SetRandomAddress sets the random address to be used for advertising.
+func (a *Adapter) SetRandomAddress(mac MAC) error {
+	addr, err := a.adapter.GetProperty("org.bluez.Adapter1.Address")
+	if err != nil {
+		if err, ok := err.(dbus.Error); ok && err.Name == "org.freedesktop.DBus.Error.UnknownObject" {
+			return fmt.Errorf("bluetooth: adapter %s does not exist", a.adapter.Path())
+		}
+		return fmt.Errorf("could not get adapter address: %w", err)
+	}
+	a.address = mac.String()
+	if err := addr.Store(&a.address); err != nil {
+		return fmt.Errorf("could not set adapter address: %w", err)
+	}
+
+	if err := a.adapter.SetProperty("org.bluez.Adapter1.AddressType", "random"); err != nil {
+		return fmt.Errorf("could not set adapter address type: %w", err)
+	}
+
+	return nil
+}

--- a/gap_windows.go
+++ b/gap_windows.go
@@ -1,6 +1,7 @@
 package bluetooth
 
 import (
+	"errors"
 	"fmt"
 	"unsafe"
 
@@ -380,4 +381,9 @@ func (d Device) RequestConnectionParams(params ConnectionParams) error {
 	// TODO: implement this using
 	// BluetoothLEDevice.RequestPreferredConnectionParameters.
 	return nil
+}
+
+// SetRandomAddress sets the random address to be used for advertising.
+func (a *Adapter) SetRandomAddress(mac MAC) error {
+	return errors.ErrUnsupported
 }


### PR DESCRIPTION
This PR is to add the `SetRandomAddress()` function for all platforms.

It contains 3 commits.

For Windows, one commit just adds a stub function that returns an error that it is not yet implemented.

For Linux, one commit adds the implementation.

For nrf51, one commit adds that implementation.

With this PR and #329 the "FindMy" beacon functionality works on all of our supported platforms except Windows.