### PR TITLE
build: update Linux and Windows to use latest versions of GH actions/Go

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -17,7 +17,7 @@ jobs:
         # We're not on a multi-user machine, so this is safe.
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: TinyGo version check
         run: tinygo version
       - name: Run unit tests

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -13,11 +13,11 @@ jobs:
     runs-on: windows-2022
     steps:
       - name: Install Go
-        uses: actions/setup-go@v4.1.0
+        uses: actions/setup-go@v6
         with:
-          go-version: '1.21.0'
+          go-version: '1.25'
       - name: Checkout
-        uses: actions/checkout@v3.6.0
+        uses: actions/checkout@v5
       - name: Run unit tests
         run: go test
       - name: "Run Windows smoke tests"


### PR DESCRIPTION
This PR updates Linux and Windows to use latest versions of GH actions/Go 1.25.