### PR TITLE
Allow selecting a ble adapter with a macAddress

### DIFF
--- a/adapter_darwin.go
+++ b/adapter_darwin.go
@@ -10,6 +10,7 @@ import (
 
 // Adapter is a connection to BLE devices.
 type Adapter struct {
+	id  string
 	cmd *centralManagerDelegate
 	pmd *peripheralManagerDelegate
 
@@ -27,18 +28,24 @@ type Adapter struct {
 	connectHandler func(device Device, connected bool)
 }
 
+// NewAdapter creates a new Adapter with the given ID.
+//
+// Make sure to call Enable() before using it to initialize the adapter.
+func NewAdapter(id string) *Adapter {
+	return &Adapter{
+		id:         id,
+		cm:         cbgo.NewCentralManager(nil),
+		pm:         cbgo.NewPeripheralManager(nil),
+		connectMap: sync.Map{},
+
+		connectHandler: func(device Device, connected bool) {},
+	}
+}
+
 // DefaultAdapter is the default adapter on the system.
 //
 // Make sure to call Enable() before using it to initialize the adapter.
-var DefaultAdapter = &Adapter{
-	cm:         cbgo.NewCentralManager(nil),
-	pm:         cbgo.NewPeripheralManager(nil),
-	connectMap: sync.Map{},
-
-	connectHandler: func(device Device, connected bool) {
-		return
-	},
-}
+var DefaultAdapter = NewAdapter("")
 
 // Enable configures the BLE stack. It must be called before any
 // Bluetooth-related calls (unless otherwise indicated).

--- a/adapter_darwin.go
+++ b/adapter_darwin.go
@@ -10,9 +10,9 @@ import (
 
 // Adapter is a connection to BLE devices.
 type Adapter struct {
-	id  string
-	cmd *centralManagerDelegate
-	pmd *peripheralManagerDelegate
+	macAddress string
+	cmd        *centralManagerDelegate
+	pmd        *peripheralManagerDelegate
 
 	cm cbgo.CentralManager
 	pm cbgo.PeripheralManager
@@ -28,12 +28,13 @@ type Adapter struct {
 	connectHandler func(device Device, connected bool)
 }
 
-// NewAdapter creates a new Adapter with the given ID.
-//
+// NewAdapter creates a new Adapter with the given macAddress.
+// this is to support a system with multiple bluetooth adapters.
+// macAddress can be found by running `system_profiler SPBluetoothDataType`
 // Make sure to call Enable() before using it to initialize the adapter.
-func NewAdapter(id string) *Adapter {
+func NewAdapter(macAddress string) *Adapter {
 	return &Adapter{
-		id:         id,
+		macAddress: macAddress,
 		cm:         cbgo.NewCentralManager(nil),
 		pm:         cbgo.NewPeripheralManager(nil),
 		connectMap: sync.Map{},


### PR DESCRIPTION
This proposes a solution to fix https://github.com/tinygo-org/bluetooth/issues/284.

Testing:

I use the following main.go to run the test with this code change.

```
package main

import (
	"tinygo.org/x/bluetooth"
)

var adapter = bluetooth.NewAdapter("F4:D4:88:7E:15:0F")

func main() {
	// Enable BLE interface.
	must("enable BLE stack", adapter.Enable())

	// Start scanning.
	println("scanning...")
	err := adapter.Scan(func(adapter *bluetooth.Adapter, device bluetooth.ScanResult) {
		println("found device:", device.Address.String(), device.RSSI, device.LocalName())
	})
	must("start scan", err)
}

func must(action string, err error) {
	if err != nil {
		panic("failed to " + action + ": " + err.Error())
	}
}

```
a ble macAddress can be found by running this terminal cmd: `system_profiler SPBluetoothDataType`

