### PR TITLE
gap_hci: remove superflous print

### DIFF
--- a/gap_hci.go
+++ b/gap_hci.go
@@ -76,7 +76,6 @@ func (a *Adapter) Scan(callback func(*Adapter, ScanResult)) error {
 			rp := rawAdvertisementPayload{len: a.hci.advData.eirLength}
 			copy(rp.data[:], a.hci.advData.eirData[:a.hci.advData.eirLength])
 			if rp.LocalName() != "" {
-				println("LocalName:", rp.LocalName())
 				adf.LocalName = rp.LocalName()
 			}
 


### PR DESCRIPTION
I was a little surprised to see some extra lines printed while scanning. I don't think they are supposed to be printed.