### PR TITLE
Actually stop BLE scan in StopScan() on nrf528xx

### DIFF
--- a/gap_nrf528xx-central.go
+++ b/gap_nrf528xx-central.go
@@ -87,10 +87,8 @@ func (a *Adapter) StopScan() error {
 		return errNotScanning
 	}
 	a.scanning = false
-
-	// TODO: stop immediately, not when the next scan result arrives.
-
-	return nil
+	errCode := C.sd_ble_gap_scan_stop()
+	return makeError(errCode)
 }
 
 // In-progress connection attempt.


### PR DESCRIPTION
Tested on a nrf52840 board.

Without this patch, calling

```
Scan()
(sleep)
StopScan()
err := Scan()
```

returns an error on the second `Scan()` because the previous scan wasn't _actually_ stopped, since the native call is missing.

With this patch, the above succeeds and the scan starts returning results, as usual.

I'm really not sure why there was a TODO rather than this simple function call. The TODO doesn't provide a rationale.