### PR TITLE
linux: add MTU accessor

### DIFF
--- a/gatts_linux.go
+++ b/gatts_linux.go
@@ -50,9 +50,17 @@ func (om *objectManager) GetManagedObjects() (map[dbus.ObjectPath]map[string]map
 type bluezChar struct {
 	props      *prop.Properties
 	writeEvent func(client Connection, offset int, value []byte)
+
+	mtu int
 }
 
 func (c *bluezChar) ReadValue(options map[string]dbus.Variant) ([]byte, *dbus.Error) {
+	if mtu, ok := options["mtu"]; ok {
+		// Store the MTU, so it can be retrieved later.
+		mtuValue := mtu.Value().(uint16)
+		c.mtu = int(mtuValue)
+	}
+
 	// TODO: should we use the offset value? The BlueZ documentation doesn't
 	// clearly specify this. The go-bluetooth library doesn't, but I believe it
 	// should be respected.
@@ -61,6 +69,12 @@ func (c *bluezChar) ReadValue(options map[string]dbus.Variant) ([]byte, *dbus.Er
 }
 
 func (c *bluezChar) WriteValue(value []byte, options map[string]dbus.Variant) *dbus.Error {
+	if mtu, ok := options["mtu"]; ok {
+		// Store the MTU, so it can be retrieved later.
+		mtuValue := mtu.Value().(uint16)
+		c.mtu = int(mtuValue)
+	}
+
 	if c.writeEvent != nil {
 		// BlueZ doesn't seem to tell who did the write, so pass 0 always as the
 		// connection ID.
@@ -167,4 +181,9 @@ func (c *Characteristic) Write(p []byte) (n int, err error) {
 		return 0, gattError
 	}
 	return len(p), nil
+}
+
+// MTU returns the exchanged MTU value, or zero if not available.
+func (c *Characteristic) MTU() int {
+	return c.char.mtu
 }


### PR DESCRIPTION
This PR exposes the MTU by reading it from the options of `ReadValue` and `WriteValue`. The downside of this approach is that there's no way to know the MTU if no reads and no writes have been made, but one could argue that it's not needed then. The D-Bus API doesn't seem to provide other ways to get the MTU anyways.