### PR TITLE
fix(darwin): Device.DiscoverServices() filters discovered services

### DIFF
--- a/gattc_darwin.go
+++ b/gattc_darwin.go
@@ -16,7 +16,16 @@ import (
 // Passing a nil slice of UUIDs will return a complete list of
 // services.
 func (d Device) DiscoverServices(uuids []UUID) ([]DeviceService, error) {
-	d.prph.DiscoverServices([]cbgo.UUID{})
+	cbuuids := make([]cbgo.UUID, len(uuids))
+	for i, u := range uuids {
+		cbuuid, err := cbgo.ParseUUID(u.String())
+		if err != nil {
+			return nil, err
+		}
+		cbuuids[i] = cbuuid
+	}
+
+	d.prph.DiscoverServices(cbuuids)
 
 	// clear cache of services
 	d.services = make(map[UUID]DeviceService)

--- a/gattc_darwin.go
+++ b/gattc_darwin.go
@@ -115,7 +115,14 @@ func (s DeviceService) UUID() UUID {
 // Passing a nil slice of UUIDs will return a complete list of
 // characteristics.
 func (s DeviceService) DiscoverCharacteristics(uuids []UUID) ([]DeviceCharacteristic, error) {
-	cbuuids := []cbgo.UUID{}
+	cbuuids := make([]cbgo.UUID, len(uuids))
+	for i, u := range uuids {
+		cbuuid, err := cbgo.ParseUUID(u.String())
+		if err != nil {
+			return nil, err
+		}
+		cbuuids[i] = cbuuid
+	}
 
 	s.device.prph.DiscoverCharacteristics(cbuuids, s.service)
 


### PR DESCRIPTION
Currently, even if you pass a slice of services to discover. CoreBluetooth still discover ALL services which is **slow**.

[As per the CoreBluetooth documentation](https://developer.apple.com/documentation/corebluetooth/cbperipheral/discoverservices(_:)#Discussion): 

> If the servicesUUIDs parameter is nil, this method returns all of the peripheral’s available services. This is much slower than providing an array of service UUIDs to search for.

---

Edit: also added the same fix for DiscoverCharacteristics