### PR TITLE
fix(darwin): write without response canSendWriteWithoutResponse

### DIFF
--- a/gap_darwin.go
+++ b/gap_darwin.go
@@ -98,9 +98,8 @@ type deviceInternal struct {
 	cm   cbgo.CentralManager
 	prph cbgo.Peripheral
 
-	servicesChan           chan error
-	charsChan              chan error
-	writeWithoutResponseCh chan struct{}
+	servicesChan chan error
+	charsChan    chan error
 
 	services map[UUID]DeviceService
 }
@@ -144,11 +143,10 @@ func (a *Adapter) Connect(address Address, params ConnectionParams) (Device, err
 			d := Device{
 				Address: address,
 				deviceInternal: &deviceInternal{
-					cm:                     a.cm,
-					prph:                   p,
-					servicesChan:           make(chan error),
-					charsChan:              make(chan error),
-					writeWithoutResponseCh: make(chan struct{}, 1),
+					cm:           a.cm,
+					prph:         p,
+					servicesChan: make(chan error),
+					charsChan:    make(chan error),
 				},
 			}
 
@@ -239,15 +237,6 @@ func (pd *peripheralDelegate) DidUpdateValueForCharacteristic(prph cbgo.Peripher
 
 		}
 
-	}
-}
-
-// IsReadyToSendWriteWithoutResponse is called when the peripheral is again
-// ready to send write-without-response requests after the internal buffer was full.
-func (pd *peripheralDelegate) IsReadyToSendWriteWithoutResponse(prph cbgo.Peripheral) {
-	select {
-	case pd.d.writeWithoutResponseCh <- struct{}{}:
-	default:
 	}
 }
 

--- a/gap_darwin.go
+++ b/gap_darwin.go
@@ -98,8 +98,9 @@ type deviceInternal struct {
 	cm   cbgo.CentralManager
 	prph cbgo.Peripheral
 
-	servicesChan chan error
-	charsChan    chan error
+	servicesChan           chan error
+	charsChan              chan error
+	writeWithoutResponseCh chan struct{}
 
 	services map[UUID]DeviceService
 }
@@ -143,10 +144,11 @@ func (a *Adapter) Connect(address Address, params ConnectionParams) (Device, err
 			d := Device{
 				Address: address,
 				deviceInternal: &deviceInternal{
-					cm:           a.cm,
-					prph:         p,
-					servicesChan: make(chan error),
-					charsChan:    make(chan error),
+					cm:                     a.cm,
+					prph:                   p,
+					servicesChan:           make(chan error),
+					charsChan:              make(chan error),
+					writeWithoutResponseCh: make(chan struct{}, 1),
 				},
 			}
 
@@ -237,6 +239,15 @@ func (pd *peripheralDelegate) DidUpdateValueForCharacteristic(prph cbgo.Peripher
 
 		}
 
+	}
+}
+
+// IsReadyToSendWriteWithoutResponse is called when the peripheral is again
+// ready to send write-without-response requests after the internal buffer was full.
+func (pd *peripheralDelegate) IsReadyToSendWriteWithoutResponse(prph cbgo.Peripheral) {
+	select {
+	case pd.d.writeWithoutResponseCh <- struct{}{}:
+	default:
 	}
 }
 

--- a/gattc_darwin.go
+++ b/gattc_darwin.go
@@ -243,26 +243,21 @@ func (c DeviceCharacteristic) Write(p []byte) (n int, err error) {
 // WriteWithoutResponse replaces the characteristic value with a new value. The
 // call will return before all data has been written. A limited number of such
 // writes can be in flight at any given time.
-// If the peripheral's buffer is full, this method waits for the
-// peripheralIsReady(toSendWriteWithoutResponse:) delegate callback before
-// retrying, with a 10-second timeout.
+// If the peripheral's buffer is full, this method polls
+// CanSendWriteWithoutResponse every 15ms (one BLE connection interval) until
+// ready, with a 10-second timeout.
 func (c DeviceCharacteristic) WriteWithoutResponse(p []byte) (int, error) {
-	if !c.service.device.prph.CanSendWriteWithoutResponse() {
-		// Drain any stale readiness signal.
-		select {
-		case <-c.service.device.writeWithoutResponseCh:
-		default:
-		}
+	dev := c.service.device
 
-		// Wait for the delegate callback signalling the peripheral is ready.
-		select {
-		case <-c.service.device.writeWithoutResponseCh:
-		case <-time.NewTimer(10 * time.Second).C:
+	deadline := time.Now().Add(10 * time.Second)
+	for !dev.prph.CanSendWriteWithoutResponse() {
+		if time.Now().After(deadline) {
 			return 0, errWriteWithoutResponseTimeout
 		}
+		time.Sleep(15 * time.Millisecond)
 	}
 
-	c.service.device.prph.WriteCharacteristic(p, c.characteristic, false)
+	dev.prph.WriteCharacteristic(p, c.characteristic, false)
 
 	return len(p), nil
 }

--- a/gattc_darwin.go
+++ b/gattc_darwin.go
@@ -9,8 +9,8 @@ import (
 )
 
 var (
-	errCannotSendWriteWithoutResponse = errors.New("bluetooth: cannot send write without response (buffer full)")
-	errTimeoutEnableNotifications     = errors.New("timeout on EnableNotifications")
+	errWriteWithoutResponseTimeout = errors.New("bluetooth: write without response timed out waiting for buffer space")
+	errTimeoutEnableNotifications  = errors.New("timeout on EnableNotifications")
 )
 
 var (
@@ -243,10 +243,23 @@ func (c DeviceCharacteristic) Write(p []byte) (n int, err error) {
 // WriteWithoutResponse replaces the characteristic value with a new value. The
 // call will return before all data has been written. A limited number of such
 // writes can be in flight at any given time.
-// If the client is not ready to send write without response requests at this time (e.g. because the internal buffer is full), an error is returned.
+// If the peripheral's buffer is full, this method waits for the
+// peripheralIsReady(toSendWriteWithoutResponse:) delegate callback before
+// retrying, with a 10-second timeout.
 func (c DeviceCharacteristic) WriteWithoutResponse(p []byte) (int, error) {
 	if !c.service.device.prph.CanSendWriteWithoutResponse() {
-		return 0, errCannotSendWriteWithoutResponse
+		// Drain any stale readiness signal.
+		select {
+		case <-c.service.device.writeWithoutResponseCh:
+		default:
+		}
+
+		// Wait for the delegate callback signalling the peripheral is ready.
+		select {
+		case <-c.service.device.writeWithoutResponseCh:
+		case <-time.NewTimer(10 * time.Second).C:
+			return 0, errWriteWithoutResponseTimeout
+		}
 	}
 
 	c.service.device.prph.WriteCharacteristic(p, c.characteristic, false)


### PR DESCRIPTION
After https://github.com/tinygo-org/bluetooth/pull/386, WriteWithoutResponses does not work anymore. For some reason, the buffer is considered full.

This is actually a known issue: https://github.com/hbldh/bleak/discussions/1589

And we can take a look at how Nordic have implemented this to work on Mac:

https://github.com/nordicsemi/IOS-nRF-Connect-Device-Manager/blob/30925fa37b453fafd34eb470d24851c6667d4848/Source/Bluetooth/McuMgrBleTransport.swift#L413-L435

Basically, it is expected that the `canSendWriteWithoutResponse` will fail ~5 times before actually sending `true`.

---

I'm trying this with the https://developer.apple.com/documentation/corebluetooth/cbperipheraldelegate/peripheralisready(tosendwritewithoutresponse:) which avoid looping.

~~I will test this and will let you know if this works.~~

Update: I've successfully tested it and it work.

Update 2: I've removed depending on `peripheralisready` because it would be error prone to handle with channels and stale events