### PR TITLE
feat(gap): add GAPDevice as base interface

### DIFF
--- a/gap.go
+++ b/gap.go
@@ -130,8 +130,8 @@ func NewDuration(interval time.Duration) Duration {
 // Connection is a numeric identifier that indicates a connection handle.
 type Connection uint16
 
-// DeviceInterface is the shared interface that all platform-specific Device types must implement.
-type DeviceInterface interface {
+// GAPDevice is the shared interface that all platform-specific Device types must implement.
+type GAPDevice interface {
 	DiscoverServices(uuids []UUID) ([]DeviceService, error)
 	RequestConnectionParams(params ConnectionParams) error
 	Disconnect() error

--- a/gap.go
+++ b/gap.go
@@ -130,6 +130,13 @@ func NewDuration(interval time.Duration) Duration {
 // Connection is a numeric identifier that indicates a connection handle.
 type Connection uint16
 
+// DeviceInterface is the shared interface that all platform-specific Device types must implement.
+type DeviceInterface interface {
+	DiscoverServices(uuids []UUID) ([]DeviceService, error)
+	RequestConnectionParams(params ConnectionParams) error
+	Disconnect() error
+}
+
 // ScanResult contains information from when an advertisement packet was
 // received. It is passed as a parameter to the callback of the Scan method.
 type ScanResult struct {

--- a/gap_darwin.go
+++ b/gap_darwin.go
@@ -83,6 +83,8 @@ func (a *Adapter) StopScan() error {
 	return nil
 }
 
+var _ DeviceInterface = Device{}
+
 // Device is a connection to a remote peripheral.
 type Device struct {
 	Address Address

--- a/gap_darwin.go
+++ b/gap_darwin.go
@@ -83,7 +83,7 @@ func (a *Adapter) StopScan() error {
 	return nil
 }
 
-var _ DeviceInterface = Device{}
+var _ GAPDevice = Device{}
 
 // Device is a connection to a remote peripheral.
 type Device struct {

--- a/gap_hci.go
+++ b/gap_hci.go
@@ -267,7 +267,7 @@ type notificationRegistration struct {
 	callback func([]byte)
 }
 
-var _ DeviceInterface = Device{}
+var _ GAPDevice = Device{}
 
 // Device is a connection to a remote peripheral.
 type Device struct {

--- a/gap_hci.go
+++ b/gap_hci.go
@@ -267,6 +267,8 @@ type notificationRegistration struct {
 	callback func([]byte)
 }
 
+var _ DeviceInterface = Device{}
+
 // Device is a connection to a remote peripheral.
 type Device struct {
 	Address Address

--- a/gap_linux.go
+++ b/gap_linux.go
@@ -430,7 +430,7 @@ func makeScanResult(props map[string]dbus.Variant) ScanResult {
 	}
 }
 
-var _ DeviceInterface = Device{}
+var _ GAPDevice = Device{}
 
 // Device is a connection to a remote bluetooth device.
 type Device struct {

--- a/gap_linux.go
+++ b/gap_linux.go
@@ -430,6 +430,8 @@ func makeScanResult(props map[string]dbus.Variant) ScanResult {
 	}
 }
 
+var _ DeviceInterface = Device{}
+
 // Device is a connection to a remote bluetooth device.
 type Device struct {
 	Address Address // the MAC address of the device

--- a/gap_nrf51.go
+++ b/gap_nrf51.go
@@ -108,3 +108,21 @@ func (a *Adapter) SetRandomAddress(mac MAC) error {
 	}
 	return nil
 }
+
+// Disconnect from the BLE device.
+func (d Device) Disconnect() error {
+	return errNotYetImplmented
+}
+
+// DiscoverServices starts a service discovery procedure.
+func (d Device) DiscoverServices(uuids []UUID) ([]DeviceService, error) {
+	return nil, errNotYetImplmented
+}
+
+// RequestConnectionParams requests a different connection latency and timeout
+// of the given device connection.
+func (d Device) RequestConnectionParams(params ConnectionParams) error {
+	return errNotYetImplmented
+}
+
+type DeviceService struct{}

--- a/gap_s113v7.go
+++ b/gap_s113v7.go
@@ -1,0 +1,28 @@
+//go:build softdevice && s113v7
+
+package bluetooth
+
+/*
+// Add the correct SoftDevice include path to CFLAGS, so #include will work as
+// expected.
+#cgo CFLAGS: -Is113_nrf52_7.0.1/s113_nrf52_7.0.1_API/include
+*/
+import "C"
+
+// Disconnect from the BLE device.
+func (d Device) Disconnect() error {
+	return errNotYetImplmented
+}
+
+// DiscoverServices starts a service discovery procedure.
+func (d Device) DiscoverServices(uuids []UUID) ([]DeviceService, error) {
+	return nil, errNotYetImplmented
+}
+
+// RequestConnectionParams requests a different connection latency and timeout
+// of the given device connection.
+func (d Device) RequestConnectionParams(params ConnectionParams) error {
+	return errNotYetImplmented
+}
+
+type DeviceService struct{}

--- a/gap_sd.go
+++ b/gap_sd.go
@@ -7,7 +7,7 @@ package bluetooth
 */
 import "C"
 
-var _ DeviceInterface = Device{}
+var _ GAPDevice = Device{}
 
 // Device is a connection to a remote peripheral or central.
 type Device struct {

--- a/gap_sd.go
+++ b/gap_sd.go
@@ -15,19 +15,3 @@ type Device struct {
 
 	connectionHandle C.uint16_t
 }
-
-// Disconnect from the BLE device.
-func (d Device) Disconnect() error {
-	return errNotYetImplmented
-}
-
-// DiscoverServices starts a service discovery procedure.
-func (d Device) DiscoverServices(uuids []UUID) ([]DeviceService, error) {
-	return nil, errNotYetImplmented
-}
-
-// RequestConnectionParams requests a different connection latency and timeout
-// of the given device connection.
-func (d Device) RequestConnectionParams(params ConnectionParams) error {
-	return errNotYetImplmented
-}

--- a/gap_sd.go
+++ b/gap_sd.go
@@ -7,9 +7,27 @@ package bluetooth
 */
 import "C"
 
+var _ DeviceInterface = Device{}
+
 // Device is a connection to a remote peripheral or central.
 type Device struct {
 	Address Address
 
 	connectionHandle C.uint16_t
+}
+
+// Disconnect from the BLE device.
+func (d Device) Disconnect() error {
+	return errNotYetImplmented
+}
+
+// DiscoverServices starts a service discovery procedure.
+func (d Device) DiscoverServices(uuids []UUID) ([]DeviceService, error) {
+	return nil, errNotYetImplmented
+}
+
+// RequestConnectionParams requests a different connection latency and timeout
+// of the given device connection.
+func (d Device) RequestConnectionParams(params ConnectionParams) error {
+	return errNotYetImplmented
 }

--- a/gap_windows.go
+++ b/gap_windows.go
@@ -282,6 +282,8 @@ func (a *Adapter) StopScan() error {
 	return a.watcher.Stop()
 }
 
+var _ DeviceInterface = Device{}
+
 // Device is a connection to a remote peripheral.
 type Device struct {
 	ctx    context.Context

--- a/gap_windows.go
+++ b/gap_windows.go
@@ -282,7 +282,7 @@ func (a *Adapter) StopScan() error {
 	return a.watcher.Stop()
 }
 
-var _ DeviceInterface = Device{}
+var _ GAPDevice = Device{}
 
 // Device is a connection to a remote peripheral.
 type Device struct {


### PR DESCRIPTION
All platforms implementation of Device must now satisfy the interface.

This makes it easier to change the contract of a device accross platforms.

Related to #426 