### PR TITLE
build: update macos builds to versions 14 and 15, since 13 is deprecated

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -12,31 +12,31 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  macos-13:
-    name: macos-13
-    runs-on: macos-13
-    steps:
-      - name: Install Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: '1.21'
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Run unit tests
-        run: go test
-      - name: "Run macOS smoke tests"
-        run: make smoketest-macos
-  
   macos-14:
     name: macos-14
     runs-on: macos-14
     steps:
       - name: Install Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
-          go-version: '1.23'
+          go-version: '1.22'
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
+      - name: Run unit tests
+        run: go test
+      - name: "Run macOS smoke tests"
+        run: make smoketest-macos
+  
+  macos-15:
+    name: macos-15
+    runs-on: macos-15
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.25'
+      - name: Checkout
+        uses: actions/checkout@v5
       - name: Run unit tests
         run: go test
       - name: "Run macOS smoke tests"


### PR DESCRIPTION
This PR updates the macos builds to versions 14 and 15, since 13 is deprecated on GH actions.