### PR TITLE
feat(gap): add Device.Connected()

### DIFF
--- a/gap.go
+++ b/gap.go
@@ -134,6 +134,7 @@ type Connection uint16
 type GAPDevice interface {
 	DiscoverServices(uuids []UUID) ([]DeviceService, error)
 	RequestConnectionParams(params ConnectionParams) error
+	Connected() (bool, error)
 	Disconnect() error
 }
 

--- a/gap_darwin.go
+++ b/gap_darwin.go
@@ -178,6 +178,11 @@ func (d Device) Disconnect() error {
 	return nil
 }
 
+// Connected returns whether the device is currently connected.
+func (d Device) Connected() (bool, error) {
+	return d.prph.State() == cbgo.PeripheralStateConnected, nil
+}
+
 // RequestConnectionParams requests a different connection latency and timeout
 // of the given device connection. Fields that are unset will be left alone.
 // Whether or not the device will actually honor this, depends on the device and

--- a/gap_hci.go
+++ b/gap_hci.go
@@ -296,6 +296,10 @@ func (d Device) Disconnect() error {
 	return nil
 }
 
+func (d Device) Connected() (bool, error) {
+	return false, errNotYetImplmented
+}
+
 // RequestConnectionParams requests a different connection latency and timeout
 // of the given device connection. Fields that are unset will be left alone.
 // Whether or not the device will actually honor this, depends on the device and

--- a/gap_linux.go
+++ b/gap_linux.go
@@ -540,6 +540,15 @@ func (d Device) Disconnect() error {
 	return d.device.Call("org.bluez.Device1.Disconnect", 0).Err
 }
 
+// Connected returns whether the device is currently connected.
+func (d Device) Connected() (bool, error) {
+	val, err := d.device.GetProperty("org.bluez.Device1.Connected")
+	if err != nil {
+		return false, err
+	}
+	return val.Value().(bool), nil
+}
+
 // RequestConnectionParams requests a different connection latency and timeout
 // of the given device connection. Fields that are unset will be left alone.
 // Whether or not the device will actually honor this, depends on the device and

--- a/gap_nrf51.go
+++ b/gap_nrf51.go
@@ -125,4 +125,8 @@ func (d Device) RequestConnectionParams(params ConnectionParams) error {
 	return errNotYetImplmented
 }
 
+func (d Device) Connected() (bool, error) {
+	return false, errNotYetImplmented
+}
+
 type DeviceService struct{}

--- a/gap_nrf528xx-central.go
+++ b/gap_nrf528xx-central.go
@@ -237,3 +237,7 @@ func (d Device) RequestConnectionParams(params ConnectionParams) error {
 	errCode := C.sd_ble_gap_conn_param_update(d.connectionHandle, &connParams)
 	return makeError(errCode)
 }
+
+func (d Device) Connected() (bool, error) {
+	return false, errNotYetImplmented
+}

--- a/gap_s113v7.go
+++ b/gap_s113v7.go
@@ -25,4 +25,8 @@ func (d Device) RequestConnectionParams(params ConnectionParams) error {
 	return errNotYetImplmented
 }
 
+func (d Device) Connected() (bool, error) {
+	return false, errNotYetImplmented
+}
+
 type DeviceService struct{}

--- a/gap_windows.go
+++ b/gap_windows.go
@@ -430,6 +430,18 @@ func (d Device) Disconnect() error {
 	return nil
 }
 
+// Connected returns whether the device is currently connected.
+func (d Device) Connected() (bool, error) {
+	if d.device == nil {
+		return false, nil
+	}
+	status, err := d.device.GetConnectionStatus()
+	if err != nil {
+		return false, err
+	}
+	return status == bluetooth.BluetoothConnectionStatusConnected, nil
+}
+
 // RequestConnectionParams requests a different connection latency and timeout
 // of the given device connection. Fields that are unset will be left alone.
 // Whether or not the device will actually honor this, depends on the device and


### PR DESCRIPTION
It is currently not possible to know wether we are connected or not.

This allow the user to know if the device is connected.