### PR TITLE
Add MAC accessor for returning the MAC in the usual format

### DIFF
--- a/mac.go
+++ b/mac.go
@@ -56,6 +56,11 @@ func (mac MAC) String() string {
 	return unsafe.String(unsafe.SliceData(buf), 17)
 }
 
+// Address returns the MAC address in the typical (big-endian) format.
+func (mac MAC) Address() [6]uint8 {
+	return [6]uint8{mac[5], mac[4], mac[3], mac[2], mac[1], mac[0]}
+}
+
 const hexDigit = "0123456789ABCDEF"
 
 // AppendText appends the textual representation of itself to the end of b


### PR DESCRIPTION
The MAC address in the bluetooth.MAC type is little endian, the reverse of what is commonly used. The usual way a MAC address is printed is big endian. To simplify code, the Address() method will return the address in the usual (big endian) format.

Feel free to bikeshed on the name, I don't know whether `Address` really captures it well. Also, perhaps we should make the underlying data type private at some point? Though that may break existing users.