### PR TITLE
fix(darwin): add DidFailToConnectPeripheral handler

### DIFF
--- a/adapter_darwin.go
+++ b/adapter_darwin.go
@@ -131,6 +131,17 @@ func (cmd *centralManagerDelegate) DidConnectPeripheral(cmgr cbgo.CentralManager
 	}
 }
 
+// DidFailToConnectPeripheral when peripheral connection fails.
+func (cmd *centralManagerDelegate) DidFailToConnectPeripheral(cmgr cbgo.CentralManager, prph cbgo.Peripheral, err error) {
+	id := prph.Identifier().String()
+
+	// Send the peripheral through so ConnectWithContext can check its state
+	// and return the appropriate error.
+	if ch, ok := cmd.a.connectMap.LoadAndDelete(id); ok {
+		ch.(chan cbgo.Peripheral) <- prph
+	}
+}
+
 // makeScanResult creates a ScanResult when peripheral is found.
 func makeScanResult(prph cbgo.Peripheral, advFields cbgo.AdvFields, rssi int) ScanResult {
 	uuid, _ := ParseUUID(prph.Identifier().String())

--- a/adapter_darwin.go
+++ b/adapter_darwin.go
@@ -135,7 +135,7 @@ func (cmd *centralManagerDelegate) DidConnectPeripheral(cmgr cbgo.CentralManager
 func (cmd *centralManagerDelegate) DidFailToConnectPeripheral(cmgr cbgo.CentralManager, prph cbgo.Peripheral, err error) {
 	id := prph.Identifier().String()
 
-	// Send the peripheral through so ConnectWithContext can check its state
+	// Send the peripheral through so Connect can check its state
 	// and return the appropriate error.
 	if ch, ok := cmd.a.connectMap.LoadAndDelete(id); ok {
 		ch.(chan cbgo.Peripheral) <- prph


### PR DESCRIPTION
When using the Connect on peripherals with an unstable state, I've found that it might be because of the missing `DidFailToConnectPeripheral` handler (https://developer.apple.com/documentation/corebluetooth/cbcentralmanagerdelegate/centralmanager(_:didfailtoconnect:error:)?language=objc)

> After successfully establishing a local connection to a peripheral, the central manager object calls the [centralManager:didConnectPeripheral:](https://developer.apple.com/documentation/corebluetooth/cbcentralmanagerdelegate/centralmanager(_:didconnect:)?language=objc) method of its delegate object. If the connection attempt fails, the central manager object calls the [centralManager:didFailToConnectPeripheral:error:](https://developer.apple.com/documentation/corebluetooth/cbcentralmanagerdelegate/centralmanager(_:didfailtoconnect:error:)?language=objc) method of its delegate object instead. Attempts to connect to a peripheral don’t time out. To explicitly cancel a pending connection to a peripheral, call the [cancelPeripheralConnection:](https://developer.apple.com/documentation/corebluetooth/cbcentralmanager/cancelperipheralconnection(_:)?language=objc) method. Deallocating peripheral also implicitly calls [cancelPeripheralConnection:](https://developer.apple.com/documentation/corebluetooth/cbcentralmanager/cancelperipheralconnection(_:)?language=objc).

So this should properly handle the connection failed event.

Note:

I would like to be able to use that error object. However, it requires to completely change the channel type.

I might do another PR later.