### PR TITLE
feat: add WithContext operations to the common interfaces

### DIFF
--- a/adapter.go
+++ b/adapter.go
@@ -1,8 +1,11 @@
 package bluetooth
 
+import "context"
+
 // BLEAdapter is the shared interface that all platform-specific Adapter types must implement.
 type BLEAdapter interface {
 	Connect(address Address, params ConnectionParams) (Device, error)
+	ConnectWithContext(ctx context.Context, address Address, params ConnectionParams) (Device, error)
 	Enable() error
 	Reset() error
 	Scan(callback func(*Adapter, ScanResult)) (err error)

--- a/adapter_nrf51.go
+++ b/adapter_nrf51.go
@@ -133,7 +133,7 @@ func makeMACAddress(addr C.ble_gap_addr_t) MACAddress {
 // ConnectWithContext starts a connection attempt to the given peripheral device
 // address, abandoning the attempt if ctx is cancelled.
 //
-// Not yet implemented on this platform; use Connect.
+// Not yet implemented on the nrf51.
 func (a *Adapter) ConnectWithContext(ctx context.Context, address Address, params ConnectionParams) (Device, error) {
 	return Device{}, errNotYetImplmented
 }

--- a/adapter_nrf51.go
+++ b/adapter_nrf51.go
@@ -13,6 +13,8 @@ import "C"
 
 import "unsafe"
 
+import "context"
+
 //export assertHandler
 func assertHandler(pc uint32, line_number uint16, p_file_name *byte) {
 	println("SoftDevice assert")
@@ -126,6 +128,14 @@ func makeMACAddress(addr C.ble_gap_addr_t) MACAddress {
 		MAC:      makeAddress(addr.addr),
 		isRandom: addr.addr_type != 0,
 	}
+}
+
+// ConnectWithContext starts a connection attempt to the given peripheral device
+// address, abandoning the attempt if ctx is cancelled.
+//
+// Not yet implemented on this platform; use Connect.
+func (a *Adapter) ConnectWithContext(ctx context.Context, address Address, params ConnectionParams) (Device, error) {
+	return Device{}, errNotYetImplmented
 }
 
 // Connect starts a connection attempt to the given peripheral device address.

--- a/adapter_s113v7.go
+++ b/adapter_s113v7.go
@@ -12,6 +12,16 @@ nrf_nvic_state_t nrf_nvic_state = {0};
 */
 import "C"
 
+import "context"
+
+// ConnectWithContext starts a connection attempt to the given peripheral device
+// address, abandoning the attempt if ctx is cancelled.
+//
+// s113v7 is a peripheral-only device, so this is not supported.
+func (a *Adapter) ConnectWithContext(ctx context.Context, address Address, params ConnectionParams) (Device, error) {
+	return Device{}, errNotSupported
+}
+
 // Connect starts a connection attempt to the given peripheral device address.
 //
 // s113v7 is a peripheral-only device, so this is not supported.

--- a/gap.go
+++ b/gap.go
@@ -1,6 +1,7 @@
 package bluetooth
 
 import (
+	"context"
 	"errors"
 	"time"
 )
@@ -141,6 +142,7 @@ type Connection uint16
 // GAPDevice is the shared interface that all platform-specific Device types must implement.
 type GAPDevice interface {
 	DiscoverServices(uuids []UUID) ([]DeviceService, error)
+	DiscoverServicesWithContext(ctx context.Context, uuids []UUID) ([]DeviceService, error)
 	RequestConnectionParams(params ConnectionParams) error
 	Connected() (bool, error)
 	Disconnect() error

--- a/gap_darwin.go
+++ b/gap_darwin.go
@@ -1,6 +1,7 @@
 package bluetooth
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"time"
@@ -102,6 +103,14 @@ type deviceInternal struct {
 	charsChan    chan error
 
 	services map[UUID]DeviceService
+}
+
+// ConnectWithContext starts a connection attempt to the given peripheral device
+// address, abandoning the attempt if ctx is cancelled.
+//
+// Not yet implemented on this platform; use Connect.
+func (a *Adapter) ConnectWithContext(ctx context.Context, address Address, params ConnectionParams) (Device, error) {
+	return Device{}, errNotYetImplmented
 }
 
 // Connect starts a connection attempt to the given peripheral device address.

--- a/gap_hci.go
+++ b/gap_hci.go
@@ -3,6 +3,7 @@
 package bluetooth
 
 import (
+	"context"
 	"encoding/binary"
 	"errors"
 	"slices"
@@ -176,6 +177,14 @@ func (a *Adapter) StopScan() error {
 // Address contains a Bluetooth MAC address.
 type Address struct {
 	MACAddress
+}
+
+// ConnectWithContext starts a connection attempt to the given peripheral device
+// address, abandoning the attempt if ctx is cancelled.
+//
+// Not yet implemented on this platform; use Connect.
+func (a *Adapter) ConnectWithContext(ctx context.Context, address Address, params ConnectionParams) (Device, error) {
+	return Device{}, errNotYetImplmented
 }
 
 // Connect starts a connection attempt to the given peripheral device address.

--- a/gap_linux.go
+++ b/gap_linux.go
@@ -3,6 +3,7 @@
 package bluetooth
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strings"
@@ -438,6 +439,14 @@ type Device struct {
 
 	device  dbus.BusObject // bluez device interface
 	adapter *Adapter       // the adapter that was used to form this device connection
+}
+
+// ConnectWithContext starts a connection attempt to the given peripheral device
+// address, abandoning the attempt if ctx is cancelled.
+//
+// Not yet implemented on this platform; use Connect.
+func (a *Adapter) ConnectWithContext(ctx context.Context, address Address, params ConnectionParams) (Device, error) {
+	return Device{}, errNotYetImplmented
 }
 
 // Connect starts a connection attempt to the given peripheral device address.

--- a/gap_nrf51.go
+++ b/gap_nrf51.go
@@ -120,9 +120,9 @@ func (d Device) Disconnect() error {
 // DiscoverServicesWithContext starts a service discovery procedure, abandoning
 // it if ctx is cancelled.
 //
-// s110v8 is a peripheral-only device, so this is not supported.
+// Not yet implemented on the nrf51.
 func (d Device) DiscoverServicesWithContext(ctx context.Context, uuids []UUID) ([]DeviceService, error) {
-	return nil, errNotSupported
+	return nil, errNotYetImplmented
 }
 
 // DiscoverServices starts a service discovery procedure.

--- a/gap_nrf51.go
+++ b/gap_nrf51.go
@@ -13,6 +13,7 @@ static inline uint32_t sd_ble_gap_adv_start_noescape(ble_gap_adv_params_t const 
 import "C"
 
 import (
+	"context"
 	"runtime/volatile"
 	"time"
 	"unsafe"
@@ -114,6 +115,14 @@ func (a *Adapter) SetRandomAddress(mac MAC) error {
 // Not yet implemented on the nrf51.
 func (d Device) Disconnect() error {
 	return errNotYetImplmented
+}
+
+// DiscoverServicesWithContext starts a service discovery procedure, abandoning
+// it if ctx is cancelled.
+//
+// s110v8 is a peripheral-only device, so this is not supported.
+func (d Device) DiscoverServicesWithContext(ctx context.Context, uuids []UUID) ([]DeviceService, error) {
+	return nil, errNotSupported
 }
 
 // DiscoverServices starts a service discovery procedure.

--- a/gap_nrf528xx-central.go
+++ b/gap_nrf528xx-central.go
@@ -3,6 +3,7 @@
 package bluetooth
 
 import (
+	"context"
 	"device/arm"
 	"errors"
 	"runtime"
@@ -105,6 +106,14 @@ func (a *Adapter) StopScan() error {
 var connectionAttempt struct {
 	state            volatile.Register8 // 0 means unused, 1 means connecting, 2 means connected, 3 means timeout
 	connectionHandle C.uint16_t
+}
+
+// ConnectWithContext starts a connection attempt to the given peripheral device
+// address, abandoning the attempt if ctx is cancelled.
+//
+// Not yet implemented on this platform; use Connect.
+func (a *Adapter) ConnectWithContext(ctx context.Context, address Address, params ConnectionParams) (Device, error) {
+	return Device{}, errNotYetImplmented
 }
 
 // Connect starts a connection attempt to the given peripheral device address.

--- a/gap_s113v7.go
+++ b/gap_s113v7.go
@@ -9,11 +9,21 @@ package bluetooth
 */
 import "C"
 
+import "context"
+
 // Disconnect from the BLE device.
 //
 // s113v7 is a peripheral-only device, so this is not supported.
 func (d Device) Disconnect() error {
 	return errNotSupported
+}
+
+// DiscoverServicesWithContext starts a service discovery procedure, abandoning
+// it if ctx is cancelled.
+//
+// s113v7 is a peripheral-only device, so this is not supported.
+func (d Device) DiscoverServicesWithContext(ctx context.Context, uuids []UUID) ([]DeviceService, error) {
+	return nil, errNotSupported
 }
 
 // DiscoverServices starts a service discovery procedure.

--- a/gap_windows.go
+++ b/gap_windows.go
@@ -337,6 +337,14 @@ type Device struct {
 	connectionStatusListener      *foundation.TypedEventHandler
 }
 
+// ConnectWithContext starts a connection attempt to the given peripheral device
+// address, abandoning the attempt if ctx is cancelled.
+//
+// Not yet implemented on this platform; use Connect.
+func (a *Adapter) ConnectWithContext(ctx context.Context, address Address, params ConnectionParams) (Device, error) {
+	return Device{}, errNotYetImplmented
+}
+
 // Connect starts a connection attempt to the given peripheral device address.
 //
 // On Linux and Windows, the IsRandom part of the address is ignored.

--- a/gattc.go
+++ b/gattc.go
@@ -2,6 +2,8 @@
 
 package bluetooth
 
+import "context"
+
 // GATTCService is the common interface that all platform-specific
 // DeviceService types must implement.
 type GATTCService interface {
@@ -13,6 +15,10 @@ type GATTCService interface {
 	// function. Either a list of all requested services is returned, or if
 	// some services could not be discovered an error is returned.
 	DiscoverCharacteristics(uuids []UUID) ([]DeviceCharacteristic, error)
+
+	// DiscoverCharacteristicsWithContext is DiscoverCharacteristics, abandoning
+	// the discovery if ctx is cancelled.
+	DiscoverCharacteristicsWithContext(ctx context.Context, uuids []UUID) ([]DeviceCharacteristic, error)
 }
 
 // GATTCCharacteristic is the common interface that all platform-specific
@@ -24,12 +30,22 @@ type GATTCCharacteristic interface {
 	// Read reads the current characteristic value.
 	Read(data []byte) (int, error)
 
+	// ReadWithContext is Read, abandoning the read if ctx is cancelled.
+	ReadWithContext(ctx context.Context, data []byte) (int, error)
+
 	// Write replaces the characteristic value with a new value.
 	Write(p []byte) (n int, err error)
+
+	// WriteWithContext is Write, abandoning the write if ctx is cancelled.
+	WriteWithContext(ctx context.Context, p []byte) (n int, err error)
 
 	// WriteWithoutResponse replaces the characteristic value with a new
 	// value. The call will return before all data has been written.
 	WriteWithoutResponse(p []byte) (n int, err error)
+
+	// WriteWithoutResponseWithContext is WriteWithoutResponse, abandoning the
+	// write if ctx is cancelled.
+	WriteWithoutResponseWithContext(ctx context.Context, p []byte) (n int, err error)
 
 	// EnableNotifications enables notifications for this characteristic,
 	// calling the provided callback with the new value when the

--- a/gattc_darwin.go
+++ b/gattc_darwin.go
@@ -1,6 +1,7 @@
 package bluetooth
 
 import (
+	"context"
 	"errors"
 	"slices"
 	"time"
@@ -17,6 +18,19 @@ var (
 	_ GATTCService        = (*DeviceService)(nil)
 	_ GATTCCharacteristic = (*DeviceCharacteristic)(nil)
 )
+
+// DiscoverServicesWithContext starts a service discovery procedure, abandoning
+// it if ctx is cancelled. Pass a list of service UUIDs you are interested in to
+// this function. Either a slice of all services is returned (of the same length
+// as the requested UUIDs and in the same order), or if some services could not
+// be discovered an error is returned.
+//
+// Passing a nil slice of UUIDs will return a complete list of services.
+//
+// Not yet implemented on this platform; use DiscoverServices.
+func (d Device) DiscoverServicesWithContext(ctx context.Context, uuids []UUID) ([]DeviceService, error) {
+	return nil, errNotYetImplmented
+}
 
 // DiscoverServices starts a service discovery procedure. Pass a list of service
 // UUIDs you are interested in to this function. Either a slice of all services

--- a/gattc_darwin.go
+++ b/gattc_darwin.go
@@ -197,6 +197,19 @@ func (s DeviceService) DiscoverCharacteristics(uuids []UUID) ([]DeviceCharacteri
 	}
 }
 
+// DiscoverCharacteristicsWithContext discovers characteristics in this service,
+// abandoning the discovery if ctx is cancelled. Pass a list of characteristic
+// UUIDs you are interested in to this function. Either a list of all requested
+// services is returned, or if some services could not be discovered an error is
+// returned.
+//
+// Passing a nil slice of UUIDs will return a complete list of characteristics.
+//
+// Not yet implemented on this platform; use DiscoverCharacteristics.
+func (s DeviceService) DiscoverCharacteristicsWithContext(ctx context.Context, uuids []UUID) ([]DeviceCharacteristic, error) {
+	return nil, errNotYetImplmented
+}
+
 // Small helper to create a DeviceCharacteristic object.
 func (s DeviceService) makeCharacteristic(uuid UUID, dchar cbgo.Characteristic) DeviceCharacteristic {
 	char := DeviceCharacteristic{
@@ -254,6 +267,14 @@ func (c DeviceCharacteristic) Write(p []byte) (n int, err error) {
 	return len(p), nil
 }
 
+// WriteWithContext replaces the characteristic value with a new value,
+// abandoning the write if ctx is cancelled.
+//
+// Not yet implemented on this platform; use Write.
+func (c DeviceCharacteristic) WriteWithContext(ctx context.Context, p []byte) (n int, err error) {
+	return 0, errNotYetImplmented
+}
+
 // WriteWithoutResponse replaces the characteristic value with a new value. The
 // call will return before all data has been written. A limited number of such
 // writes can be in flight at any given time.
@@ -274,6 +295,15 @@ func (c DeviceCharacteristic) WriteWithoutResponse(p []byte) (int, error) {
 	dev.prph.WriteCharacteristic(p, c.characteristic, false)
 
 	return len(p), nil
+}
+
+// WriteWithoutResponseWithContext replaces the characteristic value with a new
+// value, abandoning the write if ctx is cancelled. The call will return before
+// all data has been written.
+//
+// Not yet implemented on this platform; use WriteWithoutResponse.
+func (c DeviceCharacteristic) WriteWithoutResponseWithContext(ctx context.Context, p []byte) (n int, err error) {
+	return 0, errNotYetImplmented
 }
 
 // EnableNotifications enables notifications in the Client Characteristic
@@ -338,4 +368,12 @@ func (c *deviceCharacteristic) Read(data []byte) (n int, err error) {
 
 	copy(data, c.characteristic.Value())
 	return len(c.characteristic.Value()), nil
+}
+
+// ReadWithContext reads the current characteristic value, abandoning the read
+// if ctx is cancelled.
+//
+// Not yet implemented on this platform; use Read.
+func (c *deviceCharacteristic) ReadWithContext(ctx context.Context, data []byte) (n int, err error) {
+	return 0, errNotYetImplmented
 }

--- a/gattc_hci.go
+++ b/gattc_hci.go
@@ -62,7 +62,7 @@ func (s DeviceService) UUID() UUID {
 //
 // Not yet implemented on this platform; use DiscoverServices.
 func (d Device) DiscoverServicesWithContext(ctx context.Context, uuids []UUID) ([]DeviceService, error) {
-	return nil, errNotYetImplmented
+	return nil, errNotYetImplemented
 }
 
 // DiscoverServices starts a service discovery procedure. Pass a list of service

--- a/gattc_hci.go
+++ b/gattc_hci.go
@@ -2,7 +2,10 @@
 
 package bluetooth
 
-import "errors"
+import (
+	"context"
+	"errors"
+)
 
 var (
 	errNotYetImplemented         = errors.New("bluetooth: not yet implemented")
@@ -47,6 +50,19 @@ type DeviceService struct {
 // UUID returns the UUID for this DeviceService.
 func (s DeviceService) UUID() UUID {
 	return s.uuid
+}
+
+// DiscoverServicesWithContext starts a service discovery procedure, abandoning
+// it if ctx is cancelled. Pass a list of service UUIDs you are interested in to
+// this function. Either a slice of all services is returned (of the same length
+// as the requested UUIDs and in the same order), or if some services could not
+// be discovered an error is returned.
+//
+// Passing a nil slice of UUIDs will return a complete list of services.
+//
+// Not yet implemented on this platform; use DiscoverServices.
+func (d Device) DiscoverServicesWithContext(ctx context.Context, uuids []UUID) ([]DeviceService, error) {
+	return nil, errNotYetImplmented
 }
 
 // DiscoverServices starts a service discovery procedure. Pass a list of service

--- a/gattc_hci.go
+++ b/gattc_hci.go
@@ -257,10 +257,31 @@ func (s DeviceService) DiscoverCharacteristics(uuids []UUID) ([]DeviceCharacteri
 	return characteristics, nil
 }
 
+// DiscoverCharacteristicsWithContext discovers characteristics in this service,
+// abandoning the discovery if ctx is cancelled. Pass a list of characteristic
+// UUIDs you are interested in to this function. Either a list of all requested
+// services is returned, or if some services could not be discovered an error is
+// returned.
+//
+// Passing a nil slice of UUIDs will return a complete list of characteristics.
+//
+// Not yet implemented on this platform; use DiscoverCharacteristics.
+func (s DeviceService) DiscoverCharacteristicsWithContext(ctx context.Context, uuids []UUID) ([]DeviceCharacteristic, error) {
+	return nil, errNotYetImplemented
+}
+
 // Write replaces the characteristic value with a new value.
 //
 // Not yet implemented on HCI.
 func (c DeviceCharacteristic) Write(p []byte) (n int, err error) {
+	return 0, errNotYetImplemented
+}
+
+// WriteWithContext replaces the characteristic value with a new value,
+// abandoning the write if ctx is cancelled.
+//
+// Not yet implemented on this platform; use Write.
+func (c DeviceCharacteristic) WriteWithContext(ctx context.Context, p []byte) (n int, err error) {
 	return 0, errNotYetImplemented
 }
 
@@ -279,6 +300,15 @@ func (c DeviceCharacteristic) WriteWithoutResponse(p []byte) (n int, err error) 
 	}
 
 	return len(p), nil
+}
+
+// WriteWithoutResponseWithContext replaces the characteristic value with a new
+// value, abandoning the write if ctx is cancelled. The call will return before
+// all data has been written.
+//
+// Not yet implemented on this platform; use WriteWithoutResponse.
+func (c DeviceCharacteristic) WriteWithoutResponseWithContext(ctx context.Context, p []byte) (n int, err error) {
+	return 0, errNotYetImplemented
 }
 
 // EnableNotifications enables notifications in the Client Characteristic
@@ -358,4 +388,12 @@ func (c DeviceCharacteristic) Read(data []byte) (int, error) {
 	copy(data, cd.value)
 
 	return len(cd.value), nil
+}
+
+// ReadWithContext reads the current characteristic value, abandoning the read
+// if ctx is cancelled.
+//
+// Not yet implemented on this platform; use Read.
+func (c DeviceCharacteristic) ReadWithContext(ctx context.Context, data []byte) (n int, err error) {
+	return 0, errNotYetImplemented
 }

--- a/gattc_linux.go
+++ b/gattc_linux.go
@@ -236,6 +236,19 @@ func (s DeviceService) DiscoverCharacteristics(uuids []UUID) ([]DeviceCharacteri
 	return chars, nil
 }
 
+// DiscoverCharacteristicsWithContext discovers characteristics in this service,
+// abandoning the discovery if ctx is cancelled. Pass a list of characteristic
+// UUIDs you are interested in to this function. Either a list of all requested
+// services is returned, or if some services could not be discovered an error is
+// returned.
+//
+// Passing a nil slice of UUIDs will return a complete list of characteristics.
+//
+// Not yet implemented on this platform; use DiscoverCharacteristics.
+func (s DeviceService) DiscoverCharacteristicsWithContext(ctx context.Context, uuids []UUID) ([]DeviceCharacteristic, error) {
+	return nil, errNotYetImplmented
+}
+
 // WriteWithoutResponse replaces the characteristic value with a new value. The
 // call will return before all data has been written. A limited number of such
 // writes can be in flight at any given time. This call is also known as a
@@ -248,6 +261,15 @@ func (c DeviceCharacteristic) WriteWithoutResponse(p []byte) (int, error) {
 	return len(p), nil
 }
 
+// WriteWithoutResponseWithContext replaces the characteristic value with a new
+// value, abandoning the write if ctx is cancelled. The call will return before
+// all data has been written.
+//
+// Not yet implemented on this platform; use WriteWithoutResponse.
+func (c DeviceCharacteristic) WriteWithoutResponseWithContext(ctx context.Context, p []byte) (n int, err error) {
+	return 0, errNotYetImplmented
+}
+
 // Write replaces the characteristic value with a new value. The
 // call will return after all data has been written.
 func (c DeviceCharacteristic) Write(p []byte) (int, error) {
@@ -256,6 +278,14 @@ func (c DeviceCharacteristic) Write(p []byte) (int, error) {
 		return 0, err
 	}
 	return len(p), nil
+}
+
+// WriteWithContext replaces the characteristic value with a new value,
+// abandoning the write if ctx is cancelled.
+//
+// Not yet implemented on this platform; use Write.
+func (c DeviceCharacteristic) WriteWithContext(ctx context.Context, p []byte) (n int, err error) {
+	return 0, errNotYetImplmented
 }
 
 // EnableNotifications enables notifications in the Client Characteristic
@@ -341,4 +371,12 @@ func (c DeviceCharacteristic) Read(data []byte) (int, error) {
 	}
 	copy(data, result)
 	return len(result), nil
+}
+
+// ReadWithContext reads the current characteristic value, abandoning the read
+// if ctx is cancelled.
+//
+// Not yet implemented on this platform; use Read.
+func (c DeviceCharacteristic) ReadWithContext(ctx context.Context, data []byte) (n int, err error) {
+	return 0, errNotYetImplmented
 }

--- a/gattc_linux.go
+++ b/gattc_linux.go
@@ -3,6 +3,7 @@
 package bluetooth
 
 import (
+	"context"
 	"errors"
 	"sort"
 	"strings"
@@ -34,6 +35,19 @@ type DeviceService struct {
 // UUID returns the UUID for this DeviceService.
 func (s DeviceService) UUID() UUID {
 	return s.uuidWrapper
+}
+
+// DiscoverServicesWithContext starts a service discovery procedure, abandoning
+// it if ctx is cancelled. Pass a list of service UUIDs you are interested in to
+// this function. Either a slice of all services is returned (of the same length
+// as the requested UUIDs and in the same order), or if some services could not
+// be discovered an error is returned.
+//
+// Passing a nil slice of UUIDs will return a complete list of services.
+//
+// Not yet implemented on this platform; use DiscoverServices.
+func (d Device) DiscoverServicesWithContext(ctx context.Context, uuids []UUID) ([]DeviceService, error) {
+	return nil, errNotYetImplmented
 }
 
 // DiscoverServices starts a service discovery procedure. Pass a list of service

--- a/gattc_sd.go
+++ b/gattc_sd.go
@@ -8,6 +8,7 @@ package bluetooth
 import "C"
 
 import (
+	"context"
 	"device/arm"
 	"errors"
 	"runtime/volatile"
@@ -52,6 +53,19 @@ type DeviceService struct {
 // UUID returns the UUID for this DeviceService.
 func (s DeviceService) UUID() UUID {
 	return s.uuid.UUID()
+}
+
+// DiscoverServicesWithContext starts a service discovery procedure, abandoning
+// it if ctx is cancelled. Pass a list of service UUIDs you are interested in to
+// this function. Either a slice of all services is returned (of the same length
+// as the requested UUIDs and in the same order), or if some services could not
+// be discovered an error is returned.
+//
+// Passing a nil slice of UUIDs will return a complete list of services.
+//
+// Not yet implemented on this platform; use DiscoverServices.
+func (d Device) DiscoverServicesWithContext(ctx context.Context, uuids []UUID) ([]DeviceService, error) {
+	return nil, errNotYetImplmented
 }
 
 // DiscoverServices starts a service discovery procedure. Pass a list of service

--- a/gattc_sd.go
+++ b/gattc_sd.go
@@ -331,11 +331,32 @@ func (s DeviceService) DiscoverCharacteristics(uuids []UUID) ([]DeviceCharacteri
 	return characteristics, nil
 }
 
+// DiscoverCharacteristicsWithContext discovers characteristics in this service,
+// abandoning the discovery if ctx is cancelled. Pass a list of characteristic
+// UUIDs you are interested in to this function. Either a list of all requested
+// services is returned, or if some services could not be discovered an error is
+// returned.
+//
+// Passing a nil slice of UUIDs will return a complete list of characteristics.
+//
+// Not yet implemented on this platform; use DiscoverCharacteristics.
+func (s DeviceService) DiscoverCharacteristicsWithContext(ctx context.Context, uuids []UUID) ([]DeviceCharacteristic, error) {
+	return nil, errNotYetImplmented
+}
+
 // Write replaces the characteristic value with a new value.
 //
 // Not yet implemented on SoftDevice.
 func (c DeviceCharacteristic) Write(p []byte) (n int, err error) {
 	return 0, errNotFound
+}
+
+// WriteWithContext replaces the characteristic value with a new value,
+// abandoning the write if ctx is cancelled.
+//
+// Not yet implemented on this platform; use Write.
+func (c DeviceCharacteristic) WriteWithContext(ctx context.Context, p []byte) (n int, err error) {
+	return 0, errNotYetImplmented
 }
 
 // WriteWithoutResponse replaces the characteristic value with a new value. The
@@ -358,6 +379,15 @@ func (c DeviceCharacteristic) WriteWithoutResponse(p []byte) (n int, err error) 
 		return 0, Error(errCode)
 	}
 	return len(p), nil
+}
+
+// WriteWithoutResponseWithContext replaces the characteristic value with a new
+// value, abandoning the write if ctx is cancelled. The call will return before
+// all data has been written.
+//
+// Not yet implemented on this platform; use WriteWithoutResponse.
+func (c DeviceCharacteristic) WriteWithoutResponseWithContext(ctx context.Context, p []byte) (n int, err error) {
+	return 0, errNotYetImplmented
 }
 
 type gattcNotificationCallback struct {
@@ -472,6 +502,14 @@ func (c DeviceCharacteristic) Read(data []byte) (n int, err error) {
 	readingCharacteristic.length = 0
 
 	return
+}
+
+// ReadWithContext reads the current characteristic value, abandoning the read
+// if ctx is cancelled.
+//
+// Not yet implemented on this platform; use Read.
+func (c DeviceCharacteristic) ReadWithContext(ctx context.Context, data []byte) (n int, err error) {
+	return 0, errNotYetImplmented
 }
 
 // GetMTU returns the MTU for the characteristic.

--- a/gattc_windows.go
+++ b/gattc_windows.go
@@ -1,6 +1,7 @@
 package bluetooth
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"slices"
@@ -39,6 +40,19 @@ const (
 	NotificationModeNotify   NotificationMode = genericattributeprofile.GattCharacteristicPropertiesNotify
 	NotificationModeIndicate NotificationMode = genericattributeprofile.GattCharacteristicPropertiesIndicate
 )
+
+// DiscoverServicesWithContext starts a service discovery procedure, abandoning
+// it if ctx is cancelled. Pass a list of service UUIDs you are interested in to
+// this function. Either a slice of all services is returned (of the same length
+// as the requested UUIDs and in the same order), or if some services could not
+// be discovered an error is returned.
+//
+// Passing a nil slice of UUIDs will return a complete list of services.
+//
+// Not yet implemented on this platform; use DiscoverServices.
+func (d Device) DiscoverServicesWithContext(ctx context.Context, uuids []UUID) ([]DeviceService, error) {
+	return nil, errNotYetImplmented
+}
 
 // DiscoverServices starts a service discovery procedure. Pass a list of service
 // UUIDs you are interested in to this function. Either a slice of all services

--- a/gattc_windows.go
+++ b/gattc_windows.go
@@ -298,6 +298,19 @@ func (s DeviceService) DiscoverCharacteristics(filterUUIDs []UUID) ([]DeviceChar
 	return characteristics, nil
 }
 
+// DiscoverCharacteristicsWithContext discovers characteristics in this service,
+// abandoning the discovery if ctx is cancelled. Pass a list of characteristic
+// UUIDs you are interested in to this function. Either a list of all requested
+// services is returned, or if some services could not be discovered an error is
+// returned.
+//
+// Passing a nil slice of UUIDs will return a complete list of characteristics.
+//
+// Not yet implemented on this platform; use DiscoverCharacteristics.
+func (s DeviceService) DiscoverCharacteristicsWithContext(ctx context.Context, uuids []UUID) ([]DeviceCharacteristic, error) {
+	return nil, errNotYetImplmented
+}
+
 // Small helper to create a DeviceCharacteristic object.
 func (s DeviceService) makeCharacteristic(uuid UUID, characteristic *genericattributeprofile.GattCharacteristic, properties genericattributeprofile.GattCharacteristicProperties) DeviceCharacteristic {
 	char := DeviceCharacteristic{
@@ -353,6 +366,14 @@ func (c DeviceCharacteristic) Write(p []byte) (n int, err error) {
 	return c.write(p, genericattributeprofile.GattWriteOptionWriteWithResponse)
 }
 
+// WriteWithContext replaces the characteristic value with a new value,
+// abandoning the write if ctx is cancelled.
+//
+// Not yet implemented on this platform; use Write.
+func (c DeviceCharacteristic) WriteWithContext(ctx context.Context, p []byte) (n int, err error) {
+	return 0, errNotYetImplmented
+}
+
 // WriteWithoutResponse replaces the characteristic value with a new value. The
 // call will return before all data has been written. A limited number of such
 // writes can be in flight at any given time. This call is also known as a
@@ -362,6 +383,15 @@ func (c DeviceCharacteristic) WriteWithoutResponse(p []byte) (n int, err error) 
 		return 0, errNoWriteWithoutResponse
 	}
 	return c.write(p, genericattributeprofile.GattWriteOptionWriteWithoutResponse)
+}
+
+// WriteWithoutResponseWithContext replaces the characteristic value with a new
+// value, abandoning the write if ctx is cancelled. The call will return before
+// all data has been written.
+//
+// Not yet implemented on this platform; use WriteWithoutResponse.
+func (c DeviceCharacteristic) WriteWithoutResponseWithContext(ctx context.Context, p []byte) (n int, err error) {
+	return 0, errNotYetImplmented
 }
 
 func (c DeviceCharacteristic) write(p []byte, mode genericattributeprofile.GattWriteOption) (n int, err error) {
@@ -463,6 +493,14 @@ func (c DeviceCharacteristic) Read(data []byte) (int, error) {
 
 	copy(data, readBuffer)
 	return len(readBuffer), nil
+}
+
+// ReadWithContext reads the current characteristic value, abandoning the read
+// if ctx is cancelled.
+//
+// Not yet implemented on this platform; use Read.
+func (c DeviceCharacteristic) ReadWithContext(ctx context.Context, data []byte) (n int, err error) {
+	return 0, errNotYetImplmented
 }
 
 // EnableNotifications enables notifications or indicate in the Client Characteristic


### PR DESCRIPTION
Closes the contract half of #339: long-running operations get a `*WithContext`
variant, so callers can cancel a hanging `Connect` or bound a discovery on a
slow peripheral.

This PR adds **only the contract**. Six methods join the four existing common
interfaces, and every definition site gets a not-implemented stub so all five
backend families still satisfy them. No behaviour changes.

| Interface | New method |
| --- | --- |
| `BLEAdapter` | `ConnectWithContext` |
| `GAPDevice` | `DiscoverServicesWithContext` |
| `GATTCService` | `DiscoverCharacteristicsWithContext` |
| `GATTCCharacteristic` | `ReadWithContext`, `WriteWithContext`, `WriteWithoutResponseWithContext` |

The implementations follow, one platform per PR, each stacked on this branch so
it can be reviewed against just the stack it touches. CoreBluetooth is first —
per CONTRIBUTING's request that a new API land on two stacks at once, please
read that one together with this.

### Notes for review

- **`sd` and `hci` are stubbed and stay that way for now.** Both spin on wait
  loops that could cheaply check `ctx.Err()`, so implementing them is open, but
  it is not part of this work.
- **Stub errors match each file's existing convention** rather than picking one
  winner. `adapter_s113v7.go` and `gap_s113v7.go` return `errNotSupported`, as
  they already do for `Connect`/`DiscoverServices` — s113v7 is peripheral-only
  and will never gain a central role, so "not yet" would promise something that
  is not coming. `gattc_hci.go` uses its own `errNotYetImplemented`, matching
  `gattc_hci.go:264`; everything else uses `gap.go`'s `errNotYetImplmented`.
- **`context` now reaches baremetal builds.** The methods went on the existing
  interfaces rather than into parallel `...WithContext` interfaces, and
  `adapter.go`/`gap.go`/`gattc.go` have no build tags. A stub only names
  `context.Context` as a parameter type, so `WithCancel`/`WithTimeout` stay
  unreachable, but I have not measured the result — I do not have a TinyGo
  toolchain, so `make smoketest-tinygo` in CI is the check that matters here.
  Happy to move this to a `!baremetal` file with embedding interfaces instead
  if the size cost turns out to be real.
- **`Scan` is deliberately excluded.** It is the operation most worth
  cancelling, but the `ScanWithContext` in the first draft of #387 had an
  unresolved deadlock that @HattoriHanzo031 caught. It should follow once the
  convention here is settled.

Refs #339