### PR TITLE
Remove service / stop advertising support

### DIFF
--- a/gatts.go
+++ b/gatts.go
@@ -2,6 +2,7 @@ package bluetooth
 
 // Service is a GATT service to be used in AddService.
 type Service struct {
+	id     uint64
 	handle uint16
 	UUID
 	Characteristics []CharacteristicConfig

--- a/gatts_hci.go
+++ b/gatts_hci.go
@@ -2,6 +2,8 @@
 
 package bluetooth
 
+import "errors"
+
 type Characteristic struct {
 	adapter     *Adapter
 	handle      uint16
@@ -77,6 +79,11 @@ func (a *Adapter) AddService(service *Service) error {
 	a.att.addLocalService(serviceHandle, endHandle, service.UUID)
 
 	return nil
+}
+
+// RemoveService removes a previously added service.
+func (a *Adapter) RemoveService(s *Service) error {
+	return errors.ErrUnsupported
 }
 
 // Write replaces the characteristic value with a new value.

--- a/gatts_linux.go
+++ b/gatts_linux.go
@@ -76,6 +76,8 @@ func (c *bluezChar) WriteValue(value []byte, options map[string]dbus.Variant) *d
 func (a *Adapter) AddService(s *Service) error {
 	// Create a unique DBus path for this service.
 	id := atomic.AddUint64(&serviceID, 1)
+	s.id = id
+
 	path := dbus.ObjectPath(fmt.Sprintf("/org/tinygo/bluetooth/service%d", id))
 
 	// All objects that will be part of the ObjectManager.
@@ -151,6 +153,12 @@ func (a *Adapter) AddService(s *Service) error {
 
 	// Register our service.
 	return a.adapter.Call("org.bluez.GattManager1.RegisterApplication", 0, path, map[string]dbus.Variant(nil)).Err
+}
+
+// RemoveService removes a previously added service.
+func (a *Adapter) RemoveService(s *Service) error {
+	path := dbus.ObjectPath(fmt.Sprintf("/org/tinygo/bluetooth/service%d", s.id))
+	return a.adapter.Call("org.bluez.GattManager1.UnregisterApplication", 0, path).Err
 }
 
 // Write replaces the characteristic value with a new value.

--- a/gatts_sd.go
+++ b/gatts_sd.go
@@ -22,7 +22,10 @@ static inline uint32_t sd_ble_gatts_value_set_noescape(uint16_t conn_handle, uin
 }
 */
 import "C"
-import "unsafe"
+import (
+	"errors"
+	"unsafe"
+)
 
 // Characteristic is a single characteristic in a service. It has an UUID and a
 // value.
@@ -89,6 +92,11 @@ func (a *Adapter) AddService(service *Service) error {
 		}
 	}
 	return makeError(errCode)
+}
+
+// RemoveService removes a service previously added with AddService.
+func (a *Adapter) RemoveService(s *Service) error {
+	return errors.ErrUnsupported
 }
 
 // charWriteHandler contains a handler->callback mapping for characteristic

--- a/gatts_windows.go
+++ b/gatts_windows.go
@@ -240,6 +240,32 @@ func (a *Adapter) AddService(s *Service) error {
 	return serviceProvider.StartAdvertisingWithParameters(params)
 }
 
+// RemoveService stops advertising the service and removes it.
+func (a *Adapter) RemoveService(s *Service) error {
+	gattServiceOp, err := genericattributeprofile.GattServiceProviderCreateAsync(syscallUUIDFromUUID(s.UUID))
+
+	if err != nil {
+		return err
+	}
+
+	if err = awaitAsyncOperation(gattServiceOp, genericattributeprofile.SignatureGattServiceProviderResult); err != nil {
+		return err
+	}
+
+	res, err := gattServiceOp.GetResults()
+	if err != nil {
+		return err
+	}
+
+	serviceProviderResult := (*genericattributeprofile.GattServiceProviderResult)(res)
+	serviceProvider, err := serviceProviderResult.GetServiceProvider()
+	if err != nil {
+		return err
+	}
+
+	return serviceProvider.StopAdvertising()
+}
+
 // Write replaces the characteristic value with a new value.
 func (c *Characteristic) Write(p []byte) (n int, err error) {
 	length := len(p)


### PR DESCRIPTION
This PR allows to remove advertised services from the adapter on Linux and Windows. Other implementations are marked as not supported.