### PR TITLE
Fix device disconnect for windows

### DIFF
--- a/gap_windows.go
+++ b/gap_windows.go
@@ -1,6 +1,7 @@
 package bluetooth
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"unsafe"
@@ -275,6 +276,9 @@ func (a *Adapter) StopScan() error {
 
 // Device is a connection to a remote peripheral.
 type Device struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+
 	Address Address // the MAC address of the device
 
 	device  *bluetooth.BluetoothLEDevice
@@ -343,7 +347,18 @@ func (a *Adapter) Connect(address Address, params ConnectionParams) (Device, err
 		return Device{}, err
 	}
 
-	device := Device{address, bleDevice, newSession}
+	ctx, cancel := context.WithCancel(context.Background())
+
+	device := Device{
+		ctx:    ctx,
+		cancel: cancel,
+
+		Address: address,
+
+		device:  bleDevice,
+		session: newSession,
+	}
+
 	if a.connectHandler != nil {
 		a.connectHandler(device, true)
 	}
@@ -356,6 +371,8 @@ func (a *Adapter) Connect(address Address, params ConnectionParams) (Device, err
 func (d Device) Disconnect() error {
 	defer d.device.Release()
 	defer d.session.Release()
+
+	d.cancel()
 
 	if err := d.session.Close(); err != nil {
 		return err

--- a/gattc_windows.go
+++ b/gattc_windows.go
@@ -107,6 +107,11 @@ func (d Device) DiscoverServices(filterUUIDs []UUID) ([]DeviceService, error) {
 			}
 		}
 
+		go func() {
+			<-d.ctx.Done()
+			srv.Close()
+		}()
+
 		services = append(services, DeviceService{
 			uuidWrapper: serviceUuid,
 			service:     srv,


### PR DESCRIPTION
Related issues #247, #248

Added a `DeviceService` subscription to `Device` `Disconnect` function call, that causes `DeviceService` `Close` function call.

Tested personally, you can now reconnect to the device without restarting the process.