### PR TITLE
Implement encoding interfaces for MAC address

### DIFF
--- a/mac.go
+++ b/mac.go
@@ -1,15 +1,16 @@
 package bluetooth
 
-import "errors"
+import (
+	"errors"
+)
 
 // MAC represents a MAC address, in little endian format.
 type MAC [6]byte
 
-var errInvalidMAC = errors.New("bluetooth: failed to parse MAC address")
-
-// ParseMAC parses the given MAC address, which must be in 11:22:33:AA:BB:CC
-// format. If it cannot be parsed, an error is returned.
-func ParseMAC(s string) (mac MAC, err error) {
+// UnmarshalText unmarshals the text into itself.
+// The given MAC address byte array must be of the format 11:22:33:AA:BB:CC.
+// If it cannot be unmarshaled, an error is returned.
+func (mac *MAC) UnmarshalText(s []byte) error {
 	macIndex := 11
 	for i := 0; i < len(s); i++ {
 		c := s[i]
@@ -22,12 +23,10 @@ func ParseMAC(s string) (mac MAC, err error) {
 		} else if c >= 'A' && c <= 'F' {
 			nibble = c - 'A' + 0xA
 		} else {
-			err = errInvalidMAC
-			return
+			return ErrInvalidMAC
 		}
 		if macIndex < 0 {
-			err = errInvalidMAC
-			return
+			return ErrInvalidMAC
 		}
 		if macIndex%2 == 0 {
 			mac[macIndex/2] |= nibble
@@ -37,8 +36,15 @@ func ParseMAC(s string) (mac MAC, err error) {
 		macIndex--
 	}
 	if macIndex != -1 {
-		err = errInvalidMAC
+		return ErrInvalidMAC
 	}
+	return nil
+}
+
+// ParseMAC parses the given MAC address, which must be in 11:22:33:AA:BB:CC
+// format. If it cannot be parsed, an error is returned.
+func ParseMAC(s string) (mac MAC, err error) {
+	err = (&mac).UnmarshalText([]byte(s))
 	return
 }
 
@@ -64,12 +70,30 @@ func (mac MAC) AppendText(buf []byte) ([]byte, error) {
 	return buf, nil
 }
 
+// MarshalText marshals itself into a string of format 11:22:33:AA:BB:CC.
+// It is a simple wrapper of the AppentText method.
 func (mac MAC) MarshalText() (text []byte, err error) {
 	return mac.AppendText(make([]byte, 0, 17))
 }
 
+var ErrInvalidMAC = errors.New("bluetooth: failed to parse MAC address")
+
+// MarshalBinary marshals itself into a binary format.
+// This is a simple wrapper of the AppendBinary method
 func (mac MAC) MarshalBinary() (data []byte, err error) {
 	return mac.AppendBinary(make([]byte, 0, 6))
+}
+
+var ErrInvalidBinaryMac = errors.New("bluetooth: failed to unmarshal the binary MAC address")
+
+// UnmarshalBinary unmarshals the mac byte slice into itself.
+// It will return the ErrInvalidBinaryMac error if the given slice is not exactually 6 in length.
+func (mac *MAC) UnmarshalBinary(data []byte) error {
+	if len(data) != 6 {
+		return ErrInvalidBinaryMac
+	}
+	copy(mac[:], data)
+	return nil
 }
 
 // AppendBinary appends the binary representation of itself to the end of b

--- a/mac.go
+++ b/mac.go
@@ -45,31 +45,35 @@ func ParseMAC(s string) (mac MAC, err error) {
 // String returns a human-readable version of this MAC address, such as
 // 11:22:33:AA:BB:CC.
 func (mac MAC) String() string {
-	// TODO: make this more efficient.
-	s := ""
+	buf, _ := mac.MarshalText()
+	return string(buf)
+}
+
+const hexDigit = "0123456789ABCDEF"
+
+// AppendText appends the textual representation of itself to the end of b
+// (allocating a larger slice if necessary) and returns the updated slice.
+func (mac MAC) AppendText(buf []byte) ([]byte, error) {
 	for i := 5; i >= 0; i-- {
-		c := mac[i]
-		// Insert a hyphen at the correct locations.
 		if i != 5 {
-			s += ":"
+			buf = append(buf, ':')
 		}
-
-		// First nibble.
-		nibble := c >> 4
-		if nibble <= 9 {
-			s += string(nibble + '0')
-		} else {
-			s += string(nibble + 'A' - 10)
-		}
-
-		// Second nibble.
-		nibble = c & 0x0f
-		if nibble <= 9 {
-			s += string(nibble + '0')
-		} else {
-			s += string(nibble + 'A' - 10)
-		}
+		buf = append(buf, hexDigit[mac[i]>>4])
+		buf = append(buf, hexDigit[mac[i]&0xF])
 	}
+	return buf, nil
+}
 
-	return s
+func (mac MAC) MarshalText() (text []byte, err error) {
+	return mac.AppendText(make([]byte, 0, 17))
+}
+
+func (mac MAC) MarshalBinary() (data []byte, err error) {
+	return mac.AppendBinary(make([]byte, 0, 6))
+}
+
+// AppendBinary appends the binary representation of itself to the end of b
+// (allocating a larger slice if necessary) and returns the updated slice.
+func (mac MAC) AppendBinary(b []byte) ([]byte, error) {
+	return append(b, mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]), nil
 }

--- a/mac.go
+++ b/mac.go
@@ -2,6 +2,7 @@ package bluetooth
 
 import (
 	"errors"
+	"unsafe"
 )
 
 // MAC represents a MAC address, in little endian format.
@@ -52,7 +53,7 @@ func ParseMAC(s string) (mac MAC, err error) {
 // 11:22:33:AA:BB:CC.
 func (mac MAC) String() string {
 	buf, _ := mac.MarshalText()
-	return string(buf)
+	return unsafe.String(unsafe.SliceData(buf), 17)
 }
 
 const hexDigit = "0123456789ABCDEF"

--- a/mac_test.go
+++ b/mac_test.go
@@ -6,9 +6,6 @@ import (
 )
 
 func TestParseMAC(t *testing.T) {
-	type args struct {
-		s string
-	}
 	tests := []struct {
 		name    string
 		strMac  string
@@ -127,5 +124,144 @@ func BenchmarkMacToString(b *testing.B) {
 	}
 	for i := 0; i < b.N; i++ {
 		_ = mac.String()
+	}
+}
+
+func TestMAC_UnmarshalBinary(t *testing.T) {
+	tests := []struct {
+		name    string
+		mac     []byte
+		wantMac MAC
+		wantErr bool
+	}{
+		{
+			name:    "incrementing",
+			mac:     []byte{188, 154, 120, 86, 52, 18},
+			wantMac: [6]byte{188, 154, 120, 86, 52, 18},
+			wantErr: false,
+		},
+		{
+			name:    "decrementing",
+			mac:     []byte{33, 67, 101, 135, 169, 203},
+			wantMac: [6]byte{33, 67, 101, 135, 169, 203},
+			wantErr: false,
+		},
+		{
+			name:    "normal",
+			mac:     []byte{204, 187, 170, 51, 34, 17},
+			wantMac: [6]byte{204, 187, 170, 51, 34, 17},
+			wantErr: false,
+		},
+		{
+			name:    "empty",
+			mac:     []byte{},
+			wantMac: [6]byte{},
+			wantErr: true,
+		},
+		{
+			name:    "extra",
+			mac:     []byte{33, 67, 101, 135, 169, 203, 255},
+			wantMac: [6]byte{},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotMac := MAC{}
+			gotMac.UnmarshalBinary(tt.mac)
+
+			if !tt.wantErr && !bytes.Equal(gotMac[:], tt.wantMac[:]) {
+				t.Errorf("ParseMAC() = %v, want %v", [6]byte(gotMac), [6]byte(tt.wantMac))
+			}
+		})
+	}
+}
+
+func TestMAC_MarshalBinary(t *testing.T) {
+	tests := []struct {
+		name     string
+		mac      MAC
+		wantData []byte
+		wantErr  bool
+	}{
+		{
+			name:     "incrementing",
+			mac:      [6]byte{188, 154, 120, 86, 52, 18},
+			wantData: []byte{188, 154, 120, 86, 52, 18},
+			wantErr:  false,
+		},
+		{
+			name:     "decrementing",
+			mac:      [6]byte{33, 67, 101, 135, 169, 203},
+			wantData: []byte{33, 67, 101, 135, 169, 203},
+			wantErr:  false,
+		},
+		{
+			name:     "normal",
+			mac:      [6]byte{204, 187, 170, 51, 34, 17},
+			wantData: []byte{204, 187, 170, 51, 34, 17},
+			wantErr:  false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotData, err := tt.mac.MarshalBinary()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("MAC.MarshalBinary() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && !bytes.Equal(gotData, tt.wantData) {
+				t.Errorf("MAC.MarshalBinary() = %v, want %v", gotData, tt.wantData)
+			}
+		})
+	}
+}
+
+func TestMAC_MarshalUnmarshalBinary(t *testing.T) {
+	tests := []struct {
+		name    string
+		mac     MAC
+		wantMac MAC
+		wantErr bool
+	}{
+		{
+			name:    "incrementing",
+			mac:     [6]byte{188, 154, 120, 86, 52, 18},
+			wantMac: [6]byte{188, 154, 120, 86, 52, 18},
+			wantErr: false,
+		},
+		{
+			name:    "decrementing",
+			mac:     [6]byte{33, 67, 101, 135, 169, 203},
+			wantMac: [6]byte{33, 67, 101, 135, 169, 203},
+			wantErr: false,
+		},
+		{
+			name:    "normal",
+			mac:     [6]byte{204, 187, 170, 51, 34, 17},
+			wantMac: [6]byte{204, 187, 170, 51, 34, 17},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b, err := tt.mac.MarshalBinary()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("MAC.MarshalBinary() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			gotMac := &MAC{}
+
+			err = gotMac.UnmarshalBinary(b)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("MAC.UnmarshalBinary() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if !tt.wantErr && !bytes.Equal(gotMac[:], tt.wantMac[:]) {
+				t.Errorf("MAC.MarshalBinary() = %v, want %v", gotMac, tt.wantMac)
+			}
+		})
 	}
 }

--- a/mac_test.go
+++ b/mac_test.go
@@ -1,0 +1,131 @@
+package bluetooth
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestParseMAC(t *testing.T) {
+	type args struct {
+		s string
+	}
+	tests := []struct {
+		name    string
+		strMac  string
+		wantMac MAC
+		wantErr bool
+	}{
+		{
+			name:    "incrementing",
+			strMac:  "12:34:56:78:9A:BC",
+			wantMac: [6]byte{188, 154, 120, 86, 52, 18},
+			wantErr: false,
+		},
+		{
+			name:    "decrementing",
+			strMac:  "CB:A9:87:65:43:21",
+			wantMac: [6]byte{33, 67, 101, 135, 169, 203},
+			wantErr: false,
+		},
+		{
+			name:    "normal",
+			strMac:  "11:22:33:AA:BB:CC",
+			wantMac: [6]byte{204, 187, 170, 51, 34, 17},
+			wantErr: false,
+		},
+		{
+			name:    "lower",
+			strMac:  "11:22:33:aa:bb:cc",
+			wantMac: [6]byte{},
+			wantErr: true,
+		},
+		{
+			name:    "longer",
+			strMac:  "11:22:33:AA:BB:CC:22",
+			wantMac: [6]byte{},
+			wantErr: true,
+		},
+		{
+			name:    "extra2",
+			strMac:  "11:222:33:AA:BB:CC",
+			wantMac: [6]byte{},
+			wantErr: true,
+		},
+		{
+			name:    "empty",
+			strMac:  "",
+			wantMac: [6]byte{},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotMac, err := ParseMAC(tt.strMac)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseMAC() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if !tt.wantErr && !bytes.Equal(gotMac[:], tt.wantMac[:]) {
+				t.Errorf("ParseMAC() = %v, want %v", [6]byte(gotMac), [6]byte(tt.wantMac))
+			}
+		})
+	}
+}
+
+func TestMAC_String(t *testing.T) {
+	tests := []struct {
+		name string
+		mac  MAC
+		want string
+	}{
+		{
+			name: "incrementing",
+			want: "12:34:56:78:9A:BC",
+			mac:  [6]byte{188, 154, 120, 86, 52, 18},
+		},
+		{
+			name: "decrementing",
+			want: "CB:A9:87:65:43:21",
+			mac:  [6]byte{33, 67, 101, 135, 169, 203},
+		},
+		{
+			name: "normal",
+			want: "11:22:33:AA:BB:CC",
+			mac:  [6]byte{204, 187, 170, 51, 34, 17},
+		},
+		{
+			name: "nil",
+			want: "00:00:00:00:00:00",
+			mac:  [6]byte{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.mac.String(); got != tt.want {
+				t.Errorf("MAC.String() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func BenchmarkParseMAC(b *testing.B) {
+	mac := "CB:A9:87:65:43:21"
+	var err error
+	for i := 0; i < b.N; i++ {
+		_, err = ParseMAC(mac)
+		if err != nil {
+			b.Errorf("expected nil but got %v", err)
+		}
+	}
+}
+
+func BenchmarkMacToString(b *testing.B) {
+	mac, err := ParseMAC("CB:A9:87:65:43:21")
+	if err != nil {
+		b.Errorf("expected nil but got %v", err)
+	}
+	for i := 0; i < b.N; i++ {
+		_ = mac.String()
+	}
+}


### PR DESCRIPTION
Implements the encoding TextMarshaler, BinaryMarshaler, TextAppender and BinaryAppender interfaces on the MAC type for efficient encoding. The String method is now written in terms of the new methods for consistency and improved performance.  This avoids unnecessary string allocations and conversions during the formatting process. This also allows MAC type to be used with other encoding packages.