### PR TITLE
Linux: Fix: connectHandler after adv.Start

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,11 +69,14 @@ func main() {
 	must("enable BLE stack", adapter.Enable())
 
 	ctx, cancel := context.WithCancel(context.Background())
-	adapter.SetConnectHandler(func(device bluetooth.Device, connected bool){
+	adapter.SetConnectHandler(func(device bluetooth.Device, connected bool) {
 		if connected {
-			println("device connected:", device.Address.String(), device.RSSI, device.LocalName())
-			cancel()
+			println("device connected:", device.Address.String())
+			return
 		}
+
+		println("device disconnected:", device.Address.String())
+		cancel()
 	})
 
   	// Define the peripheral device info.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ This example shows a central that scans for peripheral devices and then displays
 package main
 
 import (
+	"fmt"
+
 	"tinygo.org/x/bluetooth"
 )
 
@@ -32,9 +34,9 @@ func main() {
 	must("enable BLE stack", adapter.Enable())
 
 	// Start scanning.
-	println("scanning...")
+	fmt.Println("scanning...")
 	err := adapter.Scan(func(adapter *bluetooth.Adapter, device bluetooth.ScanResult) {
-		println("found device:", device.Address.String(), device.RSSI, device.LocalName())
+		fmt.Println("found device:", device.Address.String(), device.RSSI, device.LocalName())
 	})
 	must("start scan", err)
 }
@@ -56,6 +58,8 @@ This example shows a peripheral that advertises itself as being available for co
 package main
 
 import (
+	"context"
+	"fmt"
 	"time"
 
 	"tinygo.org/x/bluetooth"
@@ -67,6 +71,14 @@ func main() {
   	// Enable BLE interface.
 	must("enable BLE stack", adapter.Enable())
 
+	ctx, cancel := context.WithCancel(context.Background())
+	adapter.SetConnectHandler(func(device bluetooth.Device, connected bool){
+		if connected {
+			fmt.Println("device connected:", device.Address.String(), device.RSSI, device.LocalName())
+			cancel()
+		}
+	})
+
   	// Define the peripheral device info.
 	adv := adapter.DefaultAdvertisement()
 	must("config adv", adv.Configure(bluetooth.AdvertisementOptions{
@@ -76,11 +88,8 @@ func main() {
   	// Start advertising
 	must("start adv", adv.Start())
 
-	println("advertising...")
-	for {
-		// Sleep forever.
-		time.Sleep(time.Hour)
-	}
+	fmt.Println("advertising...")
+	<- ctx.Done()
 }
 
 func must(action string, err error) {

--- a/README.md
+++ b/README.md
@@ -84,6 +84,9 @@ func main() {
   
   	// Start advertising
 	must("start adv", adv.Start())
+	
+	// Stop advertising to release resources
+	defer adv.Stop()
 
 	println("advertising...")
 	<- ctx.Done()

--- a/README.md
+++ b/README.md
@@ -22,8 +22,6 @@ This example shows a central that scans for peripheral devices and then displays
 package main
 
 import (
-	"fmt"
-
 	"tinygo.org/x/bluetooth"
 )
 
@@ -34,9 +32,9 @@ func main() {
 	must("enable BLE stack", adapter.Enable())
 
 	// Start scanning.
-	fmt.Println("scanning...")
+	println("scanning...")
 	err := adapter.Scan(func(adapter *bluetooth.Adapter, device bluetooth.ScanResult) {
-		fmt.Println("found device:", device.Address.String(), device.RSSI, device.LocalName())
+		println("found device:", device.Address.String(), device.RSSI, device.LocalName())
 	})
 	must("start scan", err)
 }
@@ -59,7 +57,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"tinygo.org/x/bluetooth"
@@ -74,7 +71,7 @@ func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 	adapter.SetConnectHandler(func(device bluetooth.Device, connected bool){
 		if connected {
-			fmt.Println("device connected:", device.Address.String(), device.RSSI, device.LocalName())
+			println("device connected:", device.Address.String(), device.RSSI, device.LocalName())
 			cancel()
 		}
 	})
@@ -88,7 +85,7 @@ func main() {
   	// Start advertising
 	must("start adv", adv.Start())
 
-	fmt.Println("advertising...")
+	println("advertising...")
 	<- ctx.Done()
 }
 

--- a/adapter.go
+++ b/adapter.go
@@ -1,8 +1,8 @@
 package bluetooth
 
 // SetConnectHandler sets a handler function to be called whenever the adaptor connects
-// or disconnects. You must call this before you call adaptor.Connect() for centrals
-// or adaptor.Start() for peripherals in order for it to work.
+// or disconnects. You must call this before you call adapter.Connect() for centrals
+// or advertisement.Start() for peripherals in order for it to work.
 func (a *Adapter) SetConnectHandler(c func(device Device, connected bool)) {
 	a.connectHandler = c
 }

--- a/examples/advertisement/main.go
+++ b/examples/advertisement/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"time"
 
 	"tinygo.org/x/bluetooth"
@@ -10,6 +11,18 @@ var adapter = bluetooth.DefaultAdapter
 
 func main() {
 	must("enable BLE stack", adapter.Enable())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	adapter.SetConnectHandler(func(device bluetooth.Device, connected bool) {
+		if connected {
+			println("device connected:", device.Address.String())
+			return
+		}
+
+		println("device disconnected:", device.Address.String())
+		cancel()
+	})
+
 	adv := adapter.DefaultAdvertisement()
 	must("config adv", adv.Configure(bluetooth.AdvertisementOptions{
 		LocalName: "Go Bluetooth",
@@ -18,12 +31,17 @@ func main() {
 		},
 	}))
 	must("start adv", adv.Start())
+	defer adv.Stop()
 
 	println("advertising...")
 	address, _ := adapter.Address()
 	for {
-		println("Go Bluetooth /", address.MAC.String())
-		time.Sleep(time.Second)
+		select {
+		case <-time.After(1 * time.Second):
+			println("Go Bluetooth /", address.MAC.String())
+		case <-ctx.Done():
+			return
+		}
 	}
 }
 

--- a/gap_linux.go
+++ b/gap_linux.go
@@ -108,6 +108,17 @@ func (a *Advertisement) Configure(options AdvertisementOptions) error {
 	}
 	a.properties = props
 
+	if options.LocalName != "" {
+		// In BlueZ AdvertisementOptions.LocalName will be sent in Extended
+		// Advertising Data and it will not change the Adapter alias.  Setting
+		// this property will update the name in the initial advertising data.
+		call := a.adapter.adapter.Call("org.freedesktop.DBus.Properties.Set", 0,
+			"org.bluez.Adapter1", "Alias", dbus.MakeVariant(options.LocalName))
+		if call.Err != nil {
+			return fmt.Errorf("set adapter alias: %w", call.Err)
+		}
+	}
+
 	return nil
 }
 
@@ -394,7 +405,7 @@ func makeScanResult(props map[string]dbus.Variant) ScanResult {
 	}
 }
 
-// Device is a connection to a remote peripheral.
+// Device is a connection to a remote bluetooth device.
 type Device struct {
 	Address Address // the MAC address of the device
 
@@ -534,13 +545,6 @@ func (a *Adapter) SetRandomAddress(mac MAC) error {
 	return nil
 }
 
-// SetAdapterAlias sets the alias of the adapter in BlueZ.
-func (a *Adapter) SetAdapterAlias(alias string) error {
-	call := a.adapter.Call("org.freedesktop.DBus.Properties.Set", 0,
-		"org.bluez.Adapter1", "Alias", dbus.MakeVariant(alias))
-	return call.Err
-}
-
 func (a *Advertisement) handleDBusSignals() {
 	for {
 		select {
@@ -571,27 +575,43 @@ func (a *Advertisement) handleDBusSignals() {
 				obj := a.adapter.bus.Object("org.bluez", devicePath)
 
 				// The only property received is the changed property "Connected",
-				// so we have to get the Address from D-Bus.
-				deviceAddr, err := obj.GetProperty("org.bluez.Device1.Address")
+				// so we have to get the other properties from D-Bus.
+				device, err := getDeviceProperties(a.adapter, obj)
 				if err != nil {
 					continue
 				}
 
-				// In the event that the address is not provided, use an empty
-				// value so that the handler can still be called.
-				mac := [6]byte{}
-				if addrStr, ok := deviceAddr.Value().(string); ok {
-					if pmac, err := ParseMAC(addrStr); err == nil {
-						mac = pmac
-					}
-				}
-
-				a.adapter.connectHandler(Device{
-					Address: Address{MACAddress: MACAddress{MAC: mac}},
-					device:  obj,
-					adapter: a.adapter,
-				}, connected)
+				a.adapter.connectHandler(*device, connected)
 			}
 		}
 	}
+}
+
+// getDeviceProperties will fetch all known properties of a device from D-Bus
+//
+// For all possible properties see:
+// https://github.com/luetzel/bluez/blob/master/doc/device-api.txt
+func getDeviceProperties(a *Adapter, obj dbus.BusObject) (*Device, error) {
+	var props map[string]dbus.Variant
+	if err := obj.Call("org.freedesktop.DBus.Properties.GetAll", 0, "org.bluez.Device1").Store(&props); err != nil {
+		return nil, fmt.Errorf("org.freedesktop.DBus.Properties.GetAll: %w", err)
+	}
+
+	d := Device{
+		device:  obj,
+		adapter: a,
+	}
+
+	for k, v := range props {
+		switch k {
+		case "Address":
+			if addrStr, ok := v.Value().(string); ok {
+				if mac, err := ParseMAC(addrStr); err == nil {
+					d.Address = Address{MACAddress: MACAddress{MAC: mac}}
+				}
+			}
+		}
+	}
+
+	return &d, nil
 }

--- a/gap_linux.go
+++ b/gap_linux.go
@@ -12,6 +12,17 @@ import (
 	"github.com/godbus/dbus/v5/prop"
 )
 
+const (
+	// Match rule constants for D-Bus signals.
+	//
+	// See [DBusPropertiesLink] for more information.
+	DBusPropertiesChangedInterfaceName = 0
+	DBusPropertiesChangedDictionary    = 1
+	DBusPropertiesChangedInvalidated   = 2
+)
+
+// [DBusPropertiesLink]: https://dbus.freedesktop.org/doc/dbus-specification.html#standard-interfaces-properties
+
 var errAdvertisementNotStarted = errors.New("bluetooth: advertisement is not started")
 var errAdvertisementAlreadyStarted = errors.New("bluetooth: advertisement is already started")
 var errAdaptorNotPowered = errors.New("bluetooth: adaptor is not powered")
@@ -30,6 +41,10 @@ type Advertisement struct {
 	properties *prop.Properties
 	path       dbus.ObjectPath
 	started    bool
+
+	// D-Bus Signals
+	sigCh     chan *dbus.Signal
+	matchOpts []dbus.MatchOption
 }
 
 // DefaultAdvertisement returns the default advertisement instance but does not
@@ -107,6 +122,20 @@ func (a *Advertisement) Start() error {
 		return fmt.Errorf("bluetooth: could not start advertisement: %w", err)
 	}
 
+	if a.adapter.connectHandler != nil {
+		a.sigCh = make(chan *dbus.Signal)
+		a.adapter.bus.Signal(a.sigCh)
+
+		a.matchOpts = []dbus.MatchOption{dbus.WithMatchInterface("org.freedesktop.DBus.Properties"),
+			dbus.WithMatchMember("PropertiesChanged"),
+			dbus.WithMatchArg(DBusPropertiesChangedInterfaceName, "org.bluez.Device1")}
+		if err := a.adapter.bus.AddMatchSignal(a.matchOpts...); err != nil {
+			return fmt.Errorf("add match signal: %w", err)
+		}
+
+		go a.handleDBusSignals()
+	}
+
 	// Make us discoverable.
 	err = a.adapter.adapter.SetProperty("org.bluez.Adapter1.Discoverable", dbus.MakeVariant(true))
 	if err != nil {
@@ -126,6 +155,14 @@ func (a *Advertisement) Stop() error {
 		return fmt.Errorf("bluetooth: could not stop advertisement: %w", err)
 	}
 	a.started = false
+
+	if a.sigCh != nil {
+		defer close(a.sigCh)
+		if err := a.adapter.bus.RemoveMatchSignal(a.matchOpts...); err != nil {
+			return fmt.Errorf("bluetooth: failed to clean up dbus signals: %w", err)
+		}
+		a.adapter.bus.RemoveSignal(a.sigCh)
+	}
 	return nil
 }
 
@@ -495,4 +532,66 @@ func (a *Adapter) SetRandomAddress(mac MAC) error {
 	}
 
 	return nil
+}
+
+// SetAdapterAlias sets the alias of the adapter in BlueZ.
+func (a *Adapter) SetAdapterAlias(alias string) error {
+	call := a.adapter.Call("org.freedesktop.DBus.Properties.Set", 0,
+		"org.bluez.Adapter1", "Alias", dbus.MakeVariant(alias))
+	return call.Err
+}
+
+func (a *Advertisement) handleDBusSignals() {
+	for {
+		select {
+		case sig, ok := <-a.sigCh:
+			if !ok {
+				return // channel closed
+			}
+
+			if sig.Name != "org.freedesktop.DBus.Properties.PropertiesChanged" {
+				continue
+			}
+
+			// Skip any signals that are not the Device1 interface.
+			if interfaceName, ok := sig.Body[DBusPropertiesChangedInterfaceName].(string); !ok || interfaceName != "org.bluez.Device1" {
+				continue
+			}
+
+			// Get all changed properties and skip any signals that are not
+			// compliant with the Device1 interface.
+			changes, ok := sig.Body[DBusPropertiesChangedDictionary].(map[string]dbus.Variant)
+			if !ok {
+				continue
+			}
+
+			// Call the connect handler if the Connected property has changed.
+			if connected, ok := changes["Connected"].Value().(bool); ok {
+				devicePath := sig.Path
+				obj := a.adapter.bus.Object("org.bluez", devicePath)
+
+				// The only property received is the changed property "Connected",
+				// so we have to get the Address from D-Bus.
+				deviceAddr, err := obj.GetProperty("org.bluez.Device1.Address")
+				if err != nil {
+					continue
+				}
+
+				// In the event that the address is not provided, use an empty
+				// value so that the handler can still be called.
+				mac := [6]byte{}
+				if addrStr, ok := deviceAddr.Value().(string); ok {
+					if pmac, err := ParseMAC(addrStr); err == nil {
+						mac = pmac
+					}
+				}
+
+				a.adapter.connectHandler(Device{
+					Address: Address{MACAddress: MACAddress{MAC: mac}},
+					device:  obj,
+					adapter: a.adapter,
+				}, connected)
+			}
+		}
+	}
 }

--- a/gap_linux.go
+++ b/gap_linux.go
@@ -16,12 +16,34 @@ const (
 	// Match rule constants for D-Bus signals.
 	//
 	// See [DBusPropertiesLink] for more information.
-	DBusPropertiesChangedInterfaceName = 0
-	DBusPropertiesChangedDictionary    = 1
-	DBusPropertiesChangedInvalidated   = 2
+
+	dbusPropertiesChangedInterfaceName = 0
+	dbusPropertiesChangedDictionary    = 1
+	dbusPropertiesChangedInvalidated   = 2
+
+	dbusInterfacesAddedDictionary = 1
+
+	dbusSignalInterfacesAdded   = "org.freedesktop.DBus.ObjectManager.InterfacesAdded"
+	dbusSignalPropertiesChanged = "org.freedesktop.DBus.Properties.PropertiesChanged"
+
+	bluezDevice1Interface = "org.bluez.Device1"
+	bluezDevice1Address   = "Address"
+	bluezDevice1Connected = "Connected"
+)
+
+var (
+	// See [DBusPropertiesLink] for more information.
+	matchOptionsPropertiesChanged = []dbus.MatchOption{dbus.WithMatchInterface("org.freedesktop.DBus.Properties"),
+		dbus.WithMatchMember("PropertiesChanged"),
+		dbus.WithMatchArg(dbusPropertiesChangedInterfaceName, "org.bluez.Device1")}
+
+	// See [DBusObjectManagerLink] for more information.
+	matchOptionsInterfacesAdded = []dbus.MatchOption{dbus.WithMatchInterface("org.freedesktop.DBus.ObjectManager"),
+		dbus.WithMatchMember("InterfacesAdded")}
 )
 
 // [DBusPropertiesLink]: https://dbus.freedesktop.org/doc/dbus-specification.html#standard-interfaces-properties
+// [DBusObjectManagerLink]: https://dbus.freedesktop.org/doc/dbus-specification.html#standard-interfaces-objectmanager
 
 var errAdvertisementNotStarted = errors.New("bluetooth: advertisement is not started")
 var errAdvertisementAlreadyStarted = errors.New("bluetooth: advertisement is already started")
@@ -43,8 +65,7 @@ type Advertisement struct {
 	started    bool
 
 	// D-Bus Signals
-	sigCh     chan *dbus.Signal
-	matchOpts []dbus.MatchOption
+	sigCh chan *dbus.Signal
 }
 
 // DefaultAdvertisement returns the default advertisement instance but does not
@@ -137,11 +158,12 @@ func (a *Advertisement) Start() error {
 		a.sigCh = make(chan *dbus.Signal)
 		a.adapter.bus.Signal(a.sigCh)
 
-		a.matchOpts = []dbus.MatchOption{dbus.WithMatchInterface("org.freedesktop.DBus.Properties"),
-			dbus.WithMatchMember("PropertiesChanged"),
-			dbus.WithMatchArg(DBusPropertiesChangedInterfaceName, "org.bluez.Device1")}
-		if err := a.adapter.bus.AddMatchSignal(a.matchOpts...); err != nil {
-			return fmt.Errorf("add match signal: %w", err)
+		if err := a.adapter.bus.AddMatchSignal(matchOptionsPropertiesChanged...); err != nil {
+			return fmt.Errorf("bluetooth: add dbus match signal: PropertiesChanged: %w", err)
+		}
+
+		if err := a.adapter.bus.AddMatchSignal(matchOptionsInterfacesAdded...); err != nil {
+			return fmt.Errorf("bluetooth: add dbus match signal: InterfacesAdded: %w", err)
 		}
 
 		go a.handleDBusSignals()
@@ -169,8 +191,11 @@ func (a *Advertisement) Stop() error {
 
 	if a.sigCh != nil {
 		defer close(a.sigCh)
-		if err := a.adapter.bus.RemoveMatchSignal(a.matchOpts...); err != nil {
-			return fmt.Errorf("bluetooth: failed to clean up dbus signals: %w", err)
+		if err := a.adapter.bus.RemoveMatchSignal(matchOptionsPropertiesChanged...); err != nil {
+			return fmt.Errorf("bluetooth: remove dbus match signal: PropertiesChanged: %w", err)
+		}
+		if err := a.adapter.bus.RemoveMatchSignal(matchOptionsInterfacesAdded...); err != nil {
+			return fmt.Errorf("bluetooth: remove dbus match signal: InterfacesAdded: %w", err)
 		}
 		a.adapter.bus.RemoveSignal(a.sigCh)
 	}
@@ -553,65 +578,81 @@ func (a *Advertisement) handleDBusSignals() {
 				return // channel closed
 			}
 
-			if sig.Name != "org.freedesktop.DBus.Properties.PropertiesChanged" {
-				continue
+			device := Device{
+				device:  a.adapter.bus.Object("org.bluez", sig.Path),
+				adapter: a.adapter,
 			}
 
-			// Skip any signals that are not the Device1 interface.
-			if interfaceName, ok := sig.Body[DBusPropertiesChangedInterfaceName].(string); !ok || interfaceName != "org.bluez.Device1" {
-				continue
-			}
+			switch sig.Name {
+			case dbusSignalInterfacesAdded:
+				interfaces := sig.Body[dbusInterfacesAddedDictionary].(map[string]map[string]dbus.Variant)
 
-			// Get all changed properties and skip any signals that are not
-			// compliant with the Device1 interface.
-			changes, ok := sig.Body[DBusPropertiesChangedDictionary].(map[string]dbus.Variant)
-			if !ok {
-				continue
-			}
-
-			// Call the connect handler if the Connected property has changed.
-			if connected, ok := changes["Connected"].Value().(bool); ok {
-				devicePath := sig.Path
-				obj := a.adapter.bus.Object("org.bluez", devicePath)
-
-				// The only property received is the changed property "Connected",
-				// so we have to get the other properties from D-Bus.
-				device, err := getDeviceProperties(a.adapter, obj)
-				if err != nil {
+				// InterfacesAdded signal also contains all known properties so
+				// so we do not need to call org.freedesktop.DBus.Properties.GetAll
+				props, ok := interfaces[bluezDevice1Interface]
+				if !ok {
 					continue
 				}
 
-				a.adapter.connectHandler(*device, connected)
+				if err := device.parseProperties(&props); err != nil {
+					continue
+				}
+
+				if connected, ok := props[bluezDevice1Connected].Value().(bool); ok {
+					a.adapter.connectHandler(device, connected)
+				}
+			case dbusSignalPropertiesChanged:
+				// Skip any signals that are not the Device1 interface.
+				if interfaceName, ok := sig.Body[dbusPropertiesChangedInterfaceName].(string); !ok || interfaceName != bluezDevice1Interface {
+					continue
+				}
+
+				// Get all changed properties and skip any signals that are not
+				// compliant with the Device1 interface.
+				changes, ok := sig.Body[dbusPropertiesChangedDictionary].(map[string]dbus.Variant)
+				if !ok {
+					continue
+				}
+
+				// Call the connect handler if the Connected property has changed.
+				if connected, ok := changes[bluezDevice1Connected].Value().(bool); ok {
+					// The only property received is the changed property "Connected",
+					// so we have to get the other properties from D-Bus.
+					var props map[string]dbus.Variant
+					if err := device.device.Call("org.freedesktop.DBus.Properties.GetAll",
+						0,
+						bluezDevice1Interface).Store(&props); err != nil {
+						continue
+					}
+
+					if err := device.parseProperties(&props); err != nil {
+						continue
+					}
+
+					a.adapter.connectHandler(device, connected)
+				}
 			}
 		}
 	}
 }
 
-// getDeviceProperties will fetch all known properties of a device from D-Bus
+// parseProperties will set fields from provided properties
 //
 // For all possible properties see:
 // https://github.com/luetzel/bluez/blob/master/doc/device-api.txt
-func getDeviceProperties(a *Adapter, obj dbus.BusObject) (*Device, error) {
-	var props map[string]dbus.Variant
-	if err := obj.Call("org.freedesktop.DBus.Properties.GetAll", 0, "org.bluez.Device1").Store(&props); err != nil {
-		return nil, fmt.Errorf("org.freedesktop.DBus.Properties.GetAll: %w", err)
-	}
-
-	d := Device{
-		device:  obj,
-		adapter: a,
-	}
-
-	for k, v := range props {
-		switch k {
-		case "Address":
+func (d *Device) parseProperties(props *map[string]dbus.Variant) error {
+	for prop, v := range *props {
+		switch prop {
+		case bluezDevice1Address:
 			if addrStr, ok := v.Value().(string); ok {
-				if mac, err := ParseMAC(addrStr); err == nil {
-					d.Address = Address{MACAddress: MACAddress{MAC: mac}}
+				mac, err := ParseMAC(addrStr)
+				if err != nil {
+					return fmt.Errorf("ParseMAC: %w", err)
 				}
+				d.Address = Address{MACAddress: MACAddress{MAC: mac}}
 			}
 		}
 	}
 
-	return &d, nil
+	return nil
 }


### PR DESCRIPTION
In Linux the Adapter.connectHandler is never called after Advertisement.Start.

This fix preserves the existing interfaces and adds D-Bus signals to handle connect/disconnect events once the Peripheral is advertising.

- Fix Linux Advertise.Start to call a connectHandler, if defined
- Update inline documentation for Adapter.SetConnectHandler
- Update README usage example

Potentially fixes #360 and #354.