### PR TITLE
feat(gap): add ConnectionPriority to ConnectionParams

### DIFF
--- a/gap.go
+++ b/gap.go
@@ -594,6 +594,39 @@ func (buf *rawAdvertisementPayload) addServiceUUID(uuid UUID) (ok bool) {
 	}
 }
 
+// ConnectionPriority tells the platform how to optimize a connection.
+// Windows accepts only these presets and not explicit parameters:
+// https://learn.microsoft.com/en-us/uwp/api/windows.devices.bluetooth.bluetoothlepreferredconnectionparameters
+type ConnectionPriority uint8
+
+const (
+	// ConnectionPriorityUnspecified does not change the connection parameters.
+	ConnectionPriorityUnspecified ConnectionPriority = iota
+
+	// ConnectionPriorityThroughput gives fast data transfer and high power use.
+	ConnectionPriorityThroughput
+
+	// ConnectionPriorityBalanced gives a balance of speed and power use.
+	ConnectionPriorityBalanced
+
+	// ConnectionPriorityPowerSaving gives low power use and slow data transfer.
+	ConnectionPriorityPowerSaving
+)
+
+// String returns the name of the priority.
+func (p ConnectionPriority) String() string {
+	switch p {
+	case ConnectionPriorityThroughput:
+		return "throughput"
+	case ConnectionPriorityBalanced:
+		return "balanced"
+	case ConnectionPriorityPowerSaving:
+		return "power-saving"
+	default:
+		return "unspecified"
+	}
+}
+
 // ConnectionParams are used when connecting to a peripherals or when changing
 // the parameters of an active connection.
 type ConnectionParams struct {
@@ -612,6 +645,10 @@ type ConnectionParams struct {
 	// communication, the connection is considered lost. If no timeout is
 	// specified, the timeout will be unchanged.
 	Timeout Duration
+
+	// Priority is an alternative to the fields above. Platforms that do not
+	// accept explicit parameters use it. Set both to make a portable request.
+	Priority ConnectionPriority
 }
 
 type PHY int


### PR DESCRIPTION
This replaces #422. It divides that work into a base contract and one PR for each platform that can use it.

## What this adds

`ConnectionPriority`, and a `Priority` field in `ConnectionParams`. No backend reads the field yet. The behavior does not change.

## Why a priority is necessary

Not all platforms accept explicit connection parameters. There are three groups.

| Group | Mechanism |
| --- | --- |
| Exact | The Nordic SoftDevice, with `sd_ble_gap_conn_param_update`. HCI can also do this, but the code does not exist yet. |
| Presets only | Windows. `BluetoothLEPreferredConnectionParameters` has no public constructor. It has only three static presets, and only on Windows 11 build 22000 or later. |
| No mechanism | BlueZ has no D-Bus property for this. In CoreBluetooth, `setDesiredConnectionLatency` is a method of `CBPeripheralManager`, thus a central cannot use it. Web Bluetooth has no such function. |

A priority is a request that the second group can use. Android and CoreBluetooth divide the same range into three parts.

## Why the names are not Low, Medium and High

There are two problems with these names.

**The vendors do not agree on the direction.** Apple `.low` and Android `CONNECTION_PRIORITY_HIGH` have the same meaning.

| Result | Apple | Windows | Android |
| --- | --- | --- | --- |
| Fast, high power | `.low` | `ThroughputOptimized` | `CONNECTION_PRIORITY_HIGH` |
| Between the two | `.medium` | `Balanced` | `CONNECTION_PRIORITY_BALANCED` |
| Slow, low power | `.high` | `PowerOptimized` | `CONNECTION_PRIORITY_LOW_POWER` |

Thus many users will read `ConnectionLatencyHigh` in the opposite sense. Names that show the trade-off do not have this problem.

**The Bluetooth Core Specification uses the term connection latency for a different parameter.** It is the number of connection events that the peripheral can skip. Windows uses the same name for it, in `BluetoothLEPreferredConnectionParameters.ConnectionLatency`, with values from `0x0000` to `0x01F3`. This is the object that the Windows PR uses. If we keep the term free, there is no conflict when we add that field.

References:
- https://learn.microsoft.com/en-us/uwp/api/windows.devices.bluetooth.bluetoothlepreferredconnectionparameters
- https://developer.apple.com/documentation/corebluetooth/cbperipheralmanagerconnectionlatency
- https://developer.android.com/reference/android/bluetooth/BluetoothGatt#requestConnectionPriority(int)

## How to use the two together

A platform that accepts only presets uses `Priority` and ignores the explicit fields. A platform that sets the parameters in the controller uses the explicit fields. Set both fields to make a request that operates on all platforms.

The zero value does not change the connection. This agrees with the other fields in `ConnectionParams`.

## The PRs on top of this one

- Windows, which sends `Priority` to the three WinRT presets
- Nordic SoftDevice, which changes `Priority` into explicit parameters

One item stays open after these two PRs. Five backends return `nil` from `RequestConnectionParams` but do nothing. A subsequent PR can report the support level of each device.
