### PR TITLE
Ensure Ordered Notification Delivery on macOS

### DIFF
--- a/gap_darwin.go
+++ b/gap_darwin.go
@@ -220,7 +220,7 @@ func (pd *peripheralDelegate) DidUpdateValueForCharacteristic(prph cbgo.Peripher
 
 			if char.characteristic == chr && uuid == char.UUID() { // compare pointers
 				if err == nil && char.callback != nil {
-					go char.callback(chr.Value())
+					char.callback(chr.Value())
 				}
 
 				if char.readChan != nil {


### PR DESCRIPTION
While working on a project, I noticed that notifications are not delivered in order as the callback is called in a fresh goroutine. All other OS implementations already support ordered delivery.