### PR TITLE
linux: Add Write method to write characteristic value with response

### DIFF
--- a/gattc_linux.go
+++ b/gattc_linux.go
@@ -222,7 +222,21 @@ func (s DeviceService) DiscoverCharacteristics(uuids []UUID) ([]DeviceCharacteri
 // writes can be in flight at any given time. This call is also known as a
 // "write command" (as opposed to a write request).
 func (c DeviceCharacteristic) WriteWithoutResponse(p []byte) (n int, err error) {
-	err = c.characteristic.Call("org.bluez.GattCharacteristic1.WriteValue", 0, p, map[string]dbus.Variant(nil)).Err
+	args := make(map[string]any)
+	err = c.characteristic.Call("org.bluez.GattCharacteristic1.WriteValue", 0, p, args).Err
+	args["type"] = "command"
+	if err != nil {
+		return 0, err
+	}
+	return len(p), nil
+}
+
+// Write replaces the characteristic value with a new value. The
+// call will return after all data has been written.
+func (c DeviceCharacteristic) Write(p []byte) (n int, err error) {
+	args := make(map[string]any)
+	args["type"] = "request"
+	err = c.characteristic.Call("org.bluez.GattCharacteristic1.WriteValue", 0, p, args).Err
 	if err != nil {
 		return 0, err
 	}

--- a/gattc_linux.go
+++ b/gattc_linux.go
@@ -221,7 +221,7 @@ func (s DeviceService) DiscoverCharacteristics(uuids []UUID) ([]DeviceCharacteri
 // call will return before all data has been written. A limited number of such
 // writes can be in flight at any given time. This call is also known as a
 // "write command" (as opposed to a write request).
-func (c DeviceCharacteristic) WriteWithoutResponse(p []byte) (n int, err error) {
+func (c DeviceCharacteristic) WriteWithoutResponse(p []byte) (int, error) {
 	args := map[string]any{"type": "command"}
 	if err := c.characteristic.Call("org.bluez.GattCharacteristic1.WriteValue", 0, p, args).Err; err != nil {
 		return 0, err
@@ -231,7 +231,7 @@ func (c DeviceCharacteristic) WriteWithoutResponse(p []byte) (n int, err error) 
 
 // Write replaces the characteristic value with a new value. The
 // call will return after all data has been written.
-func (c DeviceCharacteristic) Write(p []byte) (n int, err error) {
+func (c DeviceCharacteristic) Write(p []byte) (int, error) {
 	args := map[string]any{"type": "request"}
 	if err := c.characteristic.Call("org.bluez.GattCharacteristic1.WriteValue", 0, p, args).Err; err != nil {
 		return 0, err

--- a/gattc_linux.go
+++ b/gattc_linux.go
@@ -222,10 +222,8 @@ func (s DeviceService) DiscoverCharacteristics(uuids []UUID) ([]DeviceCharacteri
 // writes can be in flight at any given time. This call is also known as a
 // "write command" (as opposed to a write request).
 func (c DeviceCharacteristic) WriteWithoutResponse(p []byte) (n int, err error) {
-	args := make(map[string]any)
-	err = c.characteristic.Call("org.bluez.GattCharacteristic1.WriteValue", 0, p, args).Err
-	args["type"] = "command"
-	if err != nil {
+	args := map[string]any{"type": "command"}
+	if err := c.characteristic.Call("org.bluez.GattCharacteristic1.WriteValue", 0, p, args).Err; err != nil {
 		return 0, err
 	}
 	return len(p), nil
@@ -234,10 +232,8 @@ func (c DeviceCharacteristic) WriteWithoutResponse(p []byte) (n int, err error) 
 // Write replaces the characteristic value with a new value. The
 // call will return after all data has been written.
 func (c DeviceCharacteristic) Write(p []byte) (n int, err error) {
-	args := make(map[string]any)
-	args["type"] = "request"
-	err = c.characteristic.Call("org.bluez.GattCharacteristic1.WriteValue", 0, p, args).Err
-	if err != nil {
+	args := map[string]any{"type": "request"}
+	if err := c.characteristic.Call("org.bluez.GattCharacteristic1.WriteValue", 0, p, args).Err; err != nil {
 		return 0, err
 	}
 	return len(p), nil


### PR DESCRIPTION
Simple change that adds a `Write` (with response) method to the `DeviceCharacteristic` linux dbus implementation, consistent with what is already available in the windows and mac versions. It sets the dbus `type` argument of the `WriteValue` method, as listed in the [documentation](https://github.com/bluez/bluez/blob/c6dcf6b714501768ab7ea293e75d945be0eec188/doc/org.bluez.GattCharacteristic.rst#void-writevaluearraybyte-value-dict-options).

My use case is setting [ble ftms](https://www.bluetooth.com/specifications/specs/fitness-machine-service-1-0/) simulation parameters, which requires writing with response to the ftms control characteristic. I verified that my ftms device successfully updates the parameters using the new `Write` method; it doesn't respond to `WriteWithoutResponse` on the characteristic in any way.

I have also set the `type` argument of `WriteWithoutResponse` to `command`, consistent with the suggestion by @tazjin in #382 .