### PR TITLE
Linux: Fix unsubscribe from characteristic notifications issue

### DIFF
--- a/bluetooth.go
+++ b/bluetooth.go
@@ -5,4 +5,4 @@
 // those produced by Nordic Semiconductor.
 //
 // This package can be use to create Bluetooth Low Energy centrals as well as peripherals.
-package bluetooth // import "tinygo.org/x/bluetooth"
+package bluetooth // import "github.com/aventari/bluetooth"

--- a/examples/advertisement/main.go
+++ b/examples/advertisement/main.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"time"
 
-	"tinygo.org/x/bluetooth"
+	"github.com/aventari/bluetooth"
 )
 
 var adapter = bluetooth.DefaultAdapter

--- a/examples/battery/main.go
+++ b/examples/battery/main.go
@@ -5,7 +5,7 @@ import (
 	"math/rand"
 	"time"
 
-	"tinygo.org/x/bluetooth"
+	"github.com/aventari/bluetooth"
 )
 
 var adapter = bluetooth.DefaultAdapter

--- a/examples/beacon/main.go
+++ b/examples/beacon/main.go
@@ -5,7 +5,7 @@ import (
 	"math/rand"
 	"time"
 
-	"tinygo.org/x/bluetooth"
+	"github.com/aventari/bluetooth"
 )
 
 var adapter = bluetooth.DefaultAdapter

--- a/examples/circuitplay/main.go
+++ b/examples/circuitplay/main.go
@@ -8,7 +8,7 @@ import (
 	"machine"
 	"time"
 
-	"tinygo.org/x/bluetooth"
+	"github.com/aventari/bluetooth"
 	"tinygo.org/x/drivers/ws2812"
 )
 

--- a/examples/connparams/main.go
+++ b/examples/connparams/main.go
@@ -12,7 +12,7 @@ package main
 import (
 	"time"
 
-	"tinygo.org/x/bluetooth"
+	"github.com/aventari/bluetooth"
 )
 
 var (

--- a/examples/device-information/main.go
+++ b/examples/device-information/main.go
@@ -4,7 +4,7 @@ package main
 import (
 	"time"
 
-	"tinygo.org/x/bluetooth"
+	"github.com/aventari/bluetooth"
 )
 
 var adapter = bluetooth.DefaultAdapter

--- a/examples/discover/main.go
+++ b/examples/discover/main.go
@@ -18,7 +18,7 @@ package main
 import (
 	"strconv"
 
-	"tinygo.org/x/bluetooth"
+	"github.com/aventari/bluetooth"
 )
 
 var adapter = bluetooth.DefaultAdapter

--- a/examples/heartrate-monitor/main.go
+++ b/examples/heartrate-monitor/main.go
@@ -24,7 +24,7 @@
 package main
 
 import (
-	"tinygo.org/x/bluetooth"
+	"github.com/aventari/bluetooth"
 )
 
 var (

--- a/examples/heartrate/main.go
+++ b/examples/heartrate/main.go
@@ -6,7 +6,7 @@ import (
 	"math/rand"
 	"time"
 
-	"tinygo.org/x/bluetooth"
+	"github.com/aventari/bluetooth"
 )
 
 var (

--- a/examples/ledcolor/main.go
+++ b/examples/ledcolor/main.go
@@ -4,7 +4,7 @@ import (
 	"machine"
 	"time"
 
-	"tinygo.org/x/bluetooth"
+	"github.com/aventari/bluetooth"
 )
 
 var adapter = bluetooth.DefaultAdapter

--- a/examples/nusclient/main.go
+++ b/examples/nusclient/main.go
@@ -4,8 +4,8 @@ package main
 // details.
 
 import (
-	"tinygo.org/x/bluetooth"
-	"tinygo.org/x/bluetooth/rawterm"
+	"github.com/aventari/bluetooth"
+	"github.com/aventari/bluetooth/rawterm"
 )
 
 var (

--- a/examples/nusserver/main.go
+++ b/examples/nusserver/main.go
@@ -8,8 +8,8 @@ package main
 // Code to interact with a raw terminal is in separate files with build tags.
 
 import (
-	"tinygo.org/x/bluetooth"
-	"tinygo.org/x/bluetooth/rawterm"
+	"github.com/aventari/bluetooth"
+	"github.com/aventari/bluetooth/rawterm"
 )
 
 var (

--- a/examples/scanner/main.go
+++ b/examples/scanner/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"tinygo.org/x/bluetooth"
+	"github.com/aventari/bluetooth"
 )
 
 var adapter = bluetooth.DefaultAdapter

--- a/examples/stop-advertisement/main.go
+++ b/examples/stop-advertisement/main.go
@@ -7,7 +7,7 @@ package main
 import (
 	"time"
 
-	"tinygo.org/x/bluetooth"
+	"github.com/aventari/bluetooth"
 )
 
 var adapter = bluetooth.DefaultAdapter

--- a/examples/tinyscan/main.go
+++ b/examples/tinyscan/main.go
@@ -5,7 +5,7 @@ import (
 	"image/color"
 	"time"
 
-	"tinygo.org/x/bluetooth"
+	"github.com/aventari/bluetooth"
 	"tinygo.org/x/tinyterm"
 )
 

--- a/gattc_linux.go
+++ b/gattc_linux.go
@@ -277,12 +277,19 @@ func (c *DeviceCharacteristic) EnableNotifications(callback func(buf []byte)) er
 		if c.property == nil {
 			return nil
 		}
-
-		err := c.adapter.bus.RemoveMatchSignal(c.propertiesChangedMatchOption)
+		// Make the D-Bus call to stop notifications on the characteristic.
+		stopNotifyErr := c.characteristic.Call("org.bluez.GattCharacteristic1.StopNotify", 0).Err
+		// Still clean up other resources if there was an error
+		removeSignalErr := c.adapter.bus.RemoveMatchSignal(c.propertiesChangedMatchOption)
 		c.adapter.bus.RemoveSignal(c.property)
 		close(c.property)
 		c.property = nil
-		return err
+
+		// If there were errors, prioritize notify err
+		if stopNotifyErr == nil {
+			return removeSignalErr
+		}
+		return stopNotifyErr		
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module tinygo.org/x/bluetooth
+module github.com/aventari/bluetooth
 
 go 1.22.1
 

--- a/tools/gen-characteristic-uuids/main.go
+++ b/tools/gen-characteristic-uuids/main.go
@@ -16,7 +16,7 @@ import (
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 
-	"tinygo.org/x/bluetooth"
+	"github.com/aventari/bluetooth"
 )
 
 type Characteristic struct {

--- a/tools/gen-service-uuids/main.go
+++ b/tools/gen-service-uuids/main.go
@@ -16,7 +16,7 @@ import (
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 
-	"tinygo.org/x/bluetooth"
+	"github.com/aventari/bluetooth"
 )
 
 type Service struct {


### PR DESCRIPTION
Fix for issue #366 

Updated gattc_linux.go to properly unsubscribe from notifications using dbus call "org.bluez.GattCharacteristic1.StopNotify" which is the companion call to "org.bluez.GattCharacteristic1.StartNotify" that is being called when subscribing.

Tested working on Pi4

smoke-tests passed:
```
~/smoke/bluetooth $ make smoketest-linux
# Test on Linux.
GOOS=linux go build -o /tmp/go-build-discard ./examples/advertisement
GOOS=linux go build -o /tmp/go-build-discard ./examples/connparams
GOOS=linux go build -o /tmp/go-build-discard ./examples/heartrate
GOOS=linux go build -o /tmp/go-build-discard ./examples/heartrate-monitor
GOOS=linux go build -o /tmp/go-build-discard ./examples/nusserver
go: downloading golang.org/x/crypto v0.12.0
go: downloading golang.org/x/term v0.11.0
go: downloading golang.org/x/sys v0.11.0
GOOS=linux go build -o /tmp/go-build-discard ./examples/scanner
GOOS=linux go build -o /tmp/go-build-discard ./examples/discover
~/smoke/bluetooth $

```