### PR TITLE
sd: send the correct response to BLE_GAP_EVT_PHY_UPDATE_REQUEST

### DIFF
--- a/adapter_nrf528xx-full.go
+++ b/adapter_nrf528xx-full.go
@@ -111,8 +111,8 @@ func handleEvent() {
 		case C.BLE_GAP_EVT_DATA_LENGTH_UPDATE:
 			// ignore confirmation of data length successfully updated
 		case C.BLE_GAP_EVT_PHY_UPDATE_REQUEST:
-			phyUpdateRequest := gapEvent.params.unionfield_phy_update_request()
-			C.sd_ble_gap_phy_update(gapEvent.conn_handle, &phyUpdateRequest.peer_preferred_phys)
+			// Tell the Bluetooth stack to update the PHY as it sees fit.
+			C.sd_ble_gap_phy_update(gapEvent.conn_handle, &phyUpdateResponse)
 		case C.BLE_GAP_EVT_PHY_UPDATE:
 			// ignore confirmation of phy successfully updated
 		case C.BLE_GAP_EVT_TIMEOUT:

--- a/adapter_nrf528xx-peripheral.go
+++ b/adapter_nrf528xx-peripheral.go
@@ -60,8 +60,8 @@ func handleEvent() {
 		case C.BLE_GAP_EVT_DATA_LENGTH_UPDATE:
 			// ignore confirmation of data length successfully updated
 		case C.BLE_GAP_EVT_PHY_UPDATE_REQUEST:
-			phyUpdateRequest := gapEvent.params.unionfield_phy_update_request()
-			C.sd_ble_gap_phy_update(gapEvent.conn_handle, &phyUpdateRequest.peer_preferred_phys)
+			// Tell the Bluetooth stack to update the PHY as it sees fit.
+			C.sd_ble_gap_phy_update(gapEvent.conn_handle, &phyUpdateResponse)
 		case C.BLE_GAP_EVT_PHY_UPDATE:
 			// ignore confirmation of phy successfully updated
 		default:

--- a/adapter_nrf528xx.go
+++ b/adapter_nrf528xx.go
@@ -67,3 +67,9 @@ func makeMACAddress(addr C.ble_gap_addr_t) MACAddress {
 		isRandom: addr.bitfield_addr_type() != 0,
 	}
 }
+
+// Always let the BLE stack pick the right PHY.
+var phyUpdateResponse = C.ble_gap_phys_t{
+	tx_phys: C.BLE_GAP_PHY_AUTO,
+	rx_phys: C.BLE_GAP_PHY_AUTO,
+}


### PR DESCRIPTION
This fixes an issue on my Android phone where the connection would break after 40s because the PHY update was never responded to - or at least not correctly.