### PR TITLE
nrf528xx: add transmit power and DC supply control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 test.hex
 test.uf2
+test.bin

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,16 @@ smoketest-tinygo:
 	@md5sum test.hex
 	$(TINYGO) build -o test.uf2 -size=short -target=circuitplay-bluefruit ./examples/advertisement
 	@md5sum test.hex
+	# beacon-lowpower calls EnableDCSupply and SetTxPower, so build it for each
+	# SoftDevice and for a board that uses the stubs.
+	$(TINYGO) build -o test.hex -size=short -target=pca10056-s140v7 -serial=none ./examples/beacon-lowpower
+	@md5sum test.hex
+	$(TINYGO) build -o test.hex -size=short -target=pca10040-s132v6       ./examples/beacon-lowpower
+	@md5sum test.hex
+	$(TINYGO) build -o test.hex -size=short -target=microbit-v2-s113v7    ./examples/beacon-lowpower
+	@md5sum test.hex
+	$(TINYGO) build -o test.uf2 -size=short -target=nano-rp2040           ./examples/beacon-lowpower
+	@md5sum test.uf2
 	$(TINYGO) build -o test.uf2 -size=short -target=circuitplay-bluefruit ./examples/circuitplay
 	@md5sum test.hex
 	$(TINYGO) build -o test.hex -size=short -target=circuitplay-bluefruit ./examples/connparams
@@ -70,6 +80,7 @@ smoketest-tinygo:
 smoketest-linux:
 	# Test on Linux.
 	GOOS=linux go build -o /tmp/go-build-discard ./examples/advertisement
+	GOOS=linux go build -o /tmp/go-build-discard ./examples/beacon-lowpower
 	GOOS=linux go build -o /tmp/go-build-discard ./examples/connparams
 	GOOS=linux go build -o /tmp/go-build-discard ./examples/heartrate
 	GOOS=linux go build -o /tmp/go-build-discard ./examples/heartrate-monitor
@@ -79,6 +90,7 @@ smoketest-linux:
 
 smoketest-windows:
 	# Test on Windows.
+	GOOS=windows go build -o /tmp/go-build-discard ./examples/beacon-lowpower
 	GOOS=windows go build -o /tmp/go-build-discard ./examples/scanner
 	GOOS=windows go build -o /tmp/go-build-discard ./examples/discover
 	GOOS=windows go build -o /tmp/go-build-discard ./examples/heartrate-monitor

--- a/adapter.go
+++ b/adapter.go
@@ -16,3 +16,17 @@ type BLEAdapter interface {
 func (a *Adapter) SetConnectHandler(c func(device Device, connected bool)) {
 	a.connectHandler = c
 }
+
+// DCSupplyStage selects a regulator stage. The two stages are in series,
+// because REG0 supplies VDD from VDDH and VDD is the input to REG1.
+// See nRF52840 Product Specification v1.11 section 5.4, Power management.
+type DCSupplyStage uint8
+
+const (
+	// DCSupplyMain is the REG1 stage, which supplies the core from VDD.
+	DCSupplyMain DCSupplyStage = iota
+
+	// DCSupplyHighVoltage is the REG0 stage, which needs VDDH power. The gain
+	// is small unless VDDH is much higher than VDD.
+	DCSupplyHighVoltage
+)

--- a/adapter_dcsupply-other.go
+++ b/adapter_dcsupply-other.go
@@ -1,0 +1,9 @@
+//go:build !(softdevice && (s113v7 || s132v6 || s140v6 || s140v7))
+
+package bluetooth
+
+// EnableDCSupply turns the DC/DC converter of a stage on or off. Only the nRF52
+// series with a SoftDevice has these regulators, so this is not supported.
+func (a *Adapter) EnableDCSupply(stage DCSupplyStage, enable bool) error {
+	return errNotSupported
+}

--- a/adapter_nrf528xx.go
+++ b/adapter_nrf528xx.go
@@ -7,6 +7,7 @@ package bluetooth
 /*
 #include "nrf_sdm.h"
 #include "nrf_nvic.h"
+#include "nrf_soc.h"
 #include "ble.h"
 #include "ble_gap.h"
 
@@ -49,6 +50,24 @@ func (a *Adapter) enable() error {
 	appRAMBase := C.uint32_t(uintptr(unsafe.Pointer(&appRAMBase)))
 	errCode = C.sd_ble_enable(&appRAMBase)
 	return makeError(errCode)
+}
+
+// EnableDCSupply turns the DC/DC converter of a stage on or off, after Enable.
+// It lowers the current, but the board must have an inductor for that stage.
+// See nRF52840 Product Specification v1.11 section 5.4, Power management.
+func (a *Adapter) EnableDCSupply(stage DCSupplyStage, enable bool) error {
+	switch stage {
+	case DCSupplyMain:
+		mode := C.uint8_t(C.NRF_POWER_DCDC_DISABLE)
+		if enable {
+			mode = C.uint8_t(C.NRF_POWER_DCDC_ENABLE)
+		}
+		return makeError(C.sd_power_dcdc_mode_set(mode))
+	case DCSupplyHighVoltage:
+		return setDCSupplyHighVoltage(enable)
+	default:
+		return errNotSupported
+	}
 }
 
 func (a *Adapter) Address() (MACAddress, error) {

--- a/adapter_s113v7.go
+++ b/adapter_s113v7.go
@@ -36,3 +36,9 @@ func (a *Adapter) Scan(callback func(*Adapter, ScanResult)) (err error) {
 func (a *Adapter) StopScan() error {
 	return errNotSupported
 }
+
+// setDCSupplyHighVoltage controls the DC/DC converter of the REG0 stage. Only
+// the nRF52840 has a VDDH stage, so this is not supported.
+func setDCSupplyHighVoltage(enable bool) error {
+	return errNotSupported
+}

--- a/adapter_s113v7.go
+++ b/adapter_s113v7.go
@@ -12,6 +12,10 @@ nrf_nvic_state_t nrf_nvic_state = {0};
 */
 import "C"
 
+// Transmit power levels in dBm that every part with this SoftDevice accepts.
+// See the sd_ble_gap_tx_power_set note in ble_gap.h.
+var txPowerLevels = []int8{-40, -20, -16, -12, -8, -4, 0, 3, 4}
+
 // Connect starts a connection attempt to the given peripheral device address.
 //
 // s113v7 is a peripheral-only device, so this is not supported.

--- a/adapter_s132.go
+++ b/adapter_s132.go
@@ -11,3 +11,7 @@ package bluetooth
 nrf_nvic_state_t nrf_nvic_state = {0};
 */
 import "C"
+
+// Transmit power levels in dBm that every part with this SoftDevice accepts.
+// See the sd_ble_gap_tx_power_set note in ble_gap.h.
+var txPowerLevels = []int8{-40, -20, -16, -12, -8, -4, 0, 3, 4}

--- a/adapter_s132.go
+++ b/adapter_s132.go
@@ -15,3 +15,9 @@ import "C"
 // Transmit power levels in dBm that every part with this SoftDevice accepts.
 // See the sd_ble_gap_tx_power_set note in ble_gap.h.
 var txPowerLevels = []int8{-40, -20, -16, -12, -8, -4, 0, 3, 4}
+
+// setDCSupplyHighVoltage controls the DC/DC converter of the REG0 stage. Only
+// the nRF52840 has a VDDH stage, so this is not supported.
+func setDCSupplyHighVoltage(enable bool) error {
+	return errNotSupported
+}

--- a/adapter_s140v6.go
+++ b/adapter_s140v6.go
@@ -8,6 +8,7 @@ package bluetooth
 #cgo CFLAGS: -Is140_nrf52_6.1.1/s140_nrf52_6.1.1_API/include
 
 #include "nrf_nvic.h"
+#include "nrf_soc.h"
 nrf_nvic_state_t nrf_nvic_state = {0};
 */
 import "C"
@@ -15,3 +16,13 @@ import "C"
 // Transmit power levels in dBm that the nRF52840 accepts.
 // See nRF52840 Product Specification v1.11 section 6.20.14.19, RADIO TXPOWER.
 var txPowerLevels = []int8{-40, -20, -16, -12, -8, -4, 0, 2, 3, 4, 5, 6, 7, 8}
+
+// setDCSupplyHighVoltage controls the DC/DC converter of the REG0 stage.
+// See nRF52840 Product Specification v1.11 section 5.4.1, REG0 stage.
+func setDCSupplyHighVoltage(enable bool) error {
+	mode := C.uint8_t(C.NRF_POWER_DCDC_DISABLE)
+	if enable {
+		mode = C.uint8_t(C.NRF_POWER_DCDC_ENABLE)
+	}
+	return makeError(C.sd_power_dcdc0_mode_set(mode))
+}

--- a/adapter_s140v6.go
+++ b/adapter_s140v6.go
@@ -11,3 +11,7 @@ package bluetooth
 nrf_nvic_state_t nrf_nvic_state = {0};
 */
 import "C"
+
+// Transmit power levels in dBm that the nRF52840 accepts.
+// See nRF52840 Product Specification v1.11 section 6.20.14.19, RADIO TXPOWER.
+var txPowerLevels = []int8{-40, -20, -16, -12, -8, -4, 0, 2, 3, 4, 5, 6, 7, 8}

--- a/adapter_s140v7.go
+++ b/adapter_s140v7.go
@@ -11,3 +11,7 @@ package bluetooth
 nrf_nvic_state_t nrf_nvic_state = {0};
 */
 import "C"
+
+// Transmit power levels in dBm that the nRF52840 accepts.
+// See nRF52840 Product Specification v1.11 section 6.20.14.19, RADIO TXPOWER.
+var txPowerLevels = []int8{-40, -20, -16, -12, -8, -4, 0, 2, 3, 4, 5, 6, 7, 8}

--- a/adapter_s140v7.go
+++ b/adapter_s140v7.go
@@ -8,6 +8,7 @@ package bluetooth
 #cgo CFLAGS: -Is140_nrf52_7.3.0/s140_nrf52_7.3.0_API/include
 
 #include "nrf_nvic.h"
+#include "nrf_soc.h"
 nrf_nvic_state_t nrf_nvic_state = {0};
 */
 import "C"
@@ -15,3 +16,13 @@ import "C"
 // Transmit power levels in dBm that the nRF52840 accepts.
 // See nRF52840 Product Specification v1.11 section 6.20.14.19, RADIO TXPOWER.
 var txPowerLevels = []int8{-40, -20, -16, -12, -8, -4, 0, 2, 3, 4, 5, 6, 7, 8}
+
+// setDCSupplyHighVoltage controls the DC/DC converter of the REG0 stage.
+// See nRF52840 Product Specification v1.11 section 5.4.1, REG0 stage.
+func setDCSupplyHighVoltage(enable bool) error {
+	mode := C.uint8_t(C.NRF_POWER_DCDC_DISABLE)
+	if enable {
+		mode = C.uint8_t(C.NRF_POWER_DCDC_ENABLE)
+	}
+	return makeError(C.sd_power_dcdc0_mode_set(mode))
+}

--- a/examples/beacon-lowpower/main.go
+++ b/examples/beacon-lowpower/main.go
@@ -1,0 +1,49 @@
+// Beacon that uses as little current as possible.
+// Build it with -serial=none, so that the USB peripheral stays off.
+//
+//	tinygo flash -target xiao-ble -serial=none ./examples/beacon-lowpower
+package main
+
+import (
+	"time"
+
+	"tinygo.org/x/bluetooth"
+)
+
+// txPower is the radio transmit power in dBm. A lower level uses less current
+// but gives less range. Set 0 to keep the default level.
+const txPower = 0
+
+var adapter = bluetooth.DefaultAdapter
+
+func main() {
+	must("enable BLE stack", adapter.Enable())
+
+	// Remove this if the board has no DC/DC inductor. Not every board gives
+	// this control, so a failure is not fatal here.
+	adapter.EnableDCSupply(bluetooth.DCSupplyMain, true)
+
+	adv := adapter.DefaultAdvertisement()
+	must("config adv", adv.Configure(bluetooth.AdvertisementOptions{
+		AdvertisementType: bluetooth.AdvertisingTypeNonConnInd,
+		Interval:          bluetooth.NewDuration(2 * time.Second),
+		ManufacturerData: []bluetooth.ManufacturerDataElement{
+			{CompanyID: 0xffff, Data: []byte{0x01, 0x02}},
+		},
+	}))
+	// Not every board gives this control, so a failure here is not fatal.
+	adv.SetTxPower(txPower)
+	must("start adv", adv.Start())
+
+	// The BLE stack advertises on its own, so park the CPU. Each wake up uses
+	// current and does no work here.
+	for {
+		time.Sleep(time.Hour)
+	}
+}
+
+func must(action string, err error) {
+	if err != nil {
+		panic("failed to " + action + ": " + err.Error())
+	}
+}

--- a/gap.go
+++ b/gap.go
@@ -12,6 +12,7 @@ var (
 	errAdvertisementPacketTooBig = errors.New("bluetooth: advertisement packet overflows")
 	errNotYetImplmented          = errors.New("bluetooth: not implemented")
 	errNotSupported              = errors.New("bluetooth: not supported")
+	errInvalidTxPower            = errors.New("bluetooth: invalid transmit power level")
 )
 
 const (

--- a/gap_hci.go
+++ b/gap_hci.go
@@ -631,3 +631,9 @@ func (a *Advertisement) configureGenericServices(name string, appearance uint16)
 		})
 	a.genericServiceInit = true
 }
+
+// SetTxPower sets the radio transmit power for advertising, in dBm.
+// This HCI adapter does not give this control, so it is not supported.
+func (a *Advertisement) SetTxPower(dbm int8) error {
+	return errNotSupported
+}

--- a/gap_linux.go
+++ b/gap_linux.go
@@ -667,3 +667,9 @@ func (d *Device) parseProperties(props *map[string]dbus.Variant) error {
 
 	return nil
 }
+
+// SetTxPower sets the radio transmit power for advertising, in dBm.
+// Linux does not give this control, so it is not supported.
+func (a *Advertisement) SetTxPower(dbm int8) error {
+	return errNotSupported
+}

--- a/gap_nrf51.go
+++ b/gap_nrf51.go
@@ -139,3 +139,9 @@ func (d Device) Connected() (bool, error) {
 }
 
 type DeviceService struct{}
+
+// SetTxPower sets the radio transmit power for advertising, in dBm.
+// The s110 SoftDevice does not give this control, so it is not supported.
+func (a *Advertisement) SetTxPower(dbm int8) error {
+	return errNotSupported
+}

--- a/gap_nrf528xx-advertisement.go
+++ b/gap_nrf528xx-advertisement.go
@@ -105,6 +105,28 @@ func (a *Advertisement) Stop() error {
 	return makeError(errCode)
 }
 
+// SetTxPower sets the radio transmit power for advertising, in dBm.
+// A lower level uses less current but gives less range. Call it after Configure.
+func (a *Advertisement) SetTxPower(dbm int8) error {
+	if !isValidTxPower(dbm) {
+		return errInvalidTxPower
+	}
+	errCode := C.sd_ble_gap_tx_power_set(C.BLE_GAP_TX_POWER_ROLE_ADV,
+		C.uint16_t(a.handle), C.int8_t(dbm))
+	return makeError(errCode)
+}
+
+// isValidTxPower reports if the part accepts this level. An unlisted level gives
+// undefined behaviour. See the sd_ble_gap_tx_power_set note in ble_gap.h.
+func isValidTxPower(dbm int8) bool {
+	for _, level := range txPowerLevels {
+		if level == dbm {
+			return true
+		}
+	}
+	return false
+}
+
 // SetRandomAddress sets the random address to be used for advertising.
 func (a *Adapter) SetRandomAddress(mac MAC) error {
 	var addr C.ble_gap_addr_t

--- a/gap_windows.go
+++ b/gap_windows.go
@@ -501,3 +501,9 @@ func (d Device) RequestConnectionParams(params ConnectionParams) error {
 func (a *Adapter) SetRandomAddress(mac MAC) error {
 	return errors.ErrUnsupported
 }
+
+// SetTxPower sets the radio transmit power for advertising, in dBm.
+// Windows does not give this control, so it is not supported.
+func (a *Advertisement) SetTxPower(dbm int8) error {
+	return errNotSupported
+}


### PR DESCRIPTION
## Why

A beacon that runs from a battery must use as little current as possible. The
package gave no control of the two settings that save the most current on an
nRF52 part, which are the radio transmit power and the DC/DC converters.

## Transmit power

`(*Advertisement).SetTxPower(dbm int8) error` calls `sd_ble_gap_tx_power_set`
for the advertising role. A lower level uses much less current but gives less
range, so the caller chooses the level.

`ble_gap.h` says that a level the part does not accept gives undefined
behaviour, so an unlisted level returns the new `errInvalidTxPower` instead of
reaching the SoftDevice. The s140 SoftDevice runs only on the nRF52840, which
accepts levels up to +8 dBm. The s113 and s132 SoftDevices run on more parts,
so they accept only the levels that all of those parts have.

## DC supply

`(*Adapter).EnableDCSupply(stage DCSupplyStage, enable bool) error` calls
`sd_power_dcdc_mode_set` or `sd_power_dcdc0_mode_set`. The SoftDevice owns the
POWER peripheral, so an application cannot write these registers itself.

The nRF52840 has two regulator stages in series. REG0 supplies VDD from VDDH,
and VDD is the input to REG1. The two stages are therefore not alternatives, and
a board that is powered through VDDH uses both. One method takes the stage, so
that a caller cannot mistake them for one setting.

```go
const (
	// DCSupplyMain is the REG1 stage, which supplies the core from VDD.
	DCSupplyMain DCSupplyStage = iota

	// DCSupplyHighVoltage is the REG0 stage, which needs VDDH power. The gain
	// is small unless VDDH is much higher than VDD.
	DCSupplyHighVoltage
)
```

A board must have an inductor for the stage it enables, so both stages stay off
unless the application asks.

Only the nRF52840 has a VDDH stage, and `sd_power_dcdc0_mode_set` is absent from
the s113 and s132 headers. An internal `setDCSupplyHighVoltage` carries that
split, and it lives in the file for each SoftDevice next to the transmit power
levels, because both are facts that change with the SoftDevice. The public API
stays one method.

`DCSupplyHighVoltage` rarely helps a device that runs from a battery. A cell
gives about 3.7 V to 4.2 V while VDD is about 3.0 V to 3.3 V, so the converter
has little to convert but still costs current to run. Nordic report a case where
it [raised the current](https://devzone.nordicsemi.com/f/nordic-q-a/117514/enabling-reg0-dcdc-via-reg-dcdcen0-doesn-t-reduce-current-consumption)
from 126 uA to 140 uA, and an LDO on REG0 with the DC/DC on REG1 was best at
75 uA. The doc comment says the gain is small for this reason.

## Other platforms

Each new function has a stub that returns `errNotSupported` elsewhere. One
firmware source can then call both functions with no build tag. The go-haystack
beacon needs this, because it builds for the nRF52840, the RP2040 and Linux from
the same file.

## Example and smoke test

`examples/beacon-lowpower` shows all of this together, with a non-connectable
advertisement, a long interval, and a main loop that does not wake up.

`make smoketest-tinygo` builds the example for each SoftDevice that has the new
functions, and for a board that uses the stubs.

```
pca10056-s140v7 -serial=none   # nRF52840
pca10040-s132v6                # nRF52832, so the VDDH stage is not supported
microbit-v2-s113v7             # peripheral only SoftDevice
nano-rp2040                    # no SoftDevice, so both stubs are used
```

`make smoketest-linux` and `make smoketest-windows` build it as well, which is
what proves the stubs let one source build everywhere. The s140v7 line is also
the first `-serial=none` build in the Makefile, and that option is what keeps
the USB peripheral off.

## Test

`make smoketest-tinygo` passes with 33 builds. `make smoketest-linux` and
`make smoketest-windows` pass. `go build .` for linux and windows, `go vet .`
and `go test .` all pass.

The two `gofmt` findings in `gattc_linux.go` and `gattc_sd.go` are present
before this branch and are not touched here.

## Note

Nothing changes for an application that does not call the new functions.
