### PR TITLE
build: use TinyGo latest release for CI builds

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -11,15 +11,16 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: ghcr.io/tinygo-org/tinygo-dev
+    container:
+      image: ghcr.io/tinygo-org/tinygo:latest
+      options: --user root
     steps:
-      - name: Work around CVE-2022-24765
-        # We're not on a multi-user machine, so this is safe.
-        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       - name: TinyGo version check
         run: tinygo version
+      - name: Add required GOFLAGS
+        run: go env -w GOFLAGS=-buildvcs=false
       - name: Run unit tests
         run: go test
       - name: Run TinyGo smoke tests

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           go-version: '1.22'
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       - name: Run unit tests
         run: go test
       - name: "Run macOS smoke tests"
@@ -36,7 +36,7 @@ jobs:
         with:
           go-version: '1.25'
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       - name: Run unit tests
         run: go test
       - name: "Run macOS smoke tests"

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           go-version: '1.25'
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       - name: Run unit tests
         run: go test
       - name: "Run Windows smoke tests"


### PR DESCRIPTION
This PR switches to use the TinyGo latest release for CI builds.

It also updates the checkout action to the latest version for all platforms.