### PR TITLE
Linux: Fix unsubscribe from characteristic notifications not working

### DIFF
--- a/gattc_linux.go
+++ b/gattc_linux.go
@@ -277,12 +277,19 @@ func (c *DeviceCharacteristic) EnableNotifications(callback func(buf []byte)) er
 		if c.property == nil {
 			return nil
 		}
-
-		err := c.adapter.bus.RemoveMatchSignal(c.propertiesChangedMatchOption)
+		// Make the D-Bus call to stop notifications on the characteristic.
+		stopNotifyErr := c.characteristic.Call("org.bluez.GattCharacteristic1.StopNotify", 0).Err
+		// Still clean up other resources if there was an error
+		removeSignalErr := c.adapter.bus.RemoveMatchSignal(c.propertiesChangedMatchOption)
 		c.adapter.bus.RemoveSignal(c.property)
 		close(c.property)
 		c.property = nil
-		return err
+
+		// If there were errors, prioritize notify err
+		if stopNotifyErr == nil {
+			return removeSignalErr
+		}
+		return stopNotifyErr		
 	}
 }
 


### PR DESCRIPTION
Fix for issue https://github.com/tinygo-org/bluetooth/issues/366

Updated gattc_linux.go to properly unsubscribe from notifications using dbus call "org.bluez.GattCharacteristic1.StopNotify" which is the companion call to "org.bluez.GattCharacteristic1.StartNotify" that is being called when subscribing.

Tested working on Pi4

smoke-tests passed:
```
~/smoke/bluetooth $ make smoketest-linux
# Test on Linux.
GOOS=linux go build -o /tmp/go-build-discard ./examples/advertisement
GOOS=linux go build -o /tmp/go-build-discard ./examples/connparams
GOOS=linux go build -o /tmp/go-build-discard ./examples/heartrate
GOOS=linux go build -o /tmp/go-build-discard ./examples/heartrate-monitor
GOOS=linux go build -o /tmp/go-build-discard ./examples/nusserver
go: downloading golang.org/x/crypto v0.12.0
go: downloading golang.org/x/term v0.11.0
go: downloading golang.org/x/sys v0.11.0
GOOS=linux go build -o /tmp/go-build-discard ./examples/scanner
GOOS=linux go build -o /tmp/go-build-discard ./examples/discover
~/smoke/bluetooth $

```