### PR TITLE
feat(softdevice): use ConnectionPriority, and add PeripheralLatency

### DIFF
--- a/gap.go
+++ b/gap.go
@@ -627,6 +627,38 @@ func (p ConnectionPriority) String() string {
 	}
 }
 
+// Params returns the connection parameters for the priority. The values obey
+// the guidelines from Apple (section 35.6 Connection Parameters):
+// https://developer.apple.com/accessories/Accessory-Design-Guidelines.pdf
+func (p ConnectionPriority) Params() ConnectionParams {
+	switch p {
+	case ConnectionPriorityThroughput:
+		return ConnectionParams{
+			MinInterval: NewDuration(15 * time.Millisecond),
+			MaxInterval: NewDuration(30 * time.Millisecond),
+			Timeout:     NewDuration(2 * time.Second),
+			Priority:    p,
+		}
+	case ConnectionPriorityBalanced:
+		return ConnectionParams{
+			MinInterval: NewDuration(30 * time.Millisecond),
+			MaxInterval: NewDuration(60 * time.Millisecond),
+			Timeout:     NewDuration(4 * time.Second),
+			Priority:    p,
+		}
+	case ConnectionPriorityPowerSaving:
+		return ConnectionParams{
+			MinInterval:       NewDuration(120 * time.Millisecond),
+			MaxInterval:       NewDuration(165 * time.Millisecond),
+			PeripheralLatency: 4,
+			Timeout:           NewDuration(6 * time.Second),
+			Priority:          p,
+		}
+	default:
+		return ConnectionParams{}
+	}
+}
+
 // ConnectionParams are used when connecting to a peripherals or when changing
 // the parameters of an active connection.
 type ConnectionParams struct {
@@ -641,14 +673,41 @@ type ConnectionParams struct {
 	MinInterval Duration
 	MaxInterval Duration
 
+	// The number of connection events that the peripheral can skip. A higher
+	// value saves power on the peripheral. The default value of 0 skips none.
+	PeripheralLatency uint16
+
 	// Connection Supervision Timeout. After this time has passed with no
 	// communication, the connection is considered lost. If no timeout is
 	// specified, the timeout will be unchanged.
 	Timeout Duration
 
 	// Priority is an alternative to the fields above. Platforms that do not
-	// accept explicit parameters use it. Set both to make a portable request.
+	// accept explicit parameters use it. Resolved shows the two together.
 	Priority ConnectionPriority
+}
+
+// Resolved fills each unset field from Priority. Explicit values stay.
+// An unset Priority changes nothing.
+func (p ConnectionParams) Resolved() ConnectionParams {
+	if p.Priority == ConnectionPriorityUnspecified {
+		return p
+	}
+
+	preset := p.Priority.Params()
+	if p.MinInterval == 0 {
+		p.MinInterval = preset.MinInterval
+	}
+	if p.MaxInterval == 0 {
+		p.MaxInterval = preset.MaxInterval
+	}
+	if p.PeripheralLatency == 0 {
+		p.PeripheralLatency = preset.PeripheralLatency
+	}
+	if p.Timeout == 0 {
+		p.Timeout = preset.Timeout
+	}
+	return p
 }
 
 type PHY int

--- a/gap_connparams_test.go
+++ b/gap_connparams_test.go
@@ -1,0 +1,86 @@
+package bluetooth
+
+import (
+	"testing"
+	"time"
+)
+
+// connectionPriorities are the priorities that give parameters.
+var connectionPriorities = []ConnectionPriority{
+	ConnectionPriorityThroughput,
+	ConnectionPriorityBalanced,
+	ConnectionPriorityPowerSaving,
+}
+
+// The presets must obey the guidelines from Apple (section 35.6 Connection
+// Parameters): https://developer.apple.com/accessories/Accessory-Design-Guidelines.pdf
+func TestConnectionPriorityParams(t *testing.T) {
+	const (
+		unit         = 625 * time.Microsecond
+		intervalStep = 15 * time.Millisecond
+		minTimeout   = 2 * time.Second
+		maxTimeout   = 6 * time.Second
+	)
+
+	if got := ConnectionPriorityUnspecified.Params(); got != (ConnectionParams{}) {
+		t.Errorf("ConnectionPriorityUnspecified.Params() = %+v, want the zero value", got)
+	}
+
+	for _, priority := range connectionPriorities {
+		params := priority.Params()
+		if params.Priority != priority {
+			t.Errorf("%s: Params().Priority = %s, want %s", priority, params.Priority, priority)
+		}
+
+		minInterval := time.Duration(params.MinInterval) * unit
+		maxInterval := time.Duration(params.MaxInterval) * unit
+		timeout := time.Duration(params.Timeout) * unit
+
+		if minInterval%intervalStep != 0 || maxInterval%intervalStep != 0 {
+			t.Errorf("%s: intervals %v/%v are not multiples of %v", priority, minInterval, maxInterval, intervalStep)
+		}
+		if maxInterval-minInterval < intervalStep {
+			t.Errorf("%s: MaxInterval %v is less than %v above MinInterval %v", priority, maxInterval, intervalStep, minInterval)
+		}
+		if timeout < minTimeout || timeout > maxTimeout {
+			t.Errorf("%s: supervision timeout %v outside [%v, %v]", priority, timeout, minTimeout, maxTimeout)
+		}
+
+		// The SoftDevice rejects a supervision timeout that is not longer than
+		// the time that the peripheral can stay silent.
+		silence := time.Duration(1+params.PeripheralLatency) * maxInterval * 2
+		if timeout <= silence {
+			t.Errorf("%s: supervision timeout %v does not exceed %v of allowed silence "+
+				"(peripheral latency %d, max interval %v)",
+				priority, timeout, silence, params.PeripheralLatency, maxInterval)
+		}
+	}
+}
+
+func TestConnectionParamsResolved(t *testing.T) {
+	t.Run("an unset priority changes nothing", func(t *testing.T) {
+		params := ConnectionParams{MinInterval: NewDuration(20 * time.Millisecond)}
+		if got := params.Resolved(); got != params {
+			t.Errorf("Resolved() = %+v, want %+v", got, params)
+		}
+	})
+
+	t.Run("a priority fills the unset fields", func(t *testing.T) {
+		got := ConnectionParams{Priority: ConnectionPriorityPowerSaving}.Resolved()
+		want := ConnectionPriorityPowerSaving.Params()
+		if got != want {
+			t.Errorf("Resolved() = %+v, want %+v", got, want)
+		}
+	})
+
+	t.Run("explicit values stay", func(t *testing.T) {
+		timeout := NewDuration(3 * time.Second)
+		got := ConnectionParams{Priority: ConnectionPriorityBalanced, Timeout: timeout}.Resolved()
+		if got.Timeout != timeout {
+			t.Errorf("Resolved().Timeout = %d, want the explicit %d", got.Timeout, timeout)
+		}
+		if got.MaxInterval != ConnectionPriorityBalanced.Params().MaxInterval {
+			t.Error("Resolved() did not fill the interval from the priority")
+		}
+	})
+}

--- a/gap_nrf528xx-central.go
+++ b/gap_nrf528xx-central.go
@@ -212,13 +212,15 @@ func (d Device) Disconnect() error {
 // Whether or not the device will actually honor this, depends on the device and
 // on the specific parameters.
 //
-// On the Nordic SoftDevice, this call will also set the slave latency to 0.
+// The SoftDevice uses the explicit fields. Priority fills the unset fields.
 func (d Device) RequestConnectionParams(params ConnectionParams) error {
+	params = params.Resolved()
+
 	// The default parameters if no specific parameters are picked.
 	connParams := C.ble_gap_conn_params_t{
 		min_conn_interval: C.BLE_GAP_CP_MIN_CONN_INTVL_NONE,
 		max_conn_interval: C.BLE_GAP_CP_MAX_CONN_INTVL_NONE,
-		slave_latency:     0,
+		slave_latency:     C.uint16_t(params.PeripheralLatency),
 		conn_sup_timeout:  C.BLE_GAP_CP_CONN_SUP_TIMEOUT_NONE,
 	}
 


### PR DESCRIPTION
This PR is on top of #472. The difference shows only the SoftDevice change. It is independent of #473, which does the same work for Windows.

## What this does

The SoftDevice sets the connection parameters in the controller with `sd_ble_gap_conn_param_update`, thus it uses the explicit fields. This PR fills each field that the caller does not set from `ConnectionParams.Priority`. Thus code that sets only a priority also gets a result on this platform.

This makes the rule in #472 more exact. That PR says that a platform of this type ignores `Priority`. This is correct, but it is not sufficient, because a caller that sets only a priority then gets no result. The rule is now that explicit values stay, and that the priority fills the other fields. `ConnectionParams.Resolved` shows the two together.

## The table is in gap.go

`ConnectionPriority.Params` gives the parameters for each priority.

| Priority | Min | Max | Peripheral latency | Supervision timeout |
| --- | --- | --- | --- | --- |
| `Throughput` | 15 ms | 30 ms | 0 | 2 s |
| `Balanced` | 30 ms | 60 ms | 0 | 4 s |
| `PowerSaving` | 120 ms | 165 ms | 4 | 6 s |

The table is in `gap.go` and not in each platform. Thus all backends of this type agree, and a test can make sure of the values. The test makes sure of two conditions.

- The values obey the guidelines from Apple (section 35.6 Connection Parameters). The intervals are multiples of 15 ms, and the supervision timeouts are between 2 and 6 seconds. https://developer.apple.com/accessories/Accessory-Design-Guidelines.pdf
- The supervision timeout is longer than `(1 + peripheral latency) × max interval × 2`. The SoftDevice rejects other values.

Please examine the three rows with care. They are my selection, and I did not copy them from a specification. The values for `PowerSaving` are an estimate of a good compromise.

## PeripheralLatency

The table needs a field that `ConnectionParams` did not have. The difference between power saving and balanced is the number of connection events that the peripheral can skip. The value of `ble_gap_conn_params_t.slave_latency` was always `0`, thus the user could not set it. `ConnectionParams.PeripheralLatency` now sets it. This is also a correction on its own.

This is also why the enumeration in #422 could not operate. Without this field, `ConnectionLatencyHigh` had no equivalent on the backends that can use it.

## Tests

`go build`, `go vet` and `go test` are satisfactory on the host. golangci-lint finds no new problems. TinyGo builds `pca10056-s140v7` and `pca10040-s132v6`. The second target uses `examples/heartrate-monitor`, which includes the central file that this PR changes.

I did not test this on real hardware yet. I did not make sure on a board that a `PowerSaving` request gives the correct interval and latency in a connection parameters update event.
