### PR TITLE
fix(darwin): make Adapter.Enable callable after first invocation

### DIFF
--- a/adapter_darwin.go
+++ b/adapter_darwin.go
@@ -44,14 +44,32 @@ var DefaultAdapter = &Adapter{
 
 // Enable configures the BLE stack. It must be called before any
 // Bluetooth-related calls (unless otherwise indicated).
+//
+// poweredChan doubles as the "Enable currently in flight" sentinel
+// (the upfront non-nil check guards against re-entry) and the
+// channel the central-manager delegate signals on once
+// CoreBluetooth reports powered-on. It is cleared on every exit
+// path — success and timeout — so a subsequent call can run again.
+// Previously the channel was set at the start of Enable and never
+// cleared, so any second Enable on the same Adapter (e.g. from a
+// recovery flow that re-Enables after an error) returned "already
+// calling Enable function" even though no Enable was actually in
+// flight.
 func (a *Adapter) Enable() error {
 	if a.poweredChan != nil {
 		return errors.New("already calling Enable function")
 	}
 
-	// wait until powered
 	a.poweredChan = make(chan error, 1)
 
+	// Attach the central-manager delegate BEFORE checking
+	// cm.State(): a freshly-constructed CBCentralManager fires
+	// DidUpdateState asynchronously, and if SetDelegate happens
+	// after the callback runs we miss the powered-on event entirely
+	// and wait the full 10s timeout for a callback that already
+	// fired. Setting the delegate first guarantees the callback
+	// path is wired before the manager has had a chance to update
+	// state.
 	a.cmd = &centralManagerDelegate{a: a}
 	a.cm.SetDelegate(a.cmd)
 
@@ -59,6 +77,7 @@ func (a *Adapter) Enable() error {
 		select {
 		case <-a.poweredChan:
 		case <-time.NewTimer(10 * time.Second).C:
+			a.poweredChan = nil
 			return errors.New("timeout enabling CentralManager")
 		}
 	}
@@ -68,9 +87,10 @@ func (a *Adapter) Enable() error {
 		<-a.poweredChan
 	}
 
-	// wait until powered?
 	a.pmd = &peripheralManagerDelegate{a: a}
 	a.pm.SetDelegate(a.pmd)
+
+	a.poweredChan = nil
 
 	return nil
 }
@@ -85,9 +105,20 @@ type centralManagerDelegate struct {
 
 // CentralManagerDidUpdateState when central manager state updated.
 func (cmd *centralManagerDelegate) CentralManagerDidUpdateState(cmgr cbgo.CentralManager) {
-	// powered on?
 	if cmgr.State() == cbgo.ManagerStatePoweredOn {
-		cmd.a.poweredChan <- nil
+		// Guard against poweredChan being nil — Enable clears it
+		// once the adapter is powered on, so a late or repeated
+		// state update (CoreBluetooth occasionally fires multiple
+		// times during startup, or after a state-toggle event)
+		// would otherwise block forever on a nil-channel send.
+		// Non-blocking send so we never park the delegate goroutine
+		// even if the channel is set but already buffered full.
+		if cmd.a.poweredChan != nil {
+			select {
+			case cmd.a.poweredChan <- nil:
+			default:
+			}
+		}
 	}
 
 	// TODO: handle other state changes.

--- a/adapter_darwin.go
+++ b/adapter_darwin.go
@@ -44,17 +44,6 @@ var DefaultAdapter = &Adapter{
 
 // Enable configures the BLE stack. It must be called before any
 // Bluetooth-related calls (unless otherwise indicated).
-//
-// poweredChan doubles as the "Enable currently in flight" sentinel
-// (the upfront non-nil check guards against re-entry) and the
-// channel the central-manager delegate signals on once
-// CoreBluetooth reports powered-on. It is cleared on every exit
-// path — success and timeout — so a subsequent call can run again.
-// Previously the channel was set at the start of Enable and never
-// cleared, so any second Enable on the same Adapter (e.g. from a
-// recovery flow that re-Enables after an error) returned "already
-// calling Enable function" even though no Enable was actually in
-// flight.
 func (a *Adapter) Enable() error {
 	if a.poweredChan != nil {
 		return errors.New("already calling Enable function")
@@ -62,20 +51,18 @@ func (a *Adapter) Enable() error {
 
 	a.poweredChan = make(chan error, 1)
 
-	// Attach the central-manager delegate BEFORE checking
-	// cm.State(): a freshly-constructed CBCentralManager fires
-	// DidUpdateState asynchronously, and if SetDelegate happens
-	// after the callback runs we miss the powered-on event entirely
-	// and wait the full 10s timeout for a callback that already
-	// fired. Setting the delegate first guarantees the callback
-	// path is wired before the manager has had a chance to update
-	// state.
+	// Set the delegate before checking State so we don't miss an
+	// async DidUpdateState that fires between construction and now.
 	a.cmd = &centralManagerDelegate{a: a}
 	a.cm.SetDelegate(a.cmd)
 
 	if a.cm.State() != cbgo.ManagerStatePoweredOn {
 		select {
-		case <-a.poweredChan:
+		case err := <-a.poweredChan:
+			if err != nil {
+				a.poweredChan = nil
+				return err
+			}
 		case <-time.NewTimer(10 * time.Second).C:
 			a.poweredChan = nil
 			return errors.New("timeout enabling CentralManager")
@@ -105,23 +92,27 @@ type centralManagerDelegate struct {
 
 // CentralManagerDidUpdateState when central manager state updated.
 func (cmd *centralManagerDelegate) CentralManagerDidUpdateState(cmgr cbgo.CentralManager) {
-	if cmgr.State() == cbgo.ManagerStatePoweredOn {
-		// Guard against poweredChan being nil — Enable clears it
-		// once the adapter is powered on, so a late or repeated
-		// state update (CoreBluetooth occasionally fires multiple
-		// times during startup, or after a state-toggle event)
-		// would otherwise block forever on a nil-channel send.
-		// Non-blocking send so we never park the delegate goroutine
-		// even if the channel is set but already buffered full.
-		if cmd.a.poweredChan != nil {
-			select {
-			case cmd.a.poweredChan <- nil:
-			default:
-			}
-		}
+	var event error
+	switch cmgr.State() {
+	case cbgo.ManagerStatePoweredOn:
+		event = nil
+	case cbgo.ManagerStatePoweredOff:
+		event = errors.New("bluetooth is powered off")
+	case cbgo.ManagerStateUnsupported:
+		event = errors.New("bluetooth is not supported on this device")
+	case cbgo.ManagerStateUnauthorized:
+		event = errors.New("bluetooth is not authorized for this app")
+	default:
+		// Unknown / Resetting are intermediate; wait for the next update.
+		return
 	}
-
-	// TODO: handle other state changes.
+	// Non-blocking; select handles a nil poweredChan correctly (the
+	// case is never ready, default fires) so a late or repeated
+	// update never parks the delegate goroutine.
+	select {
+	case cmd.a.poweredChan <- event:
+	default:
+	}
 }
 
 // DidDiscoverPeripheral when peripheral is discovered.


### PR DESCRIPTION
Three small fixes in adapter_darwin.go's Enable / DidUpdateState that I hit while building a recovery flow that needs to re-enable the adapter after an error.

### 1. Clear poweredChan on every exit path

poweredChan was being used as both the "Enable in flight" sentinel and the powered-on signal channel, but only the second role was ever cleared. Set it at the start of Enable, never reset it. So a second call to Enable on the same *Adapter would always return "already calling Enable function" — even though no Enable was actually running.

That's fine if you only call Enable once at startup, but it breaks any flow that wants to re-Enable after recovering from an error. Now we clear a.poweredChan = nil on both the timeout and success paths.

### 2. Set the delegate before checking cm.State()

A freshly-constructed CBCentralManager can fire DidUpdateState asynchronously between construction and SetDelegate being called. When that happens, the powered-on callback fires before the delegate is wired up, the event is lost, and Enable waits the full 10 seconds for a notification that already happened.

Moving SetDelegate ahead of the state check guarantees the callback path is wired before any state transition can be observed.

### 3. Don't block the delegate on a stale channel

Once #1 nils poweredChan after Enable completes, a late or repeated DidUpdateState (CoreBluetooth occasionally emits multiple state updates during startup or after a Bluetooth-toggle) would block forever on a nil-channel send and leak the delegate goroutine. The non-blocking select send works correctly even when poweredChan is nil — that case is just never ready, so default fires.

### 4. Handle non-powered-on state transitions

Per @acouvreur's review: CentralManagerDidUpdateState was only ever looking for ManagerStatePoweredOn, which meant any other state (powered-off, unauthorized, unsupported) caused Enable to silently time out instead of returning a useful error. The delegate now switches over all six states and pushes a real error to poweredChan for the three terminal "won't be powered on" cases. Enable reads it and returns it. Unknown / Resetting are intermediate states, so we keep waiting.

## Why these matter together

These changes together make Enable safely callable multiple times on the same *Adapter — which is the prerequisite for any in-process recovery, adapter switching, or error-retry flow on macOS. Each one is independently defensible (real bug, narrow blast radius), but the combination is what unlocks the broader use case.

## Verification

- go build . clean on darwin/arm64
- Tested against a Meshtastic BLE peripheral with a flow that calls Enable → use → tear down → Enable repeatedly. Without these fixes, the second Enable returns "already calling Enable function". With them, it succeeds.
- No behavior change for the existing single-Enable case — same code path, just with state cleanup at the end.