### PR TITLE
make uuid api safer

### DIFF
--- a/att_hci.go
+++ b/att_hci.go
@@ -118,7 +118,7 @@ func (s *rawService) Read(p []byte) (int, error) {
 		binary.LittleEndian.PutUint16(p[4:], s.uuid.Get16Bit())
 		sz += 2
 	default:
-		uuid := s.uuid.Bytes()
+		uuid := s.uuid.bytes()
 		copy(p[4:], uuid[:])
 		sz += 16
 	}
@@ -166,7 +166,7 @@ func (c *rawCharacteristic) Read(p []byte) (int, error) {
 		binary.LittleEndian.PutUint16(p[5:], c.uuid.Get16Bit())
 		sz += 2
 	default:
-		uuid := c.uuid.Bytes()
+		uuid := c.uuid.bytes()
 		copy(p[5:], uuid[:])
 		sz += 16
 	}
@@ -232,7 +232,7 @@ func (a *rawAttribute) Read(p []byte) (int, error) {
 			binary.LittleEndian.PutUint16(p[sz:], a.uuid.Get16Bit())
 			sz += 2
 		default:
-			uuid := a.uuid.Bytes()
+			uuid := a.uuid.bytes()
 			copy(p[sz:], uuid[:])
 			sz += 16
 		}

--- a/gap.go
+++ b/gap.go
@@ -316,7 +316,7 @@ func (buf *rawAdvertisementPayload) HasServiceUUID(uuid UUID) bool {
 		if len(b) == 0 {
 			b = buf.findField(0x06) // Incomplete List of 128-bit Service Class UUIDs
 		}
-		uuidBuf1 := uuid.Bytes()
+		uuidBuf1 := uuid.bytes()
 		for i := 0; i < len(b)/16; i++ {
 			uuidBuf2 := b[i*16 : i*16+16]
 			match := true
@@ -519,7 +519,7 @@ func (buf *rawAdvertisementPayload) addServiceData(uuid UUID, data []byte) (ok b
 		// Add the data.
 		buf.data[buf.len+0] = byte(fieldLength - 1)
 		buf.data[buf.len+1] = 0x21
-		uuid_bytes := uuid.Bytes()
+		uuid_bytes := uuid.bytes()
 		copy(buf.data[buf.len+2:], uuid_bytes[:])
 		copy(buf.data[buf.len+2+16:], data)
 		buf.len += uint8(fieldLength)
@@ -579,7 +579,7 @@ func (buf *rawAdvertisementPayload) addServiceUUID(uuid UUID) (ok bool) {
 		}
 		buf.data[buf.len+0] = 17   // length of field, including type
 		buf.data[buf.len+1] = 0x07 // type, 0x07 means "Complete List of 128-bit Service Class UUIDs"
-		rawUUID := uuid.Bytes()
+		rawUUID := uuid.bytes()
 		copy(buf.data[buf.len+2:], rawUUID[:])
 		buf.len += 18
 		return true

--- a/gap_hci.go
+++ b/gap_hci.go
@@ -420,7 +420,7 @@ func (a *Advertisement) Start() error {
 			binary.LittleEndian.PutUint16(advertisingData[5:], uuid.Get16Bit())
 		case uuid.Is32Bit():
 			sz = 6
-			data := uuid.Bytes()
+			data := uuid.bytes()
 			slices.Reverse(data[:])
 			copy(advertisingData[5:], data[:])
 		}

--- a/gap_test.go
+++ b/gap_test.go
@@ -137,7 +137,7 @@ func TestServiceUUIDs(t *testing.T) {
 		raw      string
 		expected []UUID
 	}
-	uuidBytes := ServiceUUIDAdafruitSound.Bytes()
+	uuidBytes := ServiceUUIDAdafruitSound.bytes()
 	tests := []testCase{
 		{},
 		{

--- a/gatts_hci.go
+++ b/gatts_hci.go
@@ -13,13 +13,13 @@ type Characteristic struct {
 // AddService creates a new service with the characteristics listed in the
 // Service struct.
 func (a *Adapter) AddService(service *Service) error {
-	uuid := service.UUID.Bytes()
+	uuid := service.UUID.bytes()
 	serviceHandle := a.att.addLocalAttribute(attributeTypeService, 0, shortUUID(gattServiceUUID).UUID(), 0, uuid[:])
 	valueHandle := serviceHandle
 	endHandle := serviceHandle
 
 	for i := range service.Characteristics {
-		data := service.Characteristics[i].UUID.Bytes()
+		data := service.Characteristics[i].UUID.bytes()
 		cuuid := append([]byte{}, data[:]...)
 
 		// add characteristic declaration

--- a/tools/gen-characteristic-uuids/main.go
+++ b/tools/gen-characteristic-uuids/main.go
@@ -45,7 +45,7 @@ func (c Characteristic) UUIDFunc() string {
 	if err != nil {
 		panic(err)
 	}
-	b := uuid.Bytes()
+	b := uuid.bytes()
 	bs := hex.EncodeToString(b[:])
 	bss := ""
 	for i := 0; i < len(bs); i += 2 {

--- a/tools/gen-service-uuids/main.go
+++ b/tools/gen-service-uuids/main.go
@@ -45,7 +45,7 @@ func (s Service) UUIDFunc() string {
 	if err != nil {
 		panic(err)
 	}
-	b := uuid.Bytes()
+	b := uuid.bytes()
 	bs := hex.EncodeToString(b[:])
 	bss := ""
 	for i := 0; i < len(bs); i += 2 {

--- a/uuid.go
+++ b/uuid.go
@@ -10,18 +10,20 @@ import (
 
 // UUID is a single UUID as used in the Bluetooth stack. It is represented as a
 // [4]uint32 instead of a [16]byte for efficiency.
-type UUID [4]uint32
+type UUID struct {
+	id [4]uint32
+}
 
 var errInvalidUUID = errors.New("bluetooth: failed to parse UUID")
 
 // NewUUID returns a new UUID based on the 128-bit (or 16-byte) input.
 func NewUUID(uuid [16]byte) UUID {
-	u := UUID{}
-	u[0] = uint32(uuid[15]) | uint32(uuid[14])<<8 | uint32(uuid[13])<<16 | uint32(uuid[12])<<24
-	u[1] = uint32(uuid[11]) | uint32(uuid[10])<<8 | uint32(uuid[9])<<16 | uint32(uuid[8])<<24
-	u[2] = uint32(uuid[7]) | uint32(uuid[6])<<8 | uint32(uuid[5])<<16 | uint32(uuid[4])<<24
-	u[3] = uint32(uuid[3]) | uint32(uuid[2])<<8 | uint32(uuid[1])<<16 | uint32(uuid[0])<<24
-	return u
+	uu := UUID{}
+	uu.id[0] = uint32(uuid[15]) | uint32(uuid[14])<<8 | uint32(uuid[13])<<16 | uint32(uuid[12])<<24
+	uu.id[1] = uint32(uuid[11]) | uint32(uuid[10])<<8 | uint32(uuid[9])<<16 | uint32(uuid[8])<<24
+	uu.id[2] = uint32(uuid[7]) | uint32(uuid[6])<<8 | uint32(uuid[5])<<16 | uint32(uuid[4])<<24
+	uu.id[3] = uint32(uuid[3]) | uint32(uuid[2])<<8 | uint32(uuid[1])<<16 | uint32(uuid[0])<<24
+	return uu
 }
 
 // New16BitUUID returns a new 128-bit UUID based on a 16-bit UUID.
@@ -29,13 +31,13 @@ func NewUUID(uuid [16]byte) UUID {
 // Note: only use registered UUIDs. See
 // https://www.bluetooth.com/specifications/gatt/services/ for a list.
 func New16BitUUID(shortUUID uint16) UUID {
-	// https://stackoverflow.com/questions/36212020/how-can-i-convert-a-bluetooth-16-bit-service-uuid-into-a-128-bit-uuid
-	var uuid UUID
-	uuid[0] = 0x5F9B34FB
-	uuid[1] = 0x80000080
-	uuid[2] = 0x00001000
-	uuid[3] = uint32(shortUUID)
-	return uuid
+	// https://stackoverflow.com/questions/36212020/how-can-i-convert-a-bluetooth-16-bit-service-uu-into-a-128-bit-uu
+	var uu UUID
+	uu.id[0] = 0x5F9B34FB
+	uu.id[1] = 0x80000080
+	uu.id[2] = 0x00001000
+	uu.id[3] = uint32(shortUUID)
+	return uu
 }
 
 // New32BitUUID returns a new 128-bit UUID based on a 32-bit UUID.
@@ -44,12 +46,12 @@ func New16BitUUID(shortUUID uint16) UUID {
 // https://www.bluetooth.com/specifications/gatt/services/ for a list.
 func New32BitUUID(shortUUID uint32) UUID {
 	// https://stackoverflow.com/questions/36212020/how-can-i-convert-a-bluetooth-16-bit-service-uuid-into-a-128-bit-uuid
-	var uuid UUID
-	uuid[0] = 0x5F9B34FB
-	uuid[1] = 0x80000080
-	uuid[2] = 0x00001000
-	uuid[3] = shortUUID
-	return uuid
+	var uu UUID
+	uu.id[0] = 0x5F9B34FB
+	uu.id[1] = 0x80000080
+	uu.id[2] = 0x00001000
+	uu.id[3] = shortUUID
+	return uu
 }
 
 // Replace16BitComponent returns a new UUID where bits 16..32 have been replaced
@@ -59,19 +61,19 @@ func New32BitUUID(shortUUID uint32) UUID {
 // This is especially useful for the Nordic SoftDevice, because it is able to
 // store custom UUIDs more efficiently when only these bits vary between them.
 func (uuid UUID) Replace16BitComponent(component uint16) UUID {
-	uuid[3] &^= 0x0000ffff       // clear the new component bits
-	uuid[3] |= uint32(component) // set the component bits
+	uuid.id[3] &^= 0x0000ffff       // clear the new component bits
+	uuid.id[3] |= uint32(component) // set the component bits
 	return uuid
 }
 
 // Is16Bit returns whether this UUID is a 16-bit BLE UUID.
 func (uuid UUID) Is16Bit() bool {
-	return uuid.Is32Bit() && uuid[3] == uint32(uint16(uuid[3]))
+	return uuid.Is32Bit() && uuid.id[3] == uint32(uint16(uuid.id[3]))
 }
 
 // Is32Bit returns whether this UUID is a 32-bit or 16-bit BLE UUID.
 func (uuid UUID) Is32Bit() bool {
-	return uuid[0] == 0x5F9B34FB && uuid[1] == 0x80000080 && uuid[2] == 0x00001000
+	return uuid.id[0] == 0x5F9B34FB && uuid.id[1] == 0x80000080 && uuid.id[2] == 0x00001000
 }
 
 // Get16Bit returns the 16-bit version of this UUID. This is only valid if it
@@ -79,7 +81,7 @@ func (uuid UUID) Is32Bit() bool {
 func (uuid UUID) Get16Bit() uint16 {
 	// Note: using a Get* function as a getter because method names can't start
 	// with a number.
-	return uint16(uuid[3])
+	return uint16(uuid.id[3])
 }
 
 // Get32Bit returns the 32-bit version of this UUID. This is only valid if it
@@ -87,54 +89,65 @@ func (uuid UUID) Get16Bit() uint16 {
 func (uuid UUID) Get32Bit() uint32 {
 	// Note: using a Get* function as a getter because method names can't start
 	// with a number.
-	return uuid[3]
+	return uuid.id[3]
 }
 
-// Bytes returns a 16-byte array containing the raw UUID.
-func (uuid UUID) Bytes() [16]byte {
-	buf := [16]byte{}
-	buf[0] = byte(uuid[0])
-	buf[1] = byte(uuid[0] >> 8)
-	buf[2] = byte(uuid[0] >> 16)
-	buf[3] = byte(uuid[0] >> 24)
-	buf[4] = byte(uuid[1])
-	buf[5] = byte(uuid[1] >> 8)
-	buf[6] = byte(uuid[1] >> 16)
-	buf[7] = byte(uuid[1] >> 24)
-	buf[8] = byte(uuid[2])
-	buf[9] = byte(uuid[2] >> 8)
-	buf[10] = byte(uuid[2] >> 16)
-	buf[11] = byte(uuid[2] >> 24)
-	buf[12] = byte(uuid[3])
-	buf[13] = byte(uuid[3] >> 8)
-	buf[14] = byte(uuid[3] >> 16)
-	buf[15] = byte(uuid[3] >> 24)
-	return buf
+// BytesBytesBigEndian returns a 16-byte array containing the raw UUID in
+// network order. The result from BytesBigEndian may be used as the input for
+// NewUUID.
+func (uuid UUID) BytesBigEndian() [16]byte {
+	return [16]byte{
+		0:  byte(uuid.id[3] >> 24),
+		1:  byte(uuid.id[3] >> 16),
+		2:  byte(uuid.id[3] >> 8),
+		3:  byte(uuid.id[3]),
+		4:  byte(uuid.id[2] >> 24),
+		5:  byte(uuid.id[2] >> 16),
+		6:  byte(uuid.id[2] >> 8),
+		7:  byte(uuid.id[2]),
+		8:  byte(uuid.id[1] >> 24),
+		9:  byte(uuid.id[1] >> 16),
+		10: byte(uuid.id[1] >> 8),
+		11: byte(uuid.id[1]),
+		12: byte(uuid.id[0] >> 24),
+		13: byte(uuid.id[0] >> 16),
+		14: byte(uuid.id[0] >> 8),
+		15: byte(uuid.id[0]),
+	}
 }
 
-// AppendBinary appends the bytes of the uuid to the given byte slice b.
+// bytes returns a 16-byte array containing the raw UUID in little-endian
+// order.
+func (uuid UUID) bytes() [16]byte {
+	return [16]byte{
+		0:  byte(uuid.id[0]),
+		1:  byte(uuid.id[0] >> 8),
+		2:  byte(uuid.id[0] >> 16),
+		3:  byte(uuid.id[0] >> 24),
+		4:  byte(uuid.id[1]),
+		5:  byte(uuid.id[1] >> 8),
+		6:  byte(uuid.id[1] >> 16),
+		7:  byte(uuid.id[1] >> 24),
+		8:  byte(uuid.id[2]),
+		9:  byte(uuid.id[2] >> 8),
+		10: byte(uuid.id[2] >> 16),
+		11: byte(uuid.id[2] >> 24),
+		12: byte(uuid.id[3]),
+		13: byte(uuid.id[3] >> 8),
+		14: byte(uuid.id[3] >> 16),
+		15: byte(uuid.id[3] >> 24),
+	}
+}
+
+// AppendBinary appends the bytes of the uuid in little-endian order to the
+// given byte slice b.
 func (uuid UUID) AppendBinary(b []byte) ([]byte, error) {
-	return append(b,
-		byte(uuid[0]),
-		byte(uuid[0]>>8),
-		byte(uuid[0]>>16),
-		byte(uuid[0]>>24),
-		byte(uuid[1]),
-		byte(uuid[1]>>8),
-		byte(uuid[1]>>16),
-		byte(uuid[1]>>24),
-		byte(uuid[2]),
-		byte(uuid[2]>>8),
-		byte(uuid[2]>>16),
-		byte(uuid[2]>>24),
-		byte(uuid[3]),
-		byte(uuid[3]>>8),
-		byte(uuid[3]>>16),
-		byte(uuid[3]>>24),
-	), nil
+	id := uuid.bytes()
+	return append(b, id[:]...), nil
 }
 
-// MarshalBinary marshals the uuid into and byte slice and returns the slice.  It will not return an error
+// MarshalBinary marshals the uuid into and byte slice in little-endian order
+// and returns the slice. It will not return an error.
 func (uuid UUID) MarshalBinary() (data []byte, err error) {
 	return uuid.AppendBinary(make([]byte, 0, 16))
 }
@@ -191,25 +204,25 @@ func (u *UUID) unmarshalText128(s []byte) error {
 		if reverseHexTable[s[j]] == 255 {
 			return errInvalidUUID
 		}
-		u[i] |= uint32(reverseHexTable[s[j]]) << 28
+		u.id[i] |= uint32(reverseHexTable[s[j]]) << 28
 		j++
 
 		if reverseHexTable[s[j]] == 255 {
 			return errInvalidUUID
 		}
-		u[i] |= uint32(reverseHexTable[s[j]]) << 24
+		u.id[i] |= uint32(reverseHexTable[s[j]]) << 24
 		j++
 
 		if reverseHexTable[s[j]] == 255 {
 			return errInvalidUUID
 		}
-		u[i] |= uint32(reverseHexTable[s[j]]) << 20
+		u.id[i] |= uint32(reverseHexTable[s[j]]) << 20
 		j++
 
 		if reverseHexTable[s[j]] == 255 {
 			return errInvalidUUID
 		}
-		u[i] |= uint32(reverseHexTable[s[j]]) << 16
+		u.id[i] |= uint32(reverseHexTable[s[j]]) << 16
 		j++
 
 		// skip hypens
@@ -220,25 +233,25 @@ func (u *UUID) unmarshalText128(s []byte) error {
 		if reverseHexTable[s[j]] == 255 {
 			return errInvalidUUID
 		}
-		u[i] |= uint32(reverseHexTable[s[j]]) << 12
+		u.id[i] |= uint32(reverseHexTable[s[j]]) << 12
 		j++
 
 		if reverseHexTable[s[j]] == 255 {
 			return errInvalidUUID
 		}
-		u[i] |= uint32(reverseHexTable[s[j]]) << 8
+		u.id[i] |= uint32(reverseHexTable[s[j]]) << 8
 		j++
 
 		if reverseHexTable[s[j]] == 255 {
 			return errInvalidUUID
 		}
-		u[i] |= uint32(reverseHexTable[s[j]]) << 4
+		u.id[i] |= uint32(reverseHexTable[s[j]]) << 4
 		j++
 
 		if reverseHexTable[s[j]] == 255 {
 			return errInvalidUUID
 		}
-		u[i] |= uint32(reverseHexTable[s[j]])
+		u.id[i] |= uint32(reverseHexTable[s[j]])
 		j++
 	}
 
@@ -248,58 +261,58 @@ func (u *UUID) unmarshalText128(s []byte) error {
 // Using the reverseHexTable rebuild the UUID from the string s represented in bytes
 // This implementation is the inverse of MarshalText and reaches performance pairity
 func (u *UUID) unmarshalText32(s []byte) error {
-	u[0] = 0x5F9B34FB
-	u[1] = 0x80000080
-	u[2] = 0x00001000
+	u.id[0] = 0x5F9B34FB
+	u.id[1] = 0x80000080
+	u.id[2] = 0x00001000
 
 	var j uint8 = 0
 
 	if reverseHexTable[s[j]] == 255 {
 		return errInvalidUUID
 	}
-	u[3] |= uint32(reverseHexTable[s[j]]) << 28
+	u.id[3] |= uint32(reverseHexTable[s[j]]) << 28
 	j++
 
 	if reverseHexTable[s[j]] == 255 {
 		return errInvalidUUID
 	}
-	u[3] |= uint32(reverseHexTable[s[j]]) << 24
+	u.id[3] |= uint32(reverseHexTable[s[j]]) << 24
 	j++
 
 	if reverseHexTable[s[j]] == 255 {
 		return errInvalidUUID
 	}
-	u[3] |= uint32(reverseHexTable[s[j]]) << 20
+	u.id[3] |= uint32(reverseHexTable[s[j]]) << 20
 	j++
 
 	if reverseHexTable[s[j]] == 255 {
 		return errInvalidUUID
 	}
-	u[3] |= uint32(reverseHexTable[s[j]]) << 16
+	u.id[3] |= uint32(reverseHexTable[s[j]]) << 16
 	j++
 
 	if reverseHexTable[s[j]] == 255 {
 		return errInvalidUUID
 	}
-	u[3] |= uint32(reverseHexTable[s[j]]) << 12
+	u.id[3] |= uint32(reverseHexTable[s[j]]) << 12
 	j++
 
 	if reverseHexTable[s[j]] == 255 {
 		return errInvalidUUID
 	}
-	u[3] |= uint32(reverseHexTable[s[j]]) << 8
+	u.id[3] |= uint32(reverseHexTable[s[j]]) << 8
 	j++
 
 	if reverseHexTable[s[j]] == 255 {
 		return errInvalidUUID
 	}
-	u[3] |= uint32(reverseHexTable[s[j]]) << 4
+	u.id[3] |= uint32(reverseHexTable[s[j]]) << 4
 	j++
 
 	if reverseHexTable[s[j]] == 255 {
 		return errInvalidUUID
 	}
-	u[3] |= uint32(reverseHexTable[s[j]])
+	u.id[3] |= uint32(reverseHexTable[s[j]])
 	j++
 
 	return nil
@@ -308,33 +321,33 @@ func (u *UUID) unmarshalText32(s []byte) error {
 // Using the reverseHexTable rebuild the UUID from the string s represented in bytes
 // This implementation is the inverse of MarshalText and reaches performance pairity
 func (u *UUID) unmarshalText16(s []byte) error {
-	u[0] = 0x5F9B34FB
-	u[1] = 0x80000080
-	u[2] = 0x00001000
+	u.id[0] = 0x5F9B34FB
+	u.id[1] = 0x80000080
+	u.id[2] = 0x00001000
 
 	var j uint8 = 0
 	if reverseHexTable[s[j]] == 255 {
 		return errInvalidUUID
 	}
-	u[3] |= uint32(reverseHexTable[s[j]]) << 12
+	u.id[3] |= uint32(reverseHexTable[s[j]]) << 12
 	j++
 
 	if reverseHexTable[s[j]] == 255 {
 		return errInvalidUUID
 	}
-	u[3] |= uint32(reverseHexTable[s[j]]) << 8
+	u.id[3] |= uint32(reverseHexTable[s[j]]) << 8
 	j++
 
 	if reverseHexTable[s[j]] == 255 {
 		return errInvalidUUID
 	}
-	u[3] |= uint32(reverseHexTable[s[j]]) << 4
+	u.id[3] |= uint32(reverseHexTable[s[j]]) << 4
 	j++
 
 	if reverseHexTable[s[j]] == 255 {
 		return errInvalidUUID
 	}
-	u[3] |= uint32(reverseHexTable[s[j]])
+	u.id[3] |= uint32(reverseHexTable[s[j]])
 	j++
 
 	return nil
@@ -377,11 +390,11 @@ func (u UUID) AppendText(buf []byte) ([]byte, error) {
 			buf = append(buf, '-')
 		}
 
-		buf = append(buf, hexDigitLower[byte(u[i]>>24)>>4])
-		buf = append(buf, hexDigitLower[byte(u[i]>>24)&0xF])
+		buf = append(buf, hexDigitLower[byte(u.id[i]>>24)>>4])
+		buf = append(buf, hexDigitLower[byte(u.id[i]>>24)&0xF])
 
-		buf = append(buf, hexDigitLower[byte(u[i]>>16)>>4])
-		buf = append(buf, hexDigitLower[byte(u[i]>>16)&0xF])
+		buf = append(buf, hexDigitLower[byte(u.id[i]>>16)>>4])
+		buf = append(buf, hexDigitLower[byte(u.id[i]>>16)&0xF])
 
 		// Insert a hyphen at the correct locations.
 		// position 6 and 10
@@ -389,11 +402,11 @@ func (u UUID) AppendText(buf []byte) ([]byte, error) {
 			buf = append(buf, '-')
 		}
 
-		buf = append(buf, hexDigitLower[byte(u[i]>>8)>>4])
-		buf = append(buf, hexDigitLower[byte(u[i]>>8)&0xF])
+		buf = append(buf, hexDigitLower[byte(u.id[i]>>8)>>4])
+		buf = append(buf, hexDigitLower[byte(u.id[i]>>8)&0xF])
 
-		buf = append(buf, hexDigitLower[byte(u[i])>>4])
-		buf = append(buf, hexDigitLower[byte(u[i])&0xF])
+		buf = append(buf, hexDigitLower[byte(u.id[i])>>4])
+		buf = append(buf, hexDigitLower[byte(u.id[i])&0xF])
 	}
 
 	return buf, nil
@@ -408,15 +421,15 @@ func (u UUID) MarshalText() ([]byte, error) {
 
 var ErrInvalidBinaryUUID = errors.New("bluetooth: failed to unmarshal the given binary UUID")
 
-// UnmarshalBinary copies the given uuid bytes onto itself
+// UnmarshalBinary copies the given uuid bytes in little-endian order onto itself.
 func (u *UUID) UnmarshalBinary(uuid []byte) error {
 	if len(uuid) != 16 {
 		return ErrInvalidBinaryUUID
 	}
 
-	u[0] = uint32(uuid[0]) | uint32(uuid[1])<<8 | uint32(uuid[2])<<16 | uint32(uuid[3])<<24
-	u[1] = uint32(uuid[4]) | uint32(uuid[5])<<8 | uint32(uuid[6])<<16 | uint32(uuid[7])<<24
-	u[2] = uint32(uuid[8]) | uint32(uuid[9])<<8 | uint32(uuid[10])<<16 | uint32(uuid[11])<<24
-	u[3] = uint32(uuid[12]) | uint32(uuid[13])<<8 | uint32(uuid[14])<<16 | uint32(uuid[15])<<24
+	u.id[0] = uint32(uuid[0]) | uint32(uuid[1])<<8 | uint32(uuid[2])<<16 | uint32(uuid[3])<<24
+	u.id[1] = uint32(uuid[4]) | uint32(uuid[5])<<8 | uint32(uuid[6])<<16 | uint32(uuid[7])<<24
+	u.id[2] = uint32(uuid[8]) | uint32(uuid[9])<<8 | uint32(uuid[10])<<16 | uint32(uuid[11])<<24
+	u.id[3] = uint32(uuid[12]) | uint32(uuid[13])<<8 | uint32(uuid[14])<<16 | uint32(uuid[15])<<24
 	return nil
 }

--- a/uuid_sd.go
+++ b/uuid_sd.go
@@ -12,12 +12,12 @@ type shortUUID C.ble_uuid_t
 
 func (uuid UUID) shortUUID() (C.ble_uuid_t, C.uint32_t) {
 	var short C.ble_uuid_t
-	short.uuid = C.uint16_t(uuid[3])
+	short.uuid = C.uint16_t(uuid.id[3])
 	if uuid.Is16Bit() {
 		short._type = C.BLE_UUID_TYPE_BLE
 		return short, 0
 	}
-	errCode := C.sd_ble_uuid_vs_add((*C.ble_uuid128_t)(unsafe.Pointer(&uuid[0])), &short._type)
+	errCode := C.sd_ble_uuid_vs_add((*C.ble_uuid128_t)(unsafe.Pointer(&uuid.id[0])), &short._type)
 	return short, errCode
 }
 
@@ -28,7 +28,7 @@ func (s shortUUID) UUID() UUID {
 	}
 	var outLen C.uint8_t
 	var outUUID UUID
-	C.sd_ble_uuid_encode(((*C.ble_uuid_t)(unsafe.Pointer(&s))), &outLen, ((*C.uint8_t)(unsafe.Pointer(&outUUID))))
+	C.sd_ble_uuid_encode(((*C.ble_uuid_t)(unsafe.Pointer(&s))), &outLen, ((*C.uint8_t)(unsafe.Pointer(&outUUID.id))))
 	return outUUID
 }
 

--- a/uuid_test.go
+++ b/uuid_test.go
@@ -100,6 +100,14 @@ func TestNewUUID(t *testing.T) {
 	}
 }
 
+func TestUUIDBytesRoundTrip(t *testing.T) {
+	uuid := NewUUID([16]byte{0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9, 0xa, 0xb, 0xc, 0xd, 0xe, 0xf})
+	rt := NewUUID(uuid.BytesBigEndian())
+	if uuid != rt {
+		t.Errorf("%s does not match %s", uuid, rt)
+	}
+}
+
 func BenchmarkUUIDToString(b *testing.B) {
 	uuid, e := ParseUUID("00001234-0000-1000-8000-00805f9b34fb")
 	if e != nil {


### PR DESCRIPTION
Unexpose the representation of the UUID data and unexport the Bytes method. Also document the byte ordering of binary marshaling and provide an exported binary round-tripper for UUID data.

Please take a look.

Closes #316 