### PR TITLE
windows: Fix memory leak in adapter.Scan

### DIFF
--- a/gap_windows.go
+++ b/gap_windows.go
@@ -224,12 +224,21 @@ func getScanResultFromArgs(args *advertisement.BluetoothLEAdvertisementReceivedE
 		Address: adr,
 	}
 
+	winAdv, err := args.GetAdvertisement()
+	if winAdv != nil {
+		defer winAdv.Release()
+	}
+	if err != nil {
+		return result
+	}
+
 	var manufacturerData []ManufacturerDataElement
-	if winAdv, err := args.GetAdvertisement(); err == nil && winAdv != nil {
-		vector, _ := winAdv.GetManufacturerData()
-		size, _ := vector.GetSize()
-		for i := uint32(0); i < size; i++ {
-			element, _ := vector.GetAt(i)
+	mVector, _ := winAdv.GetManufacturerData()
+	if mVector != nil {
+		defer mVector.Release()
+		mSize, _ := mVector.GetSize()
+		for i := uint32(0); i < mSize; i++ {
+			element, _ := mVector.GetAt(i)
 			manData := (*advertisement.BluetoothLEManufacturerData)(element)
 			companyID, _ := manData.GetCompanyId()
 			buffer, _ := manData.GetData()
@@ -237,12 +246,13 @@ func getScanResultFromArgs(args *advertisement.BluetoothLEAdvertisementReceivedE
 				CompanyID: companyID,
 				Data:      bufferToSlice(buffer),
 			})
+			buffer.Release()
+			manData.Release()
 		}
 	}
 
 	// Note: the IsRandom bit is never set.
-	advertisement, _ := args.GetAdvertisement()
-	localName, _ := advertisement.GetLocalName()
+	localName, _ := winAdv.GetLocalName()
 	result.AdvertisementPayload = &advertisementFields{
 		AdvertisementFields{
 			LocalName:        localName,

--- a/gap_windows.go
+++ b/gap_windows.go
@@ -225,12 +225,10 @@ func getScanResultFromArgs(args *advertisement.BluetoothLEAdvertisementReceivedE
 	}
 
 	winAdv, err := args.GetAdvertisement()
-	if winAdv != nil {
-		defer winAdv.Release()
-	}
 	if err != nil {
 		return result
 	}
+	defer winAdv.Release()
 
 	var manufacturerData []ManufacturerDataElement
 	mVector, _ := winAdv.GetManufacturerData()


### PR DESCRIPTION
Actual leaks occour in [`getScanResultFromArgs`](https://github.com/tinygo-org/bluetooth/blob/5c615298c3e4400150c44da3636f3d3b10967e3c/gap_windows.go#L213).

Added releasing for `BluetoothLEAdvertisement`, `ManufacturerData IVector` and its `BluetoothLEManufacturerData` elements.

Fixes #355 