### PR TITLE
[Windows] Fix write respond

### DIFF
--- a/gatts_windows.go
+++ b/gatts_windows.go
@@ -110,6 +110,9 @@ func (a *Adapter) AddService(s *Service) error {
 			// TODO: connection?
 			goChar.writeEvent(0, int(offset), bufferToSlice(buf))
 		}
+		if option, err := gattWriteRequest.GetOption(); err == nil && option == genericattributeprofile.GattWriteOptionWriteWithResponse {
+			gattWriteRequest.Respond()
+		}
 	})
 
 	guid = winrt.ParameterizedInstanceGUID(


### PR DESCRIPTION
gattWriteRequest.Respond needs to be called if option is GattWriteOptionWriteWithResponse. 