### PR TITLE
feat: add BLEAdapter common interface

### DIFF
--- a/adapter.go
+++ b/adapter.go
@@ -1,6 +1,15 @@
 package bluetooth
 
-// SetConnectHandler sets a handler function to be called whenever the adaptor connects
+// BLEAdapter is the shared interface that all platform-specific Adapter types must implement.
+type BLEAdapter interface {
+	Connect(address Address, params ConnectionParams) (Device, error)
+	Enable() error
+	Scan(callback func(*Adapter, ScanResult)) (err error)
+	SetConnectHandler(c func(device Device, connected bool))
+	StopScan() error
+}
+
+// SetConnectHandler sets a handler function to be called whenever the adapter connects
 // or disconnects. You must call this before you call adapter.Connect() for centrals
 // or advertisement.Start() for peripherals in order for it to work.
 func (a *Adapter) SetConnectHandler(c func(device Device, connected bool)) {

--- a/adapter_cyw43439.go
+++ b/adapter_cyw43439.go
@@ -12,6 +12,8 @@ import (
 
 const maxConnections = 1
 
+var _ BLEAdapter = &Adapter{}
+
 // Adapter represents a SPI connection to the HCI controller on an attached CYW4349 module.
 type Adapter struct {
 	hciAdapter

--- a/adapter_cyw43439.go
+++ b/adapter_cyw43439.go
@@ -12,7 +12,7 @@ import (
 
 const maxConnections = 1
 
-var _ BLEAdapter = &Adapter{}
+var _ BLEAdapter = (*Adapter)(nil)
 
 // Adapter represents a SPI connection to the HCI controller on an attached CYW4349 module.
 type Adapter struct {

--- a/adapter_darwin.go
+++ b/adapter_darwin.go
@@ -8,6 +8,8 @@ import (
 	"github.com/tinygo-org/cbgo"
 )
 
+var _ BLEAdapter = &Adapter{}
+
 // Adapter is a connection to BLE devices.
 type Adapter struct {
 	cmd *centralManagerDelegate

--- a/adapter_darwin.go
+++ b/adapter_darwin.go
@@ -8,7 +8,7 @@ import (
 	"github.com/tinygo-org/cbgo"
 )
 
-var _ BLEAdapter = &Adapter{}
+var _ BLEAdapter = (*Adapter)(nil)
 
 // Adapter is a connection to BLE devices.
 type Adapter struct {

--- a/adapter_hci_uart.go
+++ b/adapter_hci_uart.go
@@ -8,6 +8,8 @@ import (
 
 const maxConnections = 1
 
+var _ BLEAdapter = &Adapter{}
+
 // Adapter represents a "plain" UART connection to the HCI controller.
 type Adapter struct {
 	hciAdapter

--- a/adapter_hci_uart.go
+++ b/adapter_hci_uart.go
@@ -8,7 +8,7 @@ import (
 
 const maxConnections = 1
 
-var _ BLEAdapter = &Adapter{}
+var _ BLEAdapter = (*Adapter)(nil)
 
 // Adapter represents a "plain" UART connection to the HCI controller.
 type Adapter struct {

--- a/adapter_linux.go
+++ b/adapter_linux.go
@@ -14,6 +14,8 @@ import (
 
 const defaultAdapter = "hci0"
 
+var _ BLEAdapter = &Adapter{}
+
 type Adapter struct {
 	id                   string
 	scanCancelChan       chan struct{}

--- a/adapter_linux.go
+++ b/adapter_linux.go
@@ -14,7 +14,7 @@ import (
 
 const defaultAdapter = "hci0"
 
-var _ BLEAdapter = &Adapter{}
+var _ BLEAdapter = (*Adapter)(nil)
 
 type Adapter struct {
 	id                   string

--- a/adapter_ninafw.go
+++ b/adapter_ninafw.go
@@ -9,6 +9,8 @@ import (
 
 const maxConnections = 1
 
+var _ BLEAdapter = &Adapter{}
+
 // Adapter represents the HCI connection to the NINA fw using the hardware UART.
 type Adapter struct {
 	hciAdapter

--- a/adapter_ninafw.go
+++ b/adapter_ninafw.go
@@ -9,7 +9,7 @@ import (
 
 const maxConnections = 1
 
-var _ BLEAdapter = &Adapter{}
+var _ BLEAdapter = (*Adapter)(nil)
 
 // Adapter represents the HCI connection to the NINA fw using the hardware UART.
 type Adapter struct {

--- a/adapter_nrf51.go
+++ b/adapter_nrf51.go
@@ -127,3 +127,24 @@ func makeMACAddress(addr C.ble_gap_addr_t) MACAddress {
 		isRandom: addr.addr_type != 0,
 	}
 }
+
+// Connect starts a connection attempt to the given peripheral device address.
+//
+// Not yet implemented on the nrf51.
+func (a *Adapter) Connect(address Address, params ConnectionParams) (Device, error) {
+	return Device{}, errNotYetImplmented
+}
+
+// Scan starts a BLE scan. It is stopped by a call to StopScan.
+//
+// Not yet implemented on the nrf51.
+func (a *Adapter) Scan(callback func(*Adapter, ScanResult)) (err error) {
+	return errNotYetImplmented
+}
+
+// StopScan stops any in-progress scan.
+//
+// Not yet implemented on the nrf51.
+func (a *Adapter) StopScan() error {
+	return errNotYetImplmented
+}

--- a/adapter_s113v7.go
+++ b/adapter_s113v7.go
@@ -11,3 +11,24 @@ package bluetooth
 nrf_nvic_state_t nrf_nvic_state = {0};
 */
 import "C"
+
+// Connect starts a connection attempt to the given peripheral device address.
+//
+// Not yet implemented on the s113v7.
+func (a *Adapter) Connect(address Address, params ConnectionParams) (Device, error) {
+	return Device{}, errNotYetImplmented
+}
+
+// Scan starts a BLE scan. It is stopped by a call to StopScan.
+//
+// Not yet implemented on the s113v7.
+func (a *Adapter) Scan(callback func(*Adapter, ScanResult)) (err error) {
+	return errNotYetImplmented
+}
+
+// StopScan stops any in-progress scan.
+//
+// Not yet implemented on the s113v7.
+func (a *Adapter) StopScan() error {
+	return errNotYetImplmented
+}

--- a/adapter_s113v7.go
+++ b/adapter_s113v7.go
@@ -14,21 +14,21 @@ import "C"
 
 // Connect starts a connection attempt to the given peripheral device address.
 //
-// Not yet implemented on the s113v7.
+// s113v7 is a peripheral-only device, so this is not supported.
 func (a *Adapter) Connect(address Address, params ConnectionParams) (Device, error) {
-	return Device{}, errNotYetImplmented
+	return Device{}, errNotSupported
 }
 
 // Scan starts a BLE scan. It is stopped by a call to StopScan.
 //
-// Not yet implemented on the s113v7.
+// s113v7 is a peripheral-only device, so this is not supported.
 func (a *Adapter) Scan(callback func(*Adapter, ScanResult)) (err error) {
-	return errNotYetImplmented
+	return errNotSupported
 }
 
 // StopScan stops any in-progress scan.
 //
-// Not yet implemented on the s113v7.
+// s113v7 is a peripheral-only device, so this is not supported.
 func (a *Adapter) StopScan() error {
-	return errNotYetImplmented
+	return errNotSupported
 }

--- a/adapter_sd.go
+++ b/adapter_sd.go
@@ -41,7 +41,7 @@ func init() {
 	secModeOpen.set_bitfield_lv(1)
 }
 
-var _ BLEAdapter = &Adapter{}
+var _ BLEAdapter = (*Adapter)(nil)
 
 // Adapter is a dummy adapter: it represents the connection to the (only)
 // SoftDevice on the chip.

--- a/adapter_sd.go
+++ b/adapter_sd.go
@@ -41,6 +41,8 @@ func init() {
 	secModeOpen.set_bitfield_lv(1)
 }
 
+var _ BLEAdapter = &Adapter{}
+
 // Adapter is a dummy adapter: it represents the connection to the (only)
 // SoftDevice on the chip.
 type Adapter struct {

--- a/adapter_windows.go
+++ b/adapter_windows.go
@@ -10,6 +10,8 @@ import (
 	"github.com/saltosystems/winrt-go/windows/foundation"
 )
 
+var _ BLEAdapter = &Adapter{}
+
 type Adapter struct {
 	watcher *advertisement.BluetoothLEAdvertisementWatcher
 

--- a/adapter_windows.go
+++ b/adapter_windows.go
@@ -10,7 +10,7 @@ import (
 	"github.com/saltosystems/winrt-go/windows/foundation"
 )
 
-var _ BLEAdapter = &Adapter{}
+var _ BLEAdapter = (*Adapter)(nil)
 
 type Adapter struct {
 	watcher *advertisement.BluetoothLEAdvertisementWatcher

--- a/gap.go
+++ b/gap.go
@@ -11,6 +11,7 @@ var (
 	errScanStopped               = errors.New("bluetooth: scan was stopped unexpectedly")
 	errAdvertisementPacketTooBig = errors.New("bluetooth: advertisement packet overflows")
 	errNotYetImplmented          = errors.New("bluetooth: not implemented")
+	errNotSupported              = errors.New("bluetooth: not supported")
 )
 
 const (

--- a/gap_nrf51.go
+++ b/gap_nrf51.go
@@ -110,21 +110,30 @@ func (a *Adapter) SetRandomAddress(mac MAC) error {
 }
 
 // Disconnect from the BLE device.
+//
+// Not yet implemented on the nrf51.
 func (d Device) Disconnect() error {
 	return errNotYetImplmented
 }
 
 // DiscoverServices starts a service discovery procedure.
+//
+// Not yet implemented on the nrf51.
 func (d Device) DiscoverServices(uuids []UUID) ([]DeviceService, error) {
 	return nil, errNotYetImplmented
 }
 
 // RequestConnectionParams requests a different connection latency and timeout
 // of the given device connection.
+//
+// Not yet implemented on the nrf51.
 func (d Device) RequestConnectionParams(params ConnectionParams) error {
 	return errNotYetImplmented
 }
 
+// Connected returns whether the device is currently connected.
+//
+// Not yet implemented on the nrf51.
 func (d Device) Connected() (bool, error) {
 	return false, errNotYetImplmented
 }

--- a/gap_s113v7.go
+++ b/gap_s113v7.go
@@ -10,21 +10,30 @@ package bluetooth
 import "C"
 
 // Disconnect from the BLE device.
+//
+// Not yet implemented on the s113v7.
 func (d Device) Disconnect() error {
 	return errNotYetImplmented
 }
 
 // DiscoverServices starts a service discovery procedure.
+//
+// Not yet implemented on the s113v7.
 func (d Device) DiscoverServices(uuids []UUID) ([]DeviceService, error) {
 	return nil, errNotYetImplmented
 }
 
 // RequestConnectionParams requests a different connection latency and timeout
 // of the given device connection.
+//
+// Not yet implemented on the s113v7.
 func (d Device) RequestConnectionParams(params ConnectionParams) error {
 	return errNotYetImplmented
 }
 
+// Connected returns whether the device is currently connected.
+//
+// Not yet implemented on the s113v7.
 func (d Device) Connected() (bool, error) {
 	return false, errNotYetImplmented
 }

--- a/gap_s113v7.go
+++ b/gap_s113v7.go
@@ -11,31 +11,31 @@ import "C"
 
 // Disconnect from the BLE device.
 //
-// Not yet implemented on the s113v7.
+// s113v7 is a peripheral-only device, so this is not supported.
 func (d Device) Disconnect() error {
-	return errNotYetImplmented
+	return errNotSupported
 }
 
 // DiscoverServices starts a service discovery procedure.
 //
-// Not yet implemented on the s113v7.
+// s113v7 is a peripheral-only device, so this is not supported.
 func (d Device) DiscoverServices(uuids []UUID) ([]DeviceService, error) {
-	return nil, errNotYetImplmented
+	return nil, errNotSupported
 }
 
 // RequestConnectionParams requests a different connection latency and timeout
 // of the given device connection.
 //
-// Not yet implemented on the s113v7.
+// s113v7 is a peripheral-only device, so this is not supported.
 func (d Device) RequestConnectionParams(params ConnectionParams) error {
-	return errNotYetImplmented
+	return errNotSupported
 }
 
 // Connected returns whether the device is currently connected.
 //
-// Not yet implemented on the s113v7.
+// s113v7 is a peripheral-only device, so this is not supported.
 func (d Device) Connected() (bool, error) {
-	return false, errNotYetImplmented
+	return false, errNotSupported
 }
 
 type DeviceService struct{}


### PR DESCRIPTION
Following https://github.com/tinygo-org/bluetooth/pull/429, this PR adds a base interface to ensure that each platform implements a common set of feature.