### PR TITLE
fix: Windows services ordering in DiscoverServices

### DIFF
--- a/gattc_windows.go
+++ b/gattc_windows.go
@@ -79,6 +79,13 @@ func (d Device) DiscoverServices(filterUUIDs []UUID) ([]DeviceService, error) {
 	}
 
 	var services []DeviceService
+
+	if len(filterUUIDs) > 0 {
+		// The caller wants to get a list of services in a specific
+		// order.
+		services = make([]DeviceService, len(filterUUIDs))
+	}
+
 	for i := uint32(0); i < servicesSize; i++ {
 		s, err := servicesVector.GetAt(i)
 		if err != nil {
@@ -95,29 +102,38 @@ func (d Device) DiscoverServices(filterUUIDs []UUID) ([]DeviceService, error) {
 
 		// only include services that are included in the input filter
 		if len(filterUUIDs) > 0 {
-			found := false
-			for _, uuid := range filterUUIDs {
+			for j, uuid := range filterUUIDs {
 				if serviceUuid.String() == uuid.String() {
 					// One of the services we're looking for.
-					found = true
+					services[j] = DeviceService{
+						deviceService: &deviceService{
+							uuidWrapper: serviceUuid,
+							service:     srv,
+							device:      d,
+						},
+					}
 					break
 				}
 			}
-			if !found {
-				continue
-			}
+		} else {
+			// The caller wants to get all services, in any order.
+			services = append(services, DeviceService{
+				deviceService: &deviceService{
+					uuidWrapper: serviceUuid,
+					service:     srv,
+					device:      d,
+				},
+			})
 		}
 
 		go func() {
 			<-d.ctx.Done()
 			srv.Close()
 		}()
+	}
 
-		services = append(services, DeviceService{
-			uuidWrapper: serviceUuid,
-			service:     srv,
-			device:      d,
-		})
+	if slices.Contains(services, (DeviceService{})) {
+		return nil, errors.New("bluetooth: did not find all requested services")
 	}
 
 	return services, nil
@@ -144,8 +160,23 @@ func winRTUuidToUuid(uuid syscall.GUID) UUID {
 // struct method of the same name.
 type uuidWrapper = UUID
 
-// DeviceService is a BLE service on a connected peripheral device.
+func makeService(serviceUuid uuidWrapper, srv *genericattributeprofile.GattDeviceService, d Device) DeviceService {
+	svc := DeviceService{
+		deviceService: &deviceService{
+			uuidWrapper: serviceUuid,
+			service:     srv,
+			device:      d,
+		},
+	}
+	return svc
+}
+
 type DeviceService struct {
+	*deviceService
+}
+
+// DeviceService is a BLE service on a connected peripheral device.
+type deviceService struct {
 	uuidWrapper
 
 	service *genericattributeprofile.GattDeviceService

--- a/gattc_windows.go
+++ b/gattc_windows.go
@@ -105,25 +105,13 @@ func (d Device) DiscoverServices(filterUUIDs []UUID) ([]DeviceService, error) {
 			for j, uuid := range filterUUIDs {
 				if serviceUuid.String() == uuid.String() {
 					// One of the services we're looking for.
-					services[j] = DeviceService{
-						deviceService: &deviceService{
-							uuidWrapper: serviceUuid,
-							service:     srv,
-							device:      d,
-						},
-					}
+					services[j] = makeService(serviceUuid, srv, d)
 					break
 				}
 			}
 		} else {
 			// The caller wants to get all services, in any order.
-			services = append(services, DeviceService{
-				deviceService: &deviceService{
-					uuidWrapper: serviceUuid,
-					service:     srv,
-					device:      d,
-				},
-			})
+			services = append(services, makeService(serviceUuid, srv, d))
 		}
 
 		go func() {
@@ -160,6 +148,7 @@ func winRTUuidToUuid(uuid syscall.GUID) UUID {
 // struct method of the same name.
 type uuidWrapper = UUID
 
+// Small helper to create a DeviceService object.
 func makeService(serviceUuid uuidWrapper, srv *genericattributeprofile.GattDeviceService, d Device) DeviceService {
 	svc := DeviceService{
 		deviceService: &deviceService{
@@ -171,11 +160,11 @@ func makeService(serviceUuid uuidWrapper, srv *genericattributeprofile.GattDevic
 	return svc
 }
 
+// DeviceService is a BLE service on a connected peripheral device.
 type DeviceService struct {
 	*deviceService
 }
 
-// DeviceService is a BLE service on a connected peripheral device.
 type deviceService struct {
 	uuidWrapper
 


### PR DESCRIPTION
The services will now appear on the expected order

Closes #414 

Similar to #409 and its #410 pull request