### PR TITLE
sd: don't block other goroutines while scanning

### DIFF
--- a/gap_nrf528xx-central.go
+++ b/gap_nrf528xx-central.go
@@ -5,6 +5,7 @@ package bluetooth
 import (
 	"device/arm"
 	"errors"
+	"runtime"
 	"runtime/volatile"
 	"time"
 	"unsafe"
@@ -58,8 +59,8 @@ func (a *Adapter) Scan(callback func(*Adapter, ScanResult)) error {
 	for {
 		// Wait for the next advertisement packet to arrive.
 		// TODO: use some sort of condition variable once the scheduler supports
-		// them.
-		arm.Asm("wfe")
+		// them. Using Gosched() here as a stopgap to let other goroutines run.
+		runtime.Gosched()
 		if gotScanReport.Get() == 0 {
 			// Spurious event. Continue waiting.
 			continue


### PR DESCRIPTION
This is still a stopgap, but slightly better than what we had before. Note that `wfe` probably didn't save any battery power anyway since `wfe` doesn't work as expected when the SoftDevice is enabled.

Eventually we'd need to use something like https://github.com/tinygo-org/tinygo/pull/5016 for this.