### PR TITLE
feat!: add err parameter to connectHandler

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,13 +72,13 @@ func main() {
 	must("enable BLE stack", adapter.Enable())
 
 	ctx, cancel := context.WithCancel(context.Background())
-	adapter.SetConnectHandler(func(device bluetooth.Device, connected bool) {
+	adapter.SetConnectHandler(func(device bluetooth.Device, connected bool, err error) {
 		if connected {
 			println("device connected:", device.Address.String())
 			return
 		}
 
-		println("device disconnected:", device.Address.String())
+		println("device disconnected:", device.Address.String(), "error:", err)
 		cancel()
 	})
 

--- a/adapter.go
+++ b/adapter.go
@@ -5,13 +5,14 @@ type BLEAdapter interface {
 	Connect(address Address, params ConnectionParams) (Device, error)
 	Enable() error
 	Scan(callback func(*Adapter, ScanResult)) (err error)
-	SetConnectHandler(c func(device Device, connected bool))
+	SetConnectHandler(c func(device Device, connected bool, err error))
 	StopScan() error
 }
 
 // SetConnectHandler sets a handler function to be called whenever the adapter connects
 // or disconnects. You must call this before you call adapter.Connect() for centrals
 // or advertisement.Start() for peripherals in order for it to work.
-func (a *Adapter) SetConnectHandler(c func(device Device, connected bool)) {
+// If the device gets disconnected, the error parameter will be non-nil if the disconnection was due to an error, and nil otherwise.
+func (a *Adapter) SetConnectHandler(c func(device Device, connected bool, err error)) {
 	a.connectHandler = c
 }

--- a/adapter.go
+++ b/adapter.go
@@ -12,7 +12,6 @@ type BLEAdapter interface {
 // SetConnectHandler sets a handler function to be called whenever the adapter connects
 // or disconnects. You must call this before you call adapter.Connect() for centrals
 // or advertisement.Start() for peripherals in order for it to work.
-// If the device gets disconnected, the error parameter will be non-nil if the disconnection was due to an error, and nil otherwise.
 func (a *Adapter) SetConnectHandler(c func(device Device, connected bool, err error)) {
 	a.connectHandler = c
 }

--- a/adapter_cyw43439.go
+++ b/adapter_cyw43439.go
@@ -25,7 +25,7 @@ type Adapter struct {
 var DefaultAdapter = &Adapter{
 	hciAdapter: hciAdapter{
 		isDefault: true,
-		connectHandler: func(device Device, connected bool) {
+		connectHandler: func(device Device, connected bool, err error) {
 			return
 		},
 		connectedDevices: make([]Device, 0, maxConnections),

--- a/adapter_darwin.go
+++ b/adapter_darwin.go
@@ -120,6 +120,10 @@ func (cmd *centralManagerDelegate) DidDisconnectPeripheral(cmgr cbgo.CentralMana
 // DidConnectPeripheral when peripheral is connected.
 func (cmd *centralManagerDelegate) DidConnectPeripheral(cmgr cbgo.CentralManager, prph cbgo.Peripheral) {
 	id := prph.Identifier().String()
+	addr := Address{}
+	uuid, _ := ParseUUID(id)
+	addr.UUID = uuid
+	cmd.a.connectHandler(Device{Address: addr}, true, nil)
 
 	// Check if we have a chan allocated for this peripheral, and remove it
 	// from the map if so (it's single-use, will be garbage collected after
@@ -136,6 +140,10 @@ func (cmd *centralManagerDelegate) DidConnectPeripheral(cmgr cbgo.CentralManager
 // DidFailToConnectPeripheral when peripheral connection fails.
 func (cmd *centralManagerDelegate) DidFailToConnectPeripheral(cmgr cbgo.CentralManager, prph cbgo.Peripheral, err error) {
 	id := prph.Identifier().String()
+	addr := Address{}
+	uuid, _ := ParseUUID(id)
+	addr.UUID = uuid
+	cmd.a.connectHandler(Device{Address: addr}, false, err)
 
 	// Send the peripheral through so Connect can check its state
 	// and return the appropriate error.

--- a/adapter_darwin.go
+++ b/adapter_darwin.go
@@ -26,7 +26,7 @@ type Adapter struct {
 	// used to allow multiple callers to call Connect concurrently.
 	connectMap sync.Map
 
-	connectHandler func(device Device, connected bool)
+	connectHandler func(device Device, connected bool, err error)
 }
 
 // DefaultAdapter is the default adapter on the system.
@@ -37,7 +37,7 @@ var DefaultAdapter = &Adapter{
 	pm:         cbgo.NewPeripheralManager(nil),
 	connectMap: sync.Map{},
 
-	connectHandler: func(device Device, connected bool) {
+	connectHandler: func(device Device, connected bool, err error) {
 		return
 	},
 }
@@ -108,7 +108,7 @@ func (cmd *centralManagerDelegate) DidDisconnectPeripheral(cmgr cbgo.CentralMana
 	addr := Address{}
 	uuid, _ := ParseUUID(id)
 	addr.UUID = uuid
-	cmd.a.connectHandler(Device{Address: addr}, false)
+	cmd.a.connectHandler(Device{Address: addr}, false, err)
 
 	// like with DidConnectPeripheral, check if we have a chan allocated for this and send through the peripheral
 	// this will only be true if the receiving side is still waiting for a connection to complete

--- a/adapter_hci.go
+++ b/adapter_hci.go
@@ -17,7 +17,7 @@ type hciAdapter struct {
 	isDefault bool
 	scanning  bool
 
-	connectHandler func(device Device, connected bool)
+	connectHandler func(device Device, connected bool, err error)
 
 	connectedDevices     []Device
 	notificationsStarted bool

--- a/adapter_hci_uart.go
+++ b/adapter_hci_uart.go
@@ -26,7 +26,7 @@ type Adapter struct {
 var DefaultAdapter = &Adapter{
 	hciAdapter: hciAdapter{
 		isDefault: true,
-		connectHandler: func(device Device, connected bool) {
+		connectHandler: func(device Device, connected bool, err error) {
 			return
 		},
 		connectedDevices: make([]Device, 0, maxConnections),

--- a/adapter_linux.go
+++ b/adapter_linux.go
@@ -25,7 +25,7 @@ type Adapter struct {
 	address              string
 	defaultAdvertisement *Advertisement
 
-	connectHandler func(device Device, connected bool)
+	connectHandler func(device Device, connected bool, err error)
 }
 
 // NewAdapter creates a new Adapter with the given ID.
@@ -34,7 +34,7 @@ type Adapter struct {
 func NewAdapter(id string) *Adapter {
 	return &Adapter{
 		id:             id,
-		connectHandler: func(device Device, connected bool) {},
+		connectHandler: func(device Device, connected bool, err error) {},
 	}
 }
 

--- a/adapter_ninafw.go
+++ b/adapter_ninafw.go
@@ -22,7 +22,7 @@ type Adapter struct {
 var DefaultAdapter = &Adapter{
 	hciAdapter: hciAdapter{
 		isDefault: true,
-		connectHandler: func(device Device, connected bool) {
+		connectHandler: func(device Device, connected bool, err error) {
 			return
 		},
 		connectedDevices: make([]Device, 0, maxConnections),

--- a/adapter_nrf51.go
+++ b/adapter_nrf51.go
@@ -48,7 +48,7 @@ func handleEvent() {
 				Address:          Address{makeMACAddress(connectEvent.peer_addr)},
 				connectionHandle: gapEvent.conn_handle,
 			}
-			DefaultAdapter.connectHandler(device, true)
+			DefaultAdapter.connectHandler(device, true, nil)
 		case C.BLE_GAP_EVT_DISCONNECTED:
 			if defaultAdvertisement.isAdvertising.Get() != 0 {
 				// The advertisement was running but was automatically stopped
@@ -63,7 +63,7 @@ func handleEvent() {
 			device := Device{
 				connectionHandle: gapEvent.conn_handle,
 			}
-			DefaultAdapter.connectHandler(device, false)
+			DefaultAdapter.connectHandler(device, false, nil)
 		case C.BLE_GAP_EVT_CONN_PARAM_UPDATE_REQUEST:
 			// Respond with the default PPCP connection parameters by passing
 			// nil:

--- a/adapter_nrf528xx-full.go
+++ b/adapter_nrf528xx-full.go
@@ -35,14 +35,14 @@ func handleEvent() {
 					println("evt: connected in peripheral role")
 				}
 				currentConnection.handle.Reg = uint16(gapEvent.conn_handle)
-				DefaultAdapter.connectHandler(device, true)
+				DefaultAdapter.connectHandler(device, true, nil)
 			case C.BLE_GAP_ROLE_CENTRAL:
 				if debug {
 					println("evt: connected in central role")
 				}
 				connectionAttempt.connectionHandle = gapEvent.conn_handle
 				connectionAttempt.state.Set(2) // connection was successful
-				DefaultAdapter.connectHandler(device, true)
+				DefaultAdapter.connectHandler(device, true, nil)
 			}
 		case C.BLE_GAP_EVT_DISCONNECTED:
 			if debug {
@@ -68,7 +68,7 @@ func handleEvent() {
 			device := Device{
 				connectionHandle: gapEvent.conn_handle,
 			}
-			DefaultAdapter.connectHandler(device, false)
+			DefaultAdapter.connectHandler(device, false, nil)
 		case C.BLE_GAP_EVT_CONN_PARAM_UPDATE:
 			if debug {
 				// Print connection parameters for easy debugging.

--- a/adapter_nrf528xx-peripheral.go
+++ b/adapter_nrf528xx-peripheral.go
@@ -33,7 +33,7 @@ func handleEvent() {
 				Address:          Address{makeMACAddress(connectEvent.peer_addr)},
 				connectionHandle: gapEvent.conn_handle,
 			}
-			DefaultAdapter.connectHandler(device, true)
+			DefaultAdapter.connectHandler(device, true, nil)
 		case C.BLE_GAP_EVT_DISCONNECTED:
 			if debug {
 				println("evt: disconnected")
@@ -52,7 +52,7 @@ func handleEvent() {
 			device := Device{
 				connectionHandle: gapEvent.conn_handle,
 			}
-			DefaultAdapter.connectHandler(device, false)
+			DefaultAdapter.connectHandler(device, false, nil)
 		case C.BLE_GAP_EVT_DATA_LENGTH_UPDATE_REQUEST:
 			// We need to respond with sd_ble_gap_data_length_update. Setting
 			// both parameters to nil will make sure we send the default values.

--- a/adapter_sd.go
+++ b/adapter_sd.go
@@ -50,7 +50,7 @@ type Adapter struct {
 	scanning          bool
 	charWriteHandlers []charWriteHandler
 
-	connectHandler func(device Device, connected bool)
+	connectHandler func(device Device, connected bool, err error)
 }
 
 // DefaultAdapter is the default adapter on the current system. On Nordic chips,
@@ -58,7 +58,7 @@ type Adapter struct {
 //
 // Make sure to call Enable() before using it to initialize the adapter.
 var DefaultAdapter = &Adapter{isDefault: true,
-	connectHandler: func(device Device, connected bool) {
+	connectHandler: func(device Device, connected bool, err error) {
 		return
 	}}
 

--- a/adapter_windows.go
+++ b/adapter_windows.go
@@ -17,7 +17,7 @@ var _ BLEAdapter = (*Adapter)(nil)
 type Adapter struct {
 	watcher *advertisement.BluetoothLEAdvertisementWatcher
 
-	connectHandler func(device Device, connected bool)
+	connectHandler func(device Device, connected bool, err error)
 
 	defaultAdvertisement *Advertisement
 }
@@ -26,7 +26,7 @@ type Adapter struct {
 //
 // Make sure to call Enable() before using it to initialize the adapter.
 var DefaultAdapter = &Adapter{
-	connectHandler: func(device Device, connected bool) {
+	connectHandler: func(device Device, connected bool, err error) {
 		return
 	},
 }

--- a/examples/advertisement/main.go
+++ b/examples/advertisement/main.go
@@ -13,7 +13,7 @@ func main() {
 	must("enable BLE stack", adapter.Enable())
 
 	ctx, cancel := context.WithCancel(context.Background())
-	adapter.SetConnectHandler(func(device bluetooth.Device, connected bool, _ error) {
+	adapter.SetConnectHandler(func(device bluetooth.Device, connected bool, err error) {
 		if connected {
 			println("device connected:", device.Address.String())
 			return

--- a/examples/advertisement/main.go
+++ b/examples/advertisement/main.go
@@ -13,13 +13,13 @@ func main() {
 	must("enable BLE stack", adapter.Enable())
 
 	ctx, cancel := context.WithCancel(context.Background())
-	adapter.SetConnectHandler(func(device bluetooth.Device, connected bool) {
+	adapter.SetConnectHandler(func(device bluetooth.Device, connected bool, _ error) {
 		if connected {
 			println("device connected:", device.Address.String())
 			return
 		}
 
-		println("device disconnected:", device.Address.String())
+		println("device disconnected:", device.Address.String(), "error:", err)
 		cancel()
 	})
 

--- a/examples/circuitplay/main.go
+++ b/examples/circuitplay/main.go
@@ -38,7 +38,7 @@ func main() {
 	neo.Configure(machine.PinConfig{Mode: machine.PinOutput})
 	ws = ws2812.New(neo)
 
-	adapter.SetConnectHandler(func(d bluetooth.Device, c bool) {
+	adapter.SetConnectHandler(func(d bluetooth.Device, c bool, _ error) {
 		connected = c
 
 		if !connected && !disconnected {

--- a/examples/connparams/main.go
+++ b/examples/connparams/main.go
@@ -24,7 +24,7 @@ func main() {
 	must("enable BLE stack", adapter.Enable())
 
 	newDevice = make(chan bluetooth.Device, 1)
-	adapter.SetConnectHandler(func(device bluetooth.Device, connected bool) {
+	adapter.SetConnectHandler(func(device bluetooth.Device, connected bool, _ error) {
 		// If this is a new device, signal it to the separate goroutine.
 		if connected {
 			select {

--- a/examples/stop-advertisement/main.go
+++ b/examples/stop-advertisement/main.go
@@ -21,7 +21,7 @@ func main() {
 	must("config adv", adv.Configure(bluetooth.AdvertisementOptions{
 		LocalName: "Go Bluetooth",
 	}))
-	adapter.SetConnectHandler(func(device bluetooth.Device, connected bool) {
+	adapter.SetConnectHandler(func(device bluetooth.Device, connected bool, _ error) {
 		if connected {
 			println("connected, not advertising...")
 			advState = false

--- a/gap_darwin.go
+++ b/gap_darwin.go
@@ -153,7 +153,7 @@ func (a *Adapter) Connect(address Address, params ConnectionParams) (Device, err
 			d.delegate = &peripheralDelegate{d: d}
 			p.SetDelegate(d.delegate)
 
-			a.connectHandler(d, true)
+			a.connectHandler(d, true, nil)
 
 			return d, nil
 

--- a/gap_hci.go
+++ b/gap_hci.go
@@ -239,7 +239,7 @@ func (a *Adapter) Connect(address Address, params ConnectionParams) (Device, err
 			a.addConnection(d)
 
 			if a.connectHandler != nil {
-				a.connectHandler(d, true)
+				a.connectHandler(d, true, nil)
 			}
 
 			return d, nil
@@ -499,7 +499,7 @@ func (a *Advertisement) Start() error {
 				a.adapter.addConnection(d)
 
 				if a.adapter.connectHandler != nil {
-					a.adapter.connectHandler(d, true)
+					a.adapter.connectHandler(d, true, nil)
 				}
 
 				a.adapter.hci.clearConnectData()
@@ -513,7 +513,7 @@ func (a *Advertisement) Start() error {
 				a.adapter.removeConnection(d)
 
 				if a.adapter.connectHandler != nil {
-					a.adapter.connectHandler(d, false)
+					a.adapter.connectHandler(d, false, nil)
 				}
 
 				a.adapter.hci.clearConnectData()

--- a/gap_linux.go
+++ b/gap_linux.go
@@ -522,7 +522,7 @@ func (a *Adapter) Connect(address Address, params ConnectionParams) (Device, err
 	}
 
 	if a.connectHandler != nil {
-		a.connectHandler(device, true)
+		a.connectHandler(device, true, nil)
 	}
 
 	return device, nil
@@ -532,7 +532,7 @@ func (a *Adapter) Connect(address Address, params ConnectionParams) (Device, err
 // wait until the connection is fully gone.
 func (d Device) Disconnect() error {
 	if d.adapter.connectHandler != nil {
-		d.adapter.connectHandler(d, false)
+		d.adapter.connectHandler(d, false, nil)
 	}
 
 	// we don't call our cancel function here, instead we wait for the
@@ -610,7 +610,7 @@ func (a *Advertisement) handleDBusSignals() {
 				}
 
 				if connected, ok := props[bluezDevice1Connected].Value().(bool); ok {
-					a.adapter.connectHandler(device, connected)
+					a.adapter.connectHandler(device, connected, nil)
 				}
 			case dbusSignalPropertiesChanged:
 				// Skip any signals that are not the Device1 interface.
@@ -640,7 +640,7 @@ func (a *Advertisement) handleDBusSignals() {
 						continue
 					}
 
-					a.adapter.connectHandler(device, connected)
+					a.adapter.connectHandler(device, connected, nil)
 				}
 			}
 		}

--- a/gap_windows.go
+++ b/gap_windows.go
@@ -420,7 +420,7 @@ func (a *Adapter) Connect(address Address, params ConnectionParams) (Device, err
 		}
 
 		if a.connectHandler != nil {
-			a.connectHandler(device, status == bluetooth.BluetoothConnectionStatusConnected)
+			a.connectHandler(device, status == bluetooth.BluetoothConnectionStatusConnected, err)
 		}
 	})
 


### PR DESCRIPTION
Platforms shall implement a way of retrieving the error in case of connection failure or unexpected disconnection to give more details to the user.

Closes https://github.com/tinygo-org/bluetooth/issues/443

Note that https://github.com/tinygo-org/bluetooth/pull/444/changes/6a863d6ac4e61f6ae44bcc7c3aed20cc3f97600f implements a fix for darwin to call the connectHandler in two functions that were missing.