### PR TITLE
added security levels to CharacteristicConfig with linux implementation

### DIFF
--- a/gatts.go
+++ b/gatts.go
@@ -10,6 +10,16 @@ type Service struct {
 
 type WriteEvent = func(client Connection, offset int, value []byte)
 
+// SecurityLevel specifies the security required for a characteristic operation.
+// Settings other than the default (SecurityNone) may result in the peer initiating a pairing operation.
+type SecurityLevel uint8
+
+const (
+	SecurityNone                   SecurityLevel = iota // encryption not required
+	SecurityEncrypted                                   // encryption required
+	SecurityEncryptedAuthenticated                      // encryption and authentication (MITM protection) required
+)
+
 // CharacteristicConfig contains some parameters for the configuration of a
 // single characteristic.
 //
@@ -18,9 +28,13 @@ type WriteEvent = func(client Connection, offset int, value []byte)
 type CharacteristicConfig struct {
 	Handle *Characteristic
 	UUID
-	Value      []byte
-	Flags      CharacteristicPermissions
-	WriteEvent WriteEvent
+	Value            []byte
+	Flags            CharacteristicPermissions
+	WriteEvent       WriteEvent
+	ReadSecurity     SecurityLevel
+	WriteSecurity    SecurityLevel
+	NotifySecurity   SecurityLevel
+	IndicateSecurity SecurityLevel
 }
 
 // CharacteristicPermissions lists a number of basic permissions/capabilities

--- a/gatts_linux.go
+++ b/gatts_linux.go
@@ -108,6 +108,26 @@ func (a *Adapter) AddService(s *Service) error {
 				flags = append(flags, bluezCharFlags[i])
 			}
 		}
+		if char.ReadSecurity == SecurityEncrypted {
+			flags = append(flags, "encrypt-read")
+		} else if char.ReadSecurity == SecurityEncryptedAuthenticated {
+			flags = append(flags, "encrypt-authenticated-read")
+		}
+		if char.WriteSecurity == SecurityEncrypted {
+			flags = append(flags, "encrypt-write")
+		} else if char.WriteSecurity == SecurityEncryptedAuthenticated {
+			flags = append(flags, "encrypt-authenticated-write")
+		}
+		if char.NotifySecurity == SecurityEncrypted {
+			flags = append(flags, "encrypt-notify")
+		} else if char.NotifySecurity == SecurityEncryptedAuthenticated {
+			flags = append(flags, "encrypt-authenticated-notify")
+		}
+		if char.IndicateSecurity == SecurityEncrypted {
+			flags = append(flags, "encrypt-indicate")
+		} else if char.IndicateSecurity == SecurityEncryptedAuthenticated {
+			flags = append(flags, "encrypt-authenticated-indicate")
+		}
 
 		// Export the properties of this characteristic.
 		charPath := path + dbus.ObjectPath("/char"+strconv.Itoa(i))


### PR DESCRIPTION
This commit adds a new type - SecurityLevel - and adds instances of it to CharacteristicConfig, for each of: read, write, notify, and indicate.

The default (zero) value is no encryption, so existing user code should be unaffected.

A godoc-visible comment notes that setting a non-default value may result in the peer initiating a pairing operation.

This commit includes a linux implementation which has been tested on Alpine linux. It passes smoketest-linux. If user code specifies a non-default SecurityLevel on any other platform, it will be silently ignored.

Here is a working example CharacteristicConfig which includes a non-default security level:
{
	Handle: &rxChx,
	UUID:   rxUUID,
	Flags: bluetooth.CharacteristicWritePermission |
		bluetooth.CharacteristicWriteWithoutResponsePermission,
	WriteSecurity: bluetooth.SecurityEncryptedAuthenticated,
	WriteEvent: func(client bluetooth.Connection, offset int, value []byte) {
		fmt.Printf("RX (%d bytes): %s\n", len(value), string(value))
	},
}
