### PR TITLE
sd: fix error in sd_ble_gap_scan_start after stop scan with nrf528xx

### DIFF
--- a/gap_nrf528xx-central.go
+++ b/gap_nrf528xx-central.go
@@ -55,7 +55,7 @@ func (a *Adapter) Scan(callback func(*Adapter, ScanResult)) error {
 	}
 
 	// Wait for received scan reports.
-	for a.scanning {
+	for {
 		// Wait for the next advertisement packet to arrive.
 		// TODO: use some sort of condition variable once the scheduler supports
 		// them.
@@ -69,6 +69,11 @@ func (a *Adapter) Scan(callback func(*Adapter, ScanResult)) error {
 		// Call the callback with the scan result.
 		callback(a, globalScanResult)
 
+		if !a.scanning {
+			// the callback has stopped the scanning, calling "sd_ble_gap_scan_start" would be for nothing
+			break
+		}
+
 		// Restart the advertisement. This is needed, because advertisements are
 		// automatically stopped when the first packet arrives.
 		errCode := C.sd_ble_gap_scan_start(nil, &scanReportBufferInfo)
@@ -76,7 +81,11 @@ func (a *Adapter) Scan(callback func(*Adapter, ScanResult)) error {
 			return Error(errCode)
 		}
 	}
-	return nil
+
+	// calling "C.sd_ble_gap_scan_stop()" in "StopScan" would lead to an error in "C.sd_ble_gap_scan_start()", because
+	// "StopScan" is usually called in the "callback()" just before
+	errCode = C.sd_ble_gap_scan_stop()
+	return makeError(errCode)
 }
 
 // StopScan stops any in-progress scan. It can be called from within a Scan
@@ -87,8 +96,8 @@ func (a *Adapter) StopScan() error {
 		return errNotScanning
 	}
 	a.scanning = false
-	errCode := C.sd_ble_gap_scan_stop()
-	return makeError(errCode)
+
+	return nil
 }
 
 // In-progress connection attempt.


### PR DESCRIPTION
"C.sd_ble_gap_scan_stop()" must not followed by "C.sd_ble_gap_scan_start(nil, &scanReportBufferInfo)", otherwise the latter returns the error "invalid state, operation disallowed in this state"

This fixes #403 .

Additionally:
Postponing the termination of the for loop until after the callback speeds up the loop and should be possible without risk.