### PR TITLE
feat: addGATTCService and GATTCCharacteristic common interface

### DIFF
--- a/gattc.go
+++ b/gattc.go
@@ -1,0 +1,41 @@
+//go:build !baremetal || (softdevice && s132v6) || (softdevice && s140v6) || (softdevice && s140v7) || hci || ninafw || cyw43439
+
+package bluetooth
+
+// GATTCService is the common interface that all platform-specific
+// DeviceService types must implement.
+type GATTCService interface {
+	// UUID returns the UUID for this DeviceService.
+	UUID() UUID
+
+	// DiscoverCharacteristics discovers characteristics in this service.
+	// Pass a list of characteristic UUIDs you are interested in to this
+	// function. Either a list of all requested services is returned, or if
+	// some services could not be discovered an error is returned.
+	DiscoverCharacteristics(uuids []UUID) ([]DeviceCharacteristic, error)
+}
+
+// GATTCCharacteristic is the common interface that all platform-specific
+// DeviceCharacteristic types must implement.
+type GATTCCharacteristic interface {
+	// UUID returns the UUID for this DeviceCharacteristic.
+	UUID() UUID
+
+	// Read reads the current characteristic value.
+	Read(data []byte) (int, error)
+
+	// Write replaces the characteristic value with a new value.
+	Write(p []byte) (n int, err error)
+
+	// WriteWithoutResponse replaces the characteristic value with a new
+	// value. The call will return before all data has been written.
+	WriteWithoutResponse(p []byte) (n int, err error)
+
+	// EnableNotifications enables notifications for this characteristic,
+	// calling the provided callback with the new value when the
+	// characteristic value is changed by the remote peripheral.
+	EnableNotifications(callback func(buf []byte)) error
+
+	// GetMTU returns the MTU for this characteristic.
+	GetMTU() (uint16, error)
+}

--- a/gattc.go
+++ b/gattc.go
@@ -1,4 +1,4 @@
-//go:build !baremetal || (softdevice && s132v6) || (softdevice && s140v6) || (softdevice && s140v7) || hci || ninafw || cyw43439
+//go:build !baremetal || !(s110v8 || s113v7)
 
 package bluetooth
 

--- a/gattc_darwin.go
+++ b/gattc_darwin.go
@@ -8,8 +8,11 @@ import (
 	"github.com/tinygo-org/cbgo"
 )
 
+var errCannotSendWriteWithoutResponse = errors.New("bluetooth: cannot send write without response (buffer full)")
+
 var (
-	errCannotSendWriteWithoutResponse = errors.New("bluetooth: cannot send write without response (buffer full)")
+	_ GATTCService        = DeviceService{}
+	_ GATTCCharacteristic = DeviceCharacteristic{}
 )
 
 // DiscoverServices starts a service discovery procedure. Pass a list of service

--- a/gattc_darwin.go
+++ b/gattc_darwin.go
@@ -11,8 +11,8 @@ import (
 var errCannotSendWriteWithoutResponse = errors.New("bluetooth: cannot send write without response (buffer full)")
 
 var (
-	_ GATTCService        = DeviceService{}
-	_ GATTCCharacteristic = DeviceCharacteristic{}
+	_ GATTCService        = (*DeviceService)(nil)
+	_ GATTCCharacteristic = (*DeviceCharacteristic)(nil)
 )
 
 // DiscoverServices starts a service discovery procedure. Pass a list of service

--- a/gattc_hci.go
+++ b/gattc_hci.go
@@ -17,6 +17,11 @@ var (
 	errCharacteristicNotFound    = errors.New("bluetooth: characteristic not found")
 )
 
+var (
+	_ GATTCService        = DeviceService{}
+	_ GATTCCharacteristic = DeviceCharacteristic{}
+)
+
 const (
 	maxDefaultServicesToDiscover        = 8
 	maxDefaultCharacteristicsToDiscover = 16
@@ -234,6 +239,13 @@ func (s DeviceService) DiscoverCharacteristics(uuids []UUID) ([]DeviceCharacteri
 	}
 
 	return characteristics, nil
+}
+
+// Write replaces the characteristic value with a new value.
+//
+// Not yet implemented on HCI.
+func (c DeviceCharacteristic) Write(p []byte) (n int, err error) {
+	return 0, errNotYetImplemented
 }
 
 // WriteWithoutResponse replaces the characteristic value with a new value. The

--- a/gattc_hci.go
+++ b/gattc_hci.go
@@ -18,8 +18,8 @@ var (
 )
 
 var (
-	_ GATTCService        = DeviceService{}
-	_ GATTCCharacteristic = DeviceCharacteristic{}
+	_ GATTCService        = (*DeviceService)(nil)
+	_ GATTCCharacteristic = (*DeviceCharacteristic)(nil)
 )
 
 const (

--- a/gattc_linux.go
+++ b/gattc_linux.go
@@ -12,6 +12,11 @@ import (
 )
 
 var (
+	_ GATTCService        = DeviceService{}
+	_ GATTCCharacteristic = (*DeviceCharacteristic)(nil)
+)
+
+var (
 	errDupNotif = errors.New("unclosed notifications")
 )
 

--- a/gattc_linux.go
+++ b/gattc_linux.go
@@ -12,7 +12,7 @@ import (
 )
 
 var (
-	_ GATTCService        = DeviceService{}
+	_ GATTCService        = (*DeviceService)(nil)
 	_ GATTCCharacteristic = (*DeviceCharacteristic)(nil)
 )
 

--- a/gattc_sd.go
+++ b/gattc_sd.go
@@ -20,6 +20,11 @@ const (
 )
 
 var (
+	_ GATTCService        = DeviceService{}
+	_ GATTCCharacteristic = DeviceCharacteristic{}
+)
+
+var (
 	errAlreadyDiscovering = errors.New("bluetooth: already discovering a service or characteristic")
 	errNotFound           = errors.New("bluetooth: not found")
 	errNoNotify           = errors.New("bluetooth: no notify permission")
@@ -310,6 +315,13 @@ func (s DeviceService) DiscoverCharacteristics(uuids []UUID) ([]DeviceCharacteri
 	}
 
 	return characteristics, nil
+}
+
+// Write replaces the characteristic value with a new value.
+//
+// Not yet implemented on SoftDevice.
+func (c DeviceCharacteristic) Write(p []byte) (n int, err error) {
+	return 0, errNotFound
 }
 
 // WriteWithoutResponse replaces the characteristic value with a new value. The

--- a/gattc_sd.go
+++ b/gattc_sd.go
@@ -20,8 +20,8 @@ const (
 )
 
 var (
-	_ GATTCService        = DeviceService{}
-	_ GATTCCharacteristic = DeviceCharacteristic{}
+_ GATTCService        = (*DeviceService)(nil)
+_ GATTCCharacteristic = (*DeviceCharacteristic)(nil)
 )
 
 var (

--- a/gattc_windows.go
+++ b/gattc_windows.go
@@ -16,8 +16,8 @@ import (
 )
 
 var (
-	_ GATTCService        = DeviceService{}
-	_ GATTCCharacteristic = DeviceCharacteristic{}
+	_ GATTCService        = (*DeviceService)(nil)
+	_ GATTCCharacteristic = (*DeviceCharacteristic)(nil)
 )
 
 var (

--- a/gattc_windows.go
+++ b/gattc_windows.go
@@ -16,6 +16,11 @@ import (
 )
 
 var (
+	_ GATTCService        = DeviceService{}
+	_ GATTCCharacteristic = DeviceCharacteristic{}
+)
+
+var (
 	errNoWrite                   = errors.New("bluetooth: write not supported")
 	errNoWriteWithoutResponse    = errors.New("bluetooth: write without response not supported")
 	errWriteFailed               = errors.New("bluetooth: write failed")


### PR DESCRIPTION
Following #431 and #429, this adds a common interface for DeviceService and DeviceCharacteristic.

This act as a base interface that each platform must implement.