### PR TITLE
fix: HCI fixes when acting as peripheral

### DIFF
--- a/att_hci.go
+++ b/att_hci.go
@@ -478,12 +478,12 @@ func (a *att) sendNotification(handle uint16, data []byte) error {
 	b[0] = attOpHandleNotify
 	binary.LittleEndian.PutUint16(b[1:], handle)
 
-	for connection := range a.connections {
+	for _, connection := range a.connections {
 		if debug {
 			println("att.sendNotifications: sending to", connection)
 		}
 
-		if err := a.hci.sendAclPkt(uint16(connection), attCID, append(b[:], data...)); err != nil {
+		if err := a.hci.sendAclPkt(connection, attCID, append(b[:], data...)); err != nil {
 			return err
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/go-ole/go-ole v1.2.6
 	github.com/godbus/dbus/v5 v5.1.0
 	github.com/saltosystems/winrt-go v0.0.0-20240509164145-4f7860a3bd2b
-	github.com/soypat/cyw43439 v0.0.0-20241116210509-ae1ce0e084c5
+	github.com/soypat/cyw43439 v0.0.0-20250221124649-d06a11e466eb
 	github.com/tinygo-org/cbgo v0.0.4
 	golang.org/x/crypto v0.12.0
 	tinygo.org/x/drivers v0.28.1-0.20241028090715-76a4276b5dea

--- a/go.sum
+++ b/go.sum
@@ -15,8 +15,8 @@ github.com/saltosystems/winrt-go v0.0.0-20240509164145-4f7860a3bd2b/go.mod h1:CI
 github.com/sirupsen/logrus v1.5.0/go.mod h1:+F7Ogzej0PZc/94MaYx/nvG9jOFMD2osvC3s+Squfpo=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
-github.com/soypat/cyw43439 v0.0.0-20241116210509-ae1ce0e084c5 h1:arwJFX1x5zq+wUp5ADGgudhMQEXKNMQOmTh+yYgkwzw=
-github.com/soypat/cyw43439 v0.0.0-20241116210509-ae1ce0e084c5/go.mod h1:1Otjk6PRhfzfcVHeWMEeku/VntFqWghUwuSQyivb2vE=
+github.com/soypat/cyw43439 v0.0.0-20250221124649-d06a11e466eb h1:M4ZPCf5GqJzvvKOKM6wJTKzPJ7xgZf7WqpvS3UYXguk=
+github.com/soypat/cyw43439 v0.0.0-20250221124649-d06a11e466eb/go.mod h1:1Otjk6PRhfzfcVHeWMEeku/VntFqWghUwuSQyivb2vE=
 github.com/soypat/seqs v0.0.0-20240527012110-1201bab640ef h1:phH95I9wANjTYw6bSYLZDQfNvao+HqYDom8owbNa0P4=
 github.com/soypat/seqs v0.0.0-20240527012110-1201bab640ef/go.mod h1:oCVCNGCHMKoBj97Zp9znLbQ1nHxpkmOY9X+UAGzOxc8=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/l2cap_hci.go
+++ b/l2cap_hci.go
@@ -5,7 +5,10 @@ package bluetooth
 import (
 	"encoding/binary"
 	"encoding/hex"
+	"errors"
 )
+
+var errInvalidPayloadLength = errors.New("bluetooth: invalid payload length")
 
 const (
 	connectionParamUpdateRequest  = 0x12
@@ -20,6 +23,10 @@ type l2capConnectionParamReqPkt struct {
 }
 
 func (l *l2capConnectionParamReqPkt) Write(buf []byte) (int, error) {
+	if len(buf) < 8 {
+		return 0, errInvalidPayloadLength
+	}
+
 	l.minInterval = binary.LittleEndian.Uint16(buf[0:])
 	l.maxInterval = binary.LittleEndian.Uint16(buf[2:])
 	l.latency = binary.LittleEndian.Uint16(buf[4:])
@@ -29,6 +36,10 @@ func (l *l2capConnectionParamReqPkt) Write(buf []byte) (int, error) {
 }
 
 func (l *l2capConnectionParamReqPkt) Read(p []byte) (int, error) {
+	if len(p) < 8 {
+		return 0, errInvalidPayloadLength
+	}
+
 	binary.LittleEndian.PutUint16(p[0:], l.minInterval)
 	binary.LittleEndian.PutUint16(p[2:], l.maxInterval)
 	binary.LittleEndian.PutUint16(p[4:], l.latency)


### PR DESCRIPTION
This PR includes 2 fixes that are needed when acting as a peripheral. 

I discovered them after I fixed the CYW43439 HCI using PR https://github.com/soypat/cyw43439/pull/59

One was causing a panic due to invalid slice length. The other was unable to correctly use arbitrary connection handle IDs.