### PR TITLE
fix(darwin): WriteWithoutResponse checks CanSendWriteWithoutResponse before request

### DIFF
--- a/gattc.go
+++ b/gattc.go
@@ -1,0 +1,5 @@
+package bluetooth
+
+import "errors"
+
+var ErrCannotSendWriteWithoutResponse = errors.New("cannot send write without response")

--- a/gattc.go
+++ b/gattc.go
@@ -1,5 +1,0 @@
-package bluetooth
-
-import "errors"
-
-var ErrCannotSendWriteWithoutResponse = errors.New("cannot send write without response")

--- a/gattc_darwin.go
+++ b/gattc_darwin.go
@@ -7,6 +7,10 @@ import (
 	"github.com/tinygo-org/cbgo"
 )
 
+var (
+	errCannotSendWriteWithoutResponse = errors.New("bluetooth: cannot send write without response (buffer full)")
+)
+
 // DiscoverServices starts a service discovery procedure. Pass a list of service
 // UUIDs you are interested in to this function. Either a slice of all services
 // is returned (of the same length as the requested UUIDs and in the same
@@ -203,7 +207,7 @@ func (c DeviceCharacteristic) Write(p []byte) (n int, err error) {
 // If the client is not ready to send write without response requests at this time, ErrCannotSendWriteWithoutResponse is returned.
 func (c DeviceCharacteristic) WriteWithoutResponse(p []byte) (int, error) {
 	if !c.service.device.prph.CanSendWriteWithoutResponse() {
-		return 0, ErrCannotSendWriteWithoutResponse
+		return 0, errCannotSendWriteWithoutResponse
 	}
 
 	c.service.device.prph.WriteCharacteristic(p, c.characteristic, false)
@@ -229,14 +233,6 @@ func (c DeviceCharacteristic) EnableNotifications(callback func(buf []byte)) err
 // GetMTU returns the MTU for the characteristic.
 func (c DeviceCharacteristic) GetMTU() (uint16, error) {
 	return uint16(c.service.device.prph.MaximumWriteValueLength(false)), nil
-}
-
-// CanSendWriteWithoutResponse returns whether a WriteWithoutResponse can be sent
-// at this time. If this returns false, you must wait for some time before
-// sending another WriteWithoutResponse. This is typically because the internal
-// buffer is full.
-func (c DeviceCharacteristic) CanSendWriteWithoutResponse() bool {
-	return c.service.device.prph.CanSendWriteWithoutResponse()
 }
 
 // Read reads the current characteristic value.

--- a/gattc_darwin.go
+++ b/gattc_darwin.go
@@ -201,7 +201,7 @@ func (c DeviceCharacteristic) Write(p []byte) (n int, err error) {
 // call will return before all data has been written. A limited number of such
 // writes can be in flight at any given time.
 // If the client is not ready to send write without response requests at this time, ErrCannotSendWriteWithoutResponse is returned.
-func (c DeviceCharacteristic) WriteWithoutResponse(p []byte) (n int, err error) {
+func (c DeviceCharacteristic) WriteWithoutResponse(p []byte) (int, error) {
 	if !c.service.device.prph.CanSendWriteWithoutResponse() {
 		return 0, ErrCannotSendWriteWithoutResponse
 	}
@@ -234,8 +234,7 @@ func (c DeviceCharacteristic) GetMTU() (uint16, error) {
 // CanSendWriteWithoutResponse returns whether a WriteWithoutResponse can be sent
 // at this time. If this returns false, you must wait for some time before
 // sending another WriteWithoutResponse. This is typically because the internal
-// buffer is full. You can use this to implement your own flow control when
-// sending many WriteWithoutResponse calls in a row.
+// buffer is full.
 func (c DeviceCharacteristic) CanSendWriteWithoutResponse() bool {
 	return c.service.device.prph.CanSendWriteWithoutResponse()
 }

--- a/gattc_darwin.go
+++ b/gattc_darwin.go
@@ -2,7 +2,6 @@ package bluetooth
 
 import (
 	"errors"
-	"sync"
 	"time"
 
 	"github.com/tinygo-org/cbgo"
@@ -146,10 +145,9 @@ func (s DeviceService) DiscoverCharacteristics(uuids []UUID) ([]DeviceCharacteri
 func (s DeviceService) makeCharacteristic(uuid UUID, dchar cbgo.Characteristic) DeviceCharacteristic {
 	char := DeviceCharacteristic{
 		deviceCharacteristic: &deviceCharacteristic{
-			uuidWrapper:            uuid,
-			service:                s,
-			characteristic:         dchar,
-			writeWithoutResponseMx: sync.Mutex{},
+			uuidWrapper:    uuid,
+			service:        s,
+			characteristic: dchar,
 		},
 	}
 	s.characteristics = append(s.characteristics, char)
@@ -167,11 +165,10 @@ type deviceCharacteristic struct {
 
 	service DeviceService
 
-	characteristic         cbgo.Characteristic
-	callback               func(buf []byte)
-	readChan               chan error
-	writeChan              chan error
-	writeWithoutResponseMx sync.Mutex
+	characteristic cbgo.Characteristic
+	callback       func(buf []byte)
+	readChan       chan error
+	writeChan      chan error
 }
 
 // UUID returns the UUID for this DeviceCharacteristic.
@@ -205,9 +202,6 @@ func (c DeviceCharacteristic) Write(p []byte) (n int, err error) {
 // writes can be in flight at any given time.
 // If the client is not ready to send write without response requests at this time, ErrCannotSendWriteWithoutResponse is returned.
 func (c DeviceCharacteristic) WriteWithoutResponse(p []byte) (n int, err error) {
-	c.writeWithoutResponseMx.Lock()
-	defer c.writeWithoutResponseMx.Unlock()
-
 	if !c.service.device.prph.CanSendWriteWithoutResponse() {
 		return 0, ErrCannotSendWriteWithoutResponse
 	}

--- a/gattc_darwin.go
+++ b/gattc_darwin.go
@@ -204,7 +204,7 @@ func (c DeviceCharacteristic) Write(p []byte) (n int, err error) {
 // WriteWithoutResponse replaces the characteristic value with a new value. The
 // call will return before all data has been written. A limited number of such
 // writes can be in flight at any given time.
-// If the client is not ready to send write without response requests at this time, ErrCannotSendWriteWithoutResponse is returned.
+// If the client is not ready to send write without response requests at this time (e.g. because the internal buffer is full), an error is returned.
 func (c DeviceCharacteristic) WriteWithoutResponse(p []byte) (int, error) {
 	if !c.service.device.prph.CanSendWriteWithoutResponse() {
 		return 0, errCannotSendWriteWithoutResponse

--- a/gattc_darwin.go
+++ b/gattc_darwin.go
@@ -2,6 +2,7 @@ package bluetooth
 
 import (
 	"errors"
+	"sync"
 	"time"
 
 	"github.com/tinygo-org/cbgo"
@@ -145,9 +146,10 @@ func (s DeviceService) DiscoverCharacteristics(uuids []UUID) ([]DeviceCharacteri
 func (s DeviceService) makeCharacteristic(uuid UUID, dchar cbgo.Characteristic) DeviceCharacteristic {
 	char := DeviceCharacteristic{
 		deviceCharacteristic: &deviceCharacteristic{
-			uuidWrapper:    uuid,
-			service:        s,
-			characteristic: dchar,
+			uuidWrapper:            uuid,
+			service:                s,
+			characteristic:         dchar,
+			writeWithoutResponseMx: sync.Mutex{},
 		},
 	}
 	s.characteristics = append(s.characteristics, char)
@@ -165,10 +167,11 @@ type deviceCharacteristic struct {
 
 	service DeviceService
 
-	characteristic cbgo.Characteristic
-	callback       func(buf []byte)
-	readChan       chan error
-	writeChan      chan error
+	characteristic         cbgo.Characteristic
+	callback               func(buf []byte)
+	readChan               chan error
+	writeChan              chan error
+	writeWithoutResponseMx sync.Mutex
 }
 
 // UUID returns the UUID for this DeviceCharacteristic.
@@ -200,9 +203,15 @@ func (c DeviceCharacteristic) Write(p []byte) (n int, err error) {
 // WriteWithoutResponse replaces the characteristic value with a new value. The
 // call will return before all data has been written. A limited number of such
 // writes can be in flight at any given time.
-// You can use CanSendWriteWithoutResponse to check if you can send more writes.
-// This call is also known as a "write command" (as opposed to a write request).
+// If the client is not ready to send write without response requests at this time, ErrCannotSendWriteWithoutResponse is returned.
 func (c DeviceCharacteristic) WriteWithoutResponse(p []byte) (n int, err error) {
+	c.writeWithoutResponseMx.Lock()
+	defer c.writeWithoutResponseMx.Unlock()
+
+	if !c.service.device.prph.CanSendWriteWithoutResponse() {
+		return 0, ErrCannotSendWriteWithoutResponse
+	}
+
 	c.service.device.prph.WriteCharacteristic(p, c.characteristic, false)
 
 	return len(p), nil

--- a/gattc_darwin.go
+++ b/gattc_darwin.go
@@ -199,8 +199,9 @@ func (c DeviceCharacteristic) Write(p []byte) (n int, err error) {
 
 // WriteWithoutResponse replaces the characteristic value with a new value. The
 // call will return before all data has been written. A limited number of such
-// writes can be in flight at any given time. This call is also known as a
-// "write command" (as opposed to a write request).
+// writes can be in flight at any given time.
+// You can use CanSendWriteWithoutResponse to check if you can send more writes.
+// This call is also known as a "write command" (as opposed to a write request).
 func (c DeviceCharacteristic) WriteWithoutResponse(p []byte) (n int, err error) {
 	c.service.device.prph.WriteCharacteristic(p, c.characteristic, false)
 
@@ -225,6 +226,11 @@ func (c DeviceCharacteristic) EnableNotifications(callback func(buf []byte)) err
 // GetMTU returns the MTU for the characteristic.
 func (c DeviceCharacteristic) GetMTU() (uint16, error) {
 	return uint16(c.service.device.prph.MaximumWriteValueLength(false)), nil
+}
+
+// CanSendWriteWithoutResponse returns the MTU for the characteristic.
+func (c DeviceCharacteristic) CanSendWriteWithoutResponse() bool {
+	return c.service.device.prph.CanSendWriteWithoutResponse()
 }
 
 // Read reads the current characteristic value.

--- a/gattc_darwin.go
+++ b/gattc_darwin.go
@@ -228,7 +228,11 @@ func (c DeviceCharacteristic) GetMTU() (uint16, error) {
 	return uint16(c.service.device.prph.MaximumWriteValueLength(false)), nil
 }
 
-// CanSendWriteWithoutResponse returns the MTU for the characteristic.
+// CanSendWriteWithoutResponse returns whether a WriteWithoutResponse can be sent
+// at this time. If this returns false, you must wait for some time before
+// sending another WriteWithoutResponse. This is typically because the internal
+// buffer is full. You can use this to implement your own flow control when
+// sending many WriteWithoutResponse calls in a row.
 func (c DeviceCharacteristic) CanSendWriteWithoutResponse() bool {
 	return c.service.device.prph.CanSendWriteWithoutResponse()
 }


### PR DESCRIPTION
https://github.com/tinygo-org/bluetooth/blob/5c615298c3e4400150c44da3636f3d3b10967e3c/gattc_darwin.go#L200-L208

> **A limited number of such writes can be in flight at any given time.**

When the underlying CoreBluetooth queue is full, a call to `c.service.device.prph.WriteCharacteristic(p, c.characteristic, false)` will silently fail.

The request is dropped.

CoreBluetooth provides [`canSendWriteWithoutResponse`](https://developer.apple.com/documentation/corebluetooth/cbperipheral/cansendwritewithoutresponse), which is available under the cbgo bindings as `c.service.device.prph.CanSendWriteWithoutResponse()`.

---

This pull request adds a public function to the `DeviceCharacteristic` as CanSendWriteWithoutResponse().

This pull request also uses `c.service.device.prph.CanSendWriteWithoutResponse()` in `WriteWithoutResponse()` to properly return an error if the queue it cannot send a request at that time. Letting the user retry on the new error `ErrCannotSendWriteWithoutResponse`.

---

Example usage:

```go

for i = 0; i < total; i+=chunkSize {
	end := i + chunkSize
	if end > total {
		end = total
	}

	for _, err := c.rx.WriteWithoutResponse(buffer) {
		if errors.Is(err, bluetooth.ErrCannotSendWriteWithoutResponse) {
			// Wait and retry
			<-time.After(5 * time.Millisecond)
			continue
		}
		if err != nil {
			return fmt.Errorf("failed to write to characteristic: %w", err)
		}
		break
	}

	fmt.Printf("Sent %d/%d bytes\r", end, len(buf))
}
```