### PR TITLE
hci: add unit tests, and correct what they found

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -22,7 +22,9 @@ jobs:
       - name: Add required GOFLAGS
         run: go env -w GOFLAGS=-buildvcs=false
       - name: Run unit tests
-        run: go test
+        run: go test ./ ./ble ./hci
+      - name: Run unit tests with the race detector
+        run: go test -race ./ ./ble ./hci
       - name: Run TinyGo smoke tests
         run: make smoketest-tinygo
       - name: Run Linux smoke tests

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           go-version-file: 'go.mod'
       - name: Run unit tests
-        run: go test
+        run: go test ./ ./ble ./hci
       - name: "Run macOS smoke tests"
         run: make smoketest-macos
   
@@ -38,6 +38,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Run unit tests
-        run: go test
+        run: go test ./ ./ble ./hci
       - name: "Run macOS smoke tests"
         run: make smoketest-macos

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -19,6 +19,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Run unit tests
-        run: go test
+        run: go test ./ ./ble ./hci
       - name: "Run Windows smoke tests"
         run: make smoketest-windows

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,39 @@
+unreleased
+---
+* **core**
+  - ble: move `UUID`, `MAC` and `MACAddress` into a new `ble` subpackage. The
+    `bluetooth` package aliases them, so `bluetooth.UUID` and `ble.UUID` are the
+    same type and existing code keeps working.
+  - ble: move `AttributeProtocolError` and the `ErrAtt*` codes into the `ble`
+    subpackage, aliased in the same way. ATT now uses them instead of a second
+    copy of the same 17 codes.
+  - ble: rename `UUID.bytes()` to `UUID.BytesLittleEndian()`, and add
+    `ble.UUIDFromBytes` and `ble.NewMACAddress`.
+* **hci**
+  - hci: move the HCI, L2CAP and ATT protocol code into a new `hci` subpackage
+    that has no build tags, so it builds and unit tests on the host. A board
+    supplies an `hci.Transport` and calls `hci.NewStack`.
+  - hci: add `SetEventHandler` and `SetLEEventHandler`, so that a controller can
+    consume an event or an LE subevent that the package does not know, and
+    `SendVendorCommand` for the matching commands. Vendor extensions no longer
+    need to live in this repository.
+  - hci: add unit tests, at 87 percent statement coverage.
+  - hci: fix a panic on a Find Information Response, whose format byte was
+    treated as an entry length.
+  - hci: bounds check the entry length of a Read By Type Response and a Read By
+    Group Type Response, which came off the wire unchecked.
+  - hci: reject an ATT protocol data unit that is too short for its opcode,
+    rather than reading past the end of it.
+  - hci: fix `ReadBdAddr`, which copied the event header into the address.
+  - hci: fix `ReadLEBufferSize`, which read the raw packet buffer and raised the
+    maximum MTU far above what the response buffers hold.
+  - hci: fix `MTUReq`, which asked for an MTU of zero.
+  - hci: track the negotiated ATT MTU, so `GetMTU` reports it and a discovery
+    response carries more than one attribute.
+  - hci: reject a truncated L2CAP connection parameter update request, which was
+    answered as accepted with zeroed parameters.
+  - hci: `Transport` drops `ReadByte`, which nothing called.
+
 0.16.0
 ---
 * **core**

--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,36 @@ smoketest-tinygo:
 	$(TINYGO) build -o test.bin -size=short -target=xiao-esp32s3	./examples/discover
 	@md5sum test.bin
 
+smoketest-hci:
+	# Test the four HCI transports, for a faster loop than the whole matrix.
+	# ninafw
+	$(TINYGO) build -o test.uf2 -size=short -target=nano-rp2040           ./examples/discover
+	@md5sum test.uf2
+	$(TINYGO) build -o test.uf2 -size=short -target=nano-rp2040           ./examples/advertisement
+	@md5sum test.uf2
+	$(TINYGO) build -o test.uf2 -size=short -target=arduino-nano33        ./examples/discover
+	@md5sum test.uf2
+	$(TINYGO) build -o test.uf2 -size=short -target=pyportal              ./examples/discover
+	@md5sum test.uf2
+	# hci over a plain UART
+	$(TINYGO) build -o test.uf2 -size=short -target=circuitplay-express -tags="hci hci_uart" ./examples/advertisement
+	@md5sum test.uf2
+	# cyw43439
+	$(TINYGO) build -o test.uf2 -size=short -target=pico-w                ./examples/discover
+	@md5sum test.uf2
+	$(TINYGO) build -o test.uf2 -size=short -target=badger2040-w          ./examples/advertisement
+	@md5sum test.uf2
+	# espradio
+	$(TINYGO) build -o test.bin -size=short -target=xiao-esp32c3          ./examples/discover
+	@md5sum test.bin
+	$(TINYGO) build -o test.bin -size=short -target=xiao-esp32s3          ./examples/advertisement
+	@md5sum test.bin
+	# The bledebug build of the hci package is not covered anywhere else.
+	$(TINYGO) build -o test.uf2 -size=short -target=nano-rp2040 -tags=bledebug ./examples/discover
+	@md5sum test.uf2
+	$(TINYGO) build -o test.uf2 -size=short -target=pico-w      -tags=bledebug ./examples/discover
+	@md5sum test.uf2
+
 smoketest-linux:
 	# Test on Linux.
 	GOOS=linux go build -o /tmp/go-build-discard ./examples/advertisement

--- a/hci/att.go
+++ b/hci/att.go
@@ -42,9 +42,20 @@ const (
 	OpSignedWriteCmd      = 0xd2
 )
 
+// DefaultMTU is the ATT MTU before an exchange. See the Bluetooth Core
+// Specification, Section 3.2.8 of Part F.
+const DefaultMTU = 23
+
 const (
 	MaximumMTU          = 248
 	maximumMTUBufferLen = MaximumMTU + 8
+)
+
+// The Find Information Response formats. See the Bluetooth Core
+// Specification, Section 3.4.3.2 of Part F.
+const (
+	attFindInfoFormat16Bit  = 0x01
+	attFindInfoFormat128Bit = 0x02
 )
 
 // ShortUUID is a 16 bit UUID as it appears on the wire.
@@ -65,8 +76,6 @@ func (s ShortUUID) UUID() ble.UUID {
 	return ble.New16BitUUID(uint16(s))
 }
 
-var errNotImplemented = errors.New("bluetooth/hci: not implemented")
-
 var (
 	ErrATTTimeout           = errors.New("bluetooth: ATT timeout")
 	ErrATTUnknownEvent      = errors.New("bluetooth: ATT unknown event")
@@ -85,6 +94,10 @@ type Service struct {
 }
 
 func (s *Service) unmarshal(buf []byte) (int, error) {
+	if len(buf) < 4 {
+		return 0, errInvalidPayloadLength
+	}
+
 	s.StartHandle = binary.LittleEndian.Uint16(buf[0:])
 	s.EndHandle = binary.LittleEndian.Uint16(buf[2:])
 
@@ -154,6 +167,10 @@ type Characteristic struct {
 }
 
 func (c *Characteristic) unmarshal(buf []byte) (int, error) {
+	if len(buf) < 5 {
+		return 0, errInvalidPayloadLength
+	}
+
 	c.StartHandle = binary.LittleEndian.Uint16(buf[0:])
 	c.Properties = buf[2]
 	c.ValueHandle = binary.LittleEndian.Uint16(buf[3:])
@@ -200,15 +217,12 @@ type Descriptor struct {
 }
 
 func (d *Descriptor) unmarshal(buf []byte) (int, error) {
+	if len(buf) < 2 {
+		return 0, errInvalidPayloadLength
+	}
+
 	d.Handle = binary.LittleEndian.Uint16(buf[0:])
 	d.Data = append(d.Data, buf[2:]...)
-
-	return len(d.Data) + 2, nil
-}
-
-func (d *Descriptor) marshal(p []byte) (int, error) {
-	binary.LittleEndian.PutUint16(p[0:], d.Handle)
-	copy(p[2:], d.Data)
 
 	return len(d.Data) + 2, nil
 }
@@ -236,10 +250,6 @@ type attribute struct {
 	uuid        ble.UUID
 	permissions uint8
 	value       []byte
-}
-
-func (a *attribute) unmarshal(buf []byte) (int, error) {
-	return 0, errNotImplemented
 }
 
 func (a *attribute) marshal(p []byte) (int, error) {
@@ -323,6 +333,7 @@ func newATT(hci *HCI) *ATT {
 		lastHandle:           0x0001,
 		attributes:           []attribute{},
 		localServices:        []Service{},
+		mtu:                  DefaultMTU,
 		maxMTU:               MaximumMTU,
 	}
 }
@@ -451,17 +462,18 @@ func (a *ATT) MTUReq(connectionHandle uint16) error {
 		println("att.mtuReq:", connectionHandle)
 	}
 
-	cd, err := a.ConnectionData(connectionHandle)
-	if err != nil {
+	if _, err := a.ConnectionData(connectionHandle); err != nil {
 		return err
 	}
 
 	a.busy.Lock()
 	defer a.busy.Unlock()
 
+	// Ask for the largest MTU this stack accepts. The remote answers with the
+	// smaller of the two.
 	var b [3]byte
 	b[0] = OpMTUReq
-	binary.LittleEndian.PutUint16(b[1:], cd.MTU)
+	binary.LittleEndian.PutUint16(b[1:], a.maxMTU)
 
 	if err := a.sendReq(connectionHandle, b[:]); err != nil {
 		return err
@@ -552,9 +564,61 @@ func (a *ATT) sendError(handle uint16, opcode uint8, hdl uint16, code ble.Attrib
 	return nil
 }
 
+// attMinLength returns the smallest a protocol data unit can be for an
+// opcode, counting the opcode byte. Anything shorter cannot be parsed. The
+// lengths come from the Bluetooth Core Specification, Section 3.4 of Part F.
+//
+// A switch rather than a table, so that it costs no RAM.
+func attMinLength(opcode uint8) int {
+	switch opcode {
+	case OpReadResponse, OpWriteResponse, OpHandleCNF:
+		return 1
+	case OpFindInfoResponse, OpReadByTypeResponse, OpReadByGroupResponse:
+		return 2
+	case OpMTUReq, OpMTUResponse, OpReadReq, OpWriteReq, OpWriteCmd,
+		OpHandleNotify, OpHandleInd:
+		return 3
+	case OpError, OpFindInfoReq, OpReadBlobReq:
+		return 5
+	case OpFindByTypeReq, OpReadByTypeReq, OpReadByGroupReq:
+		return 7
+	default:
+		return 1
+	}
+}
+
+// attEntryLength validates the entry length of a list response. The length
+// comes off the wire, so a zero would loop forever and an oversized one would
+// read past the end.
+func attEntryLength(buf []byte) (int, error) {
+	length := int(buf[1])
+	if length == 0 || 2+length > len(buf) {
+		if debug {
+			println("att: bad entry length", length, len(buf))
+		}
+
+		return 0, ErrInvalidPacket
+	}
+
+	return length, nil
+}
+
 func (a *ATT) handleData(handle uint16, buf []byte) error {
 	if debug {
 		println("att.handleData:", handle, "data:", hex.EncodeToString(buf))
+	}
+
+	// The protocol data unit arrives over the air, so check that it is long
+	// enough for its opcode before reading any of it.
+	if len(buf) < 1 {
+		return ErrInvalidPacket
+	}
+	if len(buf) < attMinLength(buf[0]) {
+		if debug {
+			println("att.handleData: too short for opcode", buf[0], len(buf))
+		}
+
+		return ErrInvalidPacket
 	}
 
 	cd, err := a.ConnectionData(handle)
@@ -591,6 +655,7 @@ func (a *ATT) handleData(handle uint16, buf []byte) error {
 
 		// save mtu for connection
 		cd.MTU = mtu
+		a.mtu = mtu
 
 		var b [3]byte
 		b[0] = OpMTUResponse
@@ -606,6 +671,7 @@ func (a *ATT) handleData(handle uint16, buf []byte) error {
 		}
 		cd.responded = true
 		cd.MTU = binary.LittleEndian.Uint16(buf[1:])
+		a.mtu = cd.MTU
 
 	case OpFindInfoReq:
 		if debug {
@@ -623,11 +689,29 @@ func (a *ATT) handleData(handle uint16, buf []byte) error {
 		}
 		cd.responded = true
 
-		lengthPerDescriptor := int(buf[1])
+		// The format says how wide each entry is. See the Bluetooth Core
+		// Specification, Section 3.4.3.2 of Part F.
+		var lengthPerDescriptor int
+		switch buf[1] {
+		case attFindInfoFormat16Bit:
+			lengthPerDescriptor = 2 + 2
+		case attFindInfoFormat128Bit:
+			lengthPerDescriptor = 2 + 16
+		default:
+			if debug {
+				println("att.handleData: unknown find info format", buf[1])
+			}
 
-		for i := 2; i < len(buf); i += lengthPerDescriptor {
+			return ErrInvalidPacket
+		}
+
+		// The format comes off the wire, so only read whole entries that are
+		// really present.
+		for i := 2; i+lengthPerDescriptor <= len(buf); i += lengthPerDescriptor {
 			d := Descriptor{}
-			d.unmarshal(buf[i : i+lengthPerDescriptor])
+			if _, err := d.unmarshal(buf[i : i+lengthPerDescriptor]); err != nil {
+				return err
+			}
 
 			if debug {
 				println("att.handleData: descriptor", d.Handle, hex.EncodeToString(d.Data))
@@ -658,11 +742,17 @@ func (a *ATT) handleData(handle uint16, buf []byte) error {
 		}
 		cd.responded = true
 
-		lengthPerCharacteristic := int(buf[1])
+		lengthPerCharacteristic, err := attEntryLength(buf)
+		if err != nil {
+			return err
+		}
 
-		for i := 2; i < len(buf); i += lengthPerCharacteristic {
+		// Only read whole entries that are really present.
+		for i := 2; i+lengthPerCharacteristic <= len(buf); i += lengthPerCharacteristic {
 			c := Characteristic{}
-			c.unmarshal(buf[i : i+lengthPerCharacteristic])
+			if _, err := c.unmarshal(buf[i : i+lengthPerCharacteristic]); err != nil {
+				return err
+			}
 
 			if debug {
 				println("att.handleData: characteristic", c.StartHandle, c.Properties, c.ValueHandle, c.UUID.String())
@@ -690,11 +780,17 @@ func (a *ATT) handleData(handle uint16, buf []byte) error {
 		}
 		cd.responded = true
 
-		lengthPerService := int(buf[1])
+		lengthPerService, err := attEntryLength(buf)
+		if err != nil {
+			return err
+		}
 
-		for i := 2; i < len(buf); i += lengthPerService {
+		// Only read whole entries that are really present.
+		for i := 2; i+lengthPerService <= len(buf); i += lengthPerService {
 			service := Service{}
-			service.unmarshal(buf[i : i+lengthPerService])
+			if _, err := service.unmarshal(buf[i : i+lengthPerService]); err != nil {
+				return err
+			}
 
 			if debug {
 				println("att.handleData: service", service.StartHandle, service.EndHandle, service.UUID.String())
@@ -934,6 +1030,13 @@ func (a *ATT) handleFindInfoReq(handle, start, end uint16) error {
 	pos = 2
 	infoType := 0
 	response[1] = 0
+
+	// TODO: the format has to follow the UUID width, 1 for 16 bit and 2 for
+	// 128 bit, and only characteristic values and descriptors belong in this
+	// response. It currently follows the attribute type instead, so a
+	// database whose first match is a service declaration answers with
+	// format 2 and 16 bit UUIDs. See the Bluetooth Core Specification,
+	// Section 3.4.3.2 of Part F.
 
 	for _, attr := range a.attributes {
 		if debug {

--- a/hci/att.go
+++ b/hci/att.go
@@ -76,8 +76,6 @@ var (
 	ErrATTAttributeNotFound = errors.New("bluetooth: ATT attribute not found")
 )
 
-const defaultTimeoutSeconds = 10
-
 // Service is a service found on a remote device, or one that this stack makes
 // available.
 type Service struct {
@@ -1118,7 +1116,7 @@ func (a *ATT) waitUntilResponse(handle uint16) error {
 		return err
 	}
 
-	start := time.Now().UnixNano()
+	start := time.Now()
 	for {
 		if err := a.hci.Poll(); err != nil {
 			return err
@@ -1128,11 +1126,11 @@ func (a *ATT) waitUntilResponse(handle uint16) error {
 		case cd.responded:
 			return nil
 
-		case (time.Now().UnixNano()-start)/int64(time.Second) > defaultTimeoutSeconds:
+		case time.Since(start) > a.hci.responseTimeout:
 			return ErrATTTimeout
 
 		default:
-			time.Sleep(5 * time.Millisecond)
+			time.Sleep(a.hci.retryDelay)
 		}
 	}
 }

--- a/hci/att_test.go
+++ b/hci/att_test.go
@@ -1,0 +1,1000 @@
+package hci
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"testing"
+
+	"tinygo.org/x/bluetooth/ble"
+)
+
+const testConnHandle = 0x0040
+
+// errTestRead is returned by a characteristic handler told to fail.
+var errTestRead = errors.New("test read error")
+
+// aclPacket wraps an ATT protocol data unit in an ACL and L2CAP header, the
+// way it arrives from a controller.
+func aclPacket(handle, cid uint16, pdu []byte) []byte {
+	pkt := make([]byte, 9+len(pdu))
+	pkt[0] = PacketACLData
+	binary.LittleEndian.PutUint16(pkt[1:], handle)
+	binary.LittleEndian.PutUint16(pkt[3:], uint16(len(pdu)+4))
+	binary.LittleEndian.PutUint16(pkt[5:], uint16(len(pdu)))
+	binary.LittleEndian.PutUint16(pkt[7:], cid)
+	copy(pkt[9:], pdu)
+
+	return pkt
+}
+
+// attPacket wraps an ATT protocol data unit for the ATT channel.
+func attPacket(pdu ...byte) []byte {
+	return aclPacket(testConnHandle, CIDATT, pdu)
+}
+
+// sentPDU returns the ATT protocol data unit of the nth write, stripping the
+// ACL and L2CAP headers.
+func sentPDU(t *testing.T, f *fakeTransport, n int) []byte {
+	t.Helper()
+
+	if len(f.tx) <= n {
+		t.Fatalf("only %d packets written; want at least %d", len(f.tx), n+1)
+	}
+
+	pkt := f.tx[n]
+	if len(pkt) < 9 {
+		t.Fatalf("write %d is %d bytes; too short for an ACL packet", n, len(pkt))
+	}
+	if pkt[0] != PacketACLData {
+		t.Fatalf("write %d has packet type %#x; want an ACL packet", n, pkt[0])
+	}
+
+	return pkt[9:]
+}
+
+// newTestATT returns a stack with one connection already open, so that the ATT
+// layer has connection data to work with.
+func newTestATT(t *testing.T, rx ...[]byte) (*Stack, *fakeTransport) {
+	t.Helper()
+
+	f := &fakeTransport{rx: rx}
+	s := newTestStack(f)
+
+	if err := s.ATT.addConnection(testConnHandle); err != nil {
+		t.Fatalf("addConnection: %v", err)
+	}
+
+	return s, f
+}
+
+func TestATTServerReadByGroupRequest(t *testing.T) {
+	// A primary service with a 16 bit UUID.
+	s, f := newTestATT(t)
+	handle := s.ATT.AddLocalAttribute(AttributeTypeService, 0,
+		UUIDPrimaryService.UUID(), 0, []byte{0x0f, 0x18})
+	s.ATT.AddLocalService(handle, handle, ble.New16BitUUID(0x180f))
+
+	// Read By Group Type Request for primary services over the whole range.
+	pdu := []byte{OpReadByGroupReq, 0x01, 0x00, 0xff, 0xff, 0x00, 0x28}
+	if err := s.ATT.handleData(testConnHandle, pdu); err != nil {
+		t.Fatalf("handleData: %v", err)
+	}
+
+	got := sentPDU(t, f, 0)
+	if got[0] != OpReadByGroupResponse {
+		t.Fatalf("opcode = %#x; want OpReadByGroupResponse", got[0])
+	}
+	// length byte, then start handle, end handle and the 16 bit UUID.
+	if got[1] != 6 {
+		t.Errorf("entry length = %d; want 6", got[1])
+	}
+	if uuid := binary.LittleEndian.Uint16(got[6:]); uuid != 0x180f {
+		t.Errorf("UUID = %#x; want 0x180f", uuid)
+	}
+}
+
+func TestATTServerReadByGroupRequestNothingFound(t *testing.T) {
+	s, f := newTestATT(t)
+
+	pdu := []byte{OpReadByGroupReq, 0x01, 0x00, 0xff, 0xff, 0x00, 0x28}
+	if err := s.ATT.handleData(testConnHandle, pdu); err != nil {
+		t.Fatalf("handleData: %v", err)
+	}
+
+	got := sentPDU(t, f, 0)
+	want := []byte{OpError, OpReadByGroupReq, 0x01, 0x00, byte(ble.ErrAttNotFound)}
+	if !bytes.Equal(got, want) {
+		t.Errorf("response = %#v; want %#v", got, want)
+	}
+}
+
+func TestATTServerReadRequest(t *testing.T) {
+	s, f := newTestATT(t)
+
+	svc := s.ATT.AddLocalAttribute(AttributeTypeService, 0,
+		UUIDPrimaryService.UUID(), 0, []byte{0x0f, 0x18})
+	chr := s.ATT.AddLocalAttribute(AttributeTypeCharacteristic, svc,
+		UUIDCharacteristic.UUID(), 0x02, nil)
+	val := s.ATT.AddLocalAttribute(AttributeTypeCharacteristicValue, chr,
+		ble.New16BitUUID(0x2a19), 0x02, []byte{50})
+
+	s.ATT.AddLocalCharacteristic(chr, 0x02, val, ble.New16BitUUID(0x2a19),
+		CharacteristicHandler{
+			ReadValue: func() ([]byte, error) { return []byte{99}, nil },
+		})
+
+	pdu := []byte{OpReadReq, byte(val), byte(val >> 8)}
+	if err := s.ATT.handleData(testConnHandle, pdu); err != nil {
+		t.Fatalf("handleData: %v", err)
+	}
+
+	got := sentPDU(t, f, 0)
+	want := []byte{OpReadResponse, 99}
+	if !bytes.Equal(got, want) {
+		t.Errorf("response = %#v; want %#v", got, want)
+	}
+}
+
+func TestATTServerReadRequestHandlerError(t *testing.T) {
+	s, f := newTestATT(t)
+
+	svc := s.ATT.AddLocalAttribute(AttributeTypeService, 0,
+		UUIDPrimaryService.UUID(), 0, nil)
+	chr := s.ATT.AddLocalAttribute(AttributeTypeCharacteristic, svc,
+		UUIDCharacteristic.UUID(), 0, nil)
+	val := s.ATT.AddLocalAttribute(AttributeTypeCharacteristicValue, chr,
+		ble.New16BitUUID(0x2a19), 0, nil)
+
+	s.ATT.AddLocalCharacteristic(chr, 0, val, ble.New16BitUUID(0x2a19),
+		CharacteristicHandler{
+			ReadValue: func() ([]byte, error) { return nil, errTestRead },
+		})
+
+	pdu := []byte{OpReadReq, byte(val), byte(val >> 8)}
+	if err := s.ATT.handleData(testConnHandle, pdu); err != nil {
+		t.Fatalf("handleData: %v", err)
+	}
+
+	got := sentPDU(t, f, 0)
+	if got[0] != OpError || got[4] != byte(ble.ErrAttReadNotPermitted) {
+		t.Errorf("response = %#v; want a read not permitted error", got)
+	}
+}
+
+func TestATTServerReadRequestUnknownHandle(t *testing.T) {
+	s, f := newTestATT(t)
+
+	pdu := []byte{OpReadReq, 0x99, 0x00}
+	if err := s.ATT.handleData(testConnHandle, pdu); err != nil {
+		t.Fatalf("handleData: %v", err)
+	}
+
+	got := sentPDU(t, f, 0)
+	if got[0] != OpError || got[4] != byte(ble.ErrAttNotFound) {
+		t.Errorf("response = %#v; want an attribute not found error", got)
+	}
+}
+
+func TestATTServerWriteRequest(t *testing.T) {
+	s, f := newTestATT(t)
+
+	svc := s.ATT.AddLocalAttribute(AttributeTypeService, 0,
+		UUIDPrimaryService.UUID(), 0, nil)
+	chr := s.ATT.AddLocalAttribute(AttributeTypeCharacteristic, svc,
+		UUIDCharacteristic.UUID(), 0, nil)
+	val := s.ATT.AddLocalAttribute(AttributeTypeCharacteristicValue, chr,
+		ble.New16BitUUID(0x2a19), 0, nil)
+
+	var written []byte
+	s.ATT.AddLocalCharacteristic(chr, 0, val, ble.New16BitUUID(0x2a19),
+		CharacteristicHandler{
+			WriteValue: func(data []byte) (int, error) {
+				written = append([]byte{}, data...)
+				return len(data), nil
+			},
+		})
+
+	pdu := []byte{OpWriteReq, byte(val), byte(val >> 8), 0xaa, 0xbb}
+	if err := s.ATT.handleData(testConnHandle, pdu); err != nil {
+		t.Fatalf("handleData: %v", err)
+	}
+
+	if !bytes.Equal(written, []byte{0xaa, 0xbb}) {
+		t.Errorf("handler saw %#v; want aa bb", written)
+	}
+
+	got := sentPDU(t, f, 0)
+	if !bytes.Equal(got, []byte{OpWriteResponse}) {
+		t.Errorf("response = %#v; want a write response", got)
+	}
+}
+
+func TestATTServerWriteCCCD(t *testing.T) {
+	s, f := newTestATT(t)
+
+	svc := s.ATT.AddLocalAttribute(AttributeTypeService, 0,
+		UUIDPrimaryService.UUID(), 0, nil)
+	chr := s.ATT.AddLocalAttribute(AttributeTypeCharacteristic, svc,
+		UUIDCharacteristic.UUID(), 0, nil)
+	val := s.ATT.AddLocalAttribute(AttributeTypeCharacteristicValue, chr,
+		ble.New16BitUUID(0x2a19), 0, nil)
+	cccd := s.ATT.AddLocalAttribute(AttributeTypeDescriptor, chr,
+		UUIDClientCharacteristicConfig.UUID(), 0, []byte{0, 0})
+
+	var got uint16
+	s.ATT.AddLocalCharacteristic(chr, 0, val, ble.New16BitUUID(0x2a19),
+		CharacteristicHandler{
+			WriteCCCD: func(v uint16) error { got = v; return nil },
+			ReadCCCD:  func() (uint16, error) { return got, nil },
+		})
+
+	pdu := []byte{OpWriteReq, byte(cccd), byte(cccd >> 8), 0x01, 0x00}
+	if err := s.ATT.handleData(testConnHandle, pdu); err != nil {
+		t.Fatalf("handleData: %v", err)
+	}
+	if got != 0x0001 {
+		t.Errorf("CCCD = %#x; want 0x1", got)
+	}
+
+	// Reading it back returns what was written.
+	pdu = []byte{OpReadReq, byte(cccd), byte(cccd >> 8)}
+	if err := s.ATT.handleData(testConnHandle, pdu); err != nil {
+		t.Fatalf("handleData: %v", err)
+	}
+
+	resp := sentPDU(t, f, 1)
+	if resp[0] != OpReadResponse || binary.LittleEndian.Uint16(resp[1:]) != 0x0001 {
+		t.Errorf("read response = %#v; want the CCCD value 0x1", resp)
+	}
+}
+
+func TestATTServerNoHandlerIsAnError(t *testing.T) {
+	s, f := newTestATT(t)
+
+	svc := s.ATT.AddLocalAttribute(AttributeTypeService, 0,
+		UUIDPrimaryService.UUID(), 0, nil)
+	chr := s.ATT.AddLocalAttribute(AttributeTypeCharacteristic, svc,
+		UUIDCharacteristic.UUID(), 0, nil)
+	val := s.ATT.AddLocalAttribute(AttributeTypeCharacteristicValue, chr,
+		ble.New16BitUUID(0x2a19), 0, nil)
+
+	// A characteristic whose handler set is empty.
+	s.ATT.AddLocalCharacteristic(chr, 0, val, ble.New16BitUUID(0x2a19),
+		CharacteristicHandler{})
+
+	pdu := []byte{OpReadReq, byte(val), byte(val >> 8)}
+	if err := s.ATT.handleData(testConnHandle, pdu); err != nil {
+		t.Fatalf("handleData: %v", err)
+	}
+
+	got := sentPDU(t, f, 0)
+	if got[0] != OpError {
+		t.Errorf("response = %#v; want an error response", got)
+	}
+}
+
+func TestATTClientReadByGroupResponse(t *testing.T) {
+	s, _ := newTestATT(t)
+
+	// Two services, each with a 16 bit UUID.
+	pdu := []byte{OpReadByGroupResponse, 6,
+		0x01, 0x00, 0x05, 0x00, 0x0f, 0x18,
+		0x06, 0x00, 0x09, 0x00, 0x0a, 0x18,
+	}
+	if err := s.ATT.handleData(testConnHandle, pdu); err != nil {
+		t.Fatalf("handleData: %v", err)
+	}
+
+	cd, err := s.ATT.ConnectionData(testConnHandle)
+	if err != nil {
+		t.Fatalf("ConnectionData: %v", err)
+	}
+	if len(cd.Services) != 2 {
+		t.Fatalf("found %d services; want 2", len(cd.Services))
+	}
+	if cd.Services[0].UUID != ble.New16BitUUID(0x180f) {
+		t.Errorf("first UUID = %v; want 180f", cd.Services[0].UUID)
+	}
+	if cd.Services[0].StartHandle != 1 || cd.Services[0].EndHandle != 5 {
+		t.Errorf("first handles = %d..%d; want 1..5",
+			cd.Services[0].StartHandle, cd.Services[0].EndHandle)
+	}
+	if cd.Services[1].UUID != ble.New16BitUUID(0x180a) {
+		t.Errorf("second UUID = %v; want 180a", cd.Services[1].UUID)
+	}
+}
+
+func TestATTClientReadByTypeResponse(t *testing.T) {
+	s, _ := newTestATT(t)
+
+	// One characteristic: declaration handle, properties, value handle, UUID.
+	pdu := []byte{OpReadByTypeResponse, 7,
+		0x02, 0x00, 0x12, 0x03, 0x00, 0x19, 0x2a,
+	}
+	if err := s.ATT.handleData(testConnHandle, pdu); err != nil {
+		t.Fatalf("handleData: %v", err)
+	}
+
+	cd, _ := s.ATT.ConnectionData(testConnHandle)
+	if len(cd.Characteristics) != 1 {
+		t.Fatalf("found %d characteristics; want 1", len(cd.Characteristics))
+	}
+
+	c := cd.Characteristics[0]
+	if c.Properties != 0x12 {
+		t.Errorf("Properties = %#x; want 0x12", c.Properties)
+	}
+	if c.ValueHandle != 3 {
+		t.Errorf("ValueHandle = %d; want 3", c.ValueHandle)
+	}
+	if c.UUID != ble.New16BitUUID(0x2a19) {
+		t.Errorf("UUID = %v; want 2a19", c.UUID)
+	}
+}
+
+func TestATTClientReadResponse(t *testing.T) {
+	s, _ := newTestATT(t)
+
+	if err := s.ATT.handleData(testConnHandle, []byte{OpReadResponse, 1, 2, 3}); err != nil {
+		t.Fatalf("handleData: %v", err)
+	}
+
+	cd, _ := s.ATT.ConnectionData(testConnHandle)
+	if !bytes.Equal(cd.Value, []byte{1, 2, 3}) {
+		t.Errorf("Value = %#v; want 1 2 3", cd.Value)
+	}
+}
+
+func TestATTClientErrorResponse(t *testing.T) {
+	s, _ := newTestATT(t)
+
+	pdu := []byte{OpError, OpReadByTypeReq, 0x01, 0x00, byte(ble.ErrAttNotFound)}
+	err := s.ATT.handleData(testConnHandle, pdu)
+	if err != ErrATTAttributeNotFound {
+		t.Errorf("handleData = %v; want ErrATTAttributeNotFound", err)
+	}
+
+	attErr, ok := s.ATT.LastError(testConnHandle)
+	if !ok {
+		t.Fatal("LastError reported nothing")
+	}
+	if attErr.Opcode != OpReadByTypeReq {
+		t.Errorf("Opcode = %#x; want OpReadByTypeReq", attErr.Opcode)
+	}
+	if attErr.Code != ble.ErrAttNotFound {
+		t.Errorf("Code = %v; want ErrAttNotFound", attErr.Code)
+	}
+}
+
+func TestATTClientErrorResponseOtherCode(t *testing.T) {
+	s, _ := newTestATT(t)
+
+	pdu := []byte{OpError, OpWriteReq, 0x01, 0x00, byte(ble.ErrAttWriteNotPermitted)}
+	if err := s.ATT.handleData(testConnHandle, pdu); err != ErrATTOp {
+		t.Errorf("handleData = %v; want ErrATTOp", err)
+	}
+
+	attErr, _ := s.ATT.LastError(testConnHandle)
+	if attErr.Code != ble.ErrAttWriteNotPermitted {
+		t.Errorf("Code = %v; want ErrAttWriteNotPermitted", attErr.Code)
+	}
+}
+
+func TestATTMTUExchange(t *testing.T) {
+	t.Run("clamped to the maximum", func(t *testing.T) {
+		s, f := newTestATT(t)
+
+		// The remote asks for more than this stack accepts.
+		pdu := []byte{OpMTUReq, 0xff, 0x00}
+		if err := s.ATT.handleData(testConnHandle, pdu); err != nil {
+			t.Fatalf("handleData: %v", err)
+		}
+
+		got := sentPDU(t, f, 0)
+		if got[0] != OpMTUResponse {
+			t.Fatalf("opcode = %#x; want OpMTUResponse", got[0])
+		}
+		if mtu := binary.LittleEndian.Uint16(got[1:]); mtu != MaximumMTU {
+			t.Errorf("MTU = %d; want %d", mtu, MaximumMTU)
+		}
+	})
+
+	t.Run("a smaller request is honoured", func(t *testing.T) {
+		s, f := newTestATT(t)
+
+		pdu := []byte{OpMTUReq, 0x40, 0x00}
+		if err := s.ATT.handleData(testConnHandle, pdu); err != nil {
+			t.Fatalf("handleData: %v", err)
+		}
+
+		got := sentPDU(t, f, 0)
+		if mtu := binary.LittleEndian.Uint16(got[1:]); mtu != 0x40 {
+			t.Errorf("MTU = %d; want 64", mtu)
+		}
+	})
+}
+
+func TestATTNotificationReachesTheChannel(t *testing.T) {
+	s, _ := newTestATT(t)
+
+	pdu := []byte{OpHandleNotify, 0x03, 0x00, 0x2a, 0x2b}
+	if err := s.ATT.handleData(testConnHandle, pdu); err != nil {
+		t.Fatalf("handleData: %v", err)
+	}
+
+	select {
+	case not := <-s.ATT.Notifications():
+		if not.ConnectionHandle != testConnHandle {
+			t.Errorf("ConnectionHandle = %#x; want %#x", not.ConnectionHandle, testConnHandle)
+		}
+		if not.Handle != 3 {
+			t.Errorf("Handle = %d; want 3", not.Handle)
+		}
+		if !bytes.Equal(not.Data, []byte{0x2a, 0x2b}) {
+			t.Errorf("Data = %#v; want 2a 2b", not.Data)
+		}
+	default:
+		t.Fatal("no notification on the channel")
+	}
+}
+
+func TestATTNotificationQueueDropsWhenFull(t *testing.T) {
+	s, _ := newTestATT(t)
+
+	// The channel holds 32. The ones after that are dropped rather than
+	// blocking the poll loop.
+	for i := 0; i < 40; i++ {
+		pdu := []byte{OpHandleNotify, 0x03, 0x00, byte(i)}
+		if err := s.ATT.handleData(testConnHandle, pdu); err != nil {
+			t.Fatalf("handleData at %d: %v", i, err)
+		}
+	}
+
+	if got := len(s.ATT.Notifications()); got != 32 {
+		t.Errorf("queued %d notifications; want 32", got)
+	}
+}
+
+func TestATTUnknownConnection(t *testing.T) {
+	f := &fakeTransport{}
+	s := newTestStack(f)
+
+	if _, err := s.ATT.ConnectionData(0x99); err != ErrATTUnknownConnection {
+		t.Errorf("ConnectionData = %v; want ErrATTUnknownConnection", err)
+	}
+}
+
+func TestATTRequestWithoutAResponseTimesOut(t *testing.T) {
+	s, _ := newTestATT(t)
+
+	err := s.ATT.ReadReq(testConnHandle, 0x0003)
+	if err != ErrATTTimeout {
+		t.Errorf("ReadReq = %v; want ErrATTTimeout", err)
+	}
+}
+
+func TestATTRequestWritesTheCorrectPDU(t *testing.T) {
+	s, f := newTestATT(t)
+
+	// No answer is scripted, so the request times out. The bytes it put on the
+	// wire are what matter here.
+	_ = s.ATT.ReadReq(testConnHandle, 0x0003)
+
+	got := sentPDU(t, f, 0)
+	want := []byte{OpReadReq, 0x03, 0x00}
+	if !bytes.Equal(got, want) {
+		t.Errorf("wrote %#v; want %#v", got, want)
+	}
+}
+
+func TestATTWriteCommandNeedsNoResponse(t *testing.T) {
+	s, f := newTestATT(t)
+
+	if err := s.ATT.WriteCmd(testConnHandle, 0x0003, []byte{0xaa}); err != nil {
+		t.Fatalf("WriteCmd: %v", err)
+	}
+
+	got := sentPDU(t, f, 0)
+	want := []byte{OpWriteCmd, 0x03, 0x00, 0xaa}
+	if !bytes.Equal(got, want) {
+		t.Errorf("wrote %#v; want %#v", got, want)
+	}
+}
+
+func TestATTSendNotification(t *testing.T) {
+	s, f := newTestATT(t)
+
+	if err := s.ATT.SendNotification(0x0003, []byte{0x42}); err != nil {
+		t.Fatalf("SendNotification: %v", err)
+	}
+
+	got := sentPDU(t, f, 0)
+	want := []byte{OpHandleNotify, 0x03, 0x00, 0x42}
+	if !bytes.Equal(got, want) {
+		t.Errorf("wrote %#v; want %#v", got, want)
+	}
+}
+
+func TestATTOverACLFromTheTransport(t *testing.T) {
+	// The whole path: an ACL packet arrives, HCI unwraps it, L2CAP routes it
+	// to ATT and ATT answers on the same channel.
+	s, f := newTestATT(t, attPacket(OpMTUReq, 0x40, 0x00))
+
+	if err := s.HCI.Poll(); err != nil {
+		t.Fatalf("Poll: %v", err)
+	}
+
+	got := sentPDU(t, f, 0)
+	if got[0] != OpMTUResponse {
+		t.Errorf("response opcode = %#x; want OpMTUResponse", got[0])
+	}
+}
+
+func TestACLPacketWithMismatchedLengths(t *testing.T) {
+	// The ACL length and the L2CAP length must agree. The ACL payload is the
+	// 4 byte L2CAP header plus the L2CAP length.
+	pkt := make([]byte, 13)
+	pkt[0] = PacketACLData
+	binary.LittleEndian.PutUint16(pkt[1:], testConnHandle)
+	binary.LittleEndian.PutUint16(pkt[3:], 8) // ACL length, so 4 payload bytes
+	binary.LittleEndian.PutUint16(pkt[5:], 2) // the L2CAP length disagrees
+	binary.LittleEndian.PutUint16(pkt[7:], CIDATT)
+
+	s := newTestStack(&fakeTransport{})
+	copy(s.HCI.buf, pkt)
+	s.HCI.end = len(pkt)
+	s.HCI.pos = len(pkt)
+
+	if _, err := s.HCI.processPacket(); err == nil {
+		t.Error("processPacket = nil; want an error for mismatched lengths")
+	}
+}
+
+func TestACLPacketTooShortForTheHeaders(t *testing.T) {
+	// An ACL payload has to hold at least the 4 byte L2CAP header.
+	s := newTestStack(&fakeTransport{})
+
+	err := s.HCI.handleACLData([]byte{0x40, 0x00, 0x02, 0x00, 0x01, 0x02})
+	if err != ErrInvalidPacket {
+		t.Errorf("handleACLData = %v; want ErrInvalidPacket", err)
+	}
+}
+
+func TestACLPayloadLengthPastTheEnd(t *testing.T) {
+	// A defence in depth check. The L2CAP length comes off the wire, so
+	// handleACLData does not trust it even though processPacket has already
+	// sized the packet.
+	buf := make([]byte, 10)
+	binary.LittleEndian.PutUint16(buf[0:], testConnHandle)
+	binary.LittleEndian.PutUint16(buf[2:], 6)
+	binary.LittleEndian.PutUint16(buf[4:], 2)
+	binary.LittleEndian.PutUint16(buf[6:], CIDATT)
+
+	s := newTestStack(&fakeTransport{})
+
+	// Hand it a buffer shorter than the L2CAP length claims.
+	if err := s.HCI.handleACLData(buf[:9]); err != ErrInvalidPacket {
+		t.Errorf("handleACLData = %v; want ErrInvalidPacket", err)
+	}
+}
+
+func TestShortUUID(t *testing.T) {
+	if got := UUIDPrimaryService.UUID(); got != ble.New16BitUUID(0x2800) {
+		t.Errorf("UUIDPrimaryService.UUID() = %v; want 2800", got)
+	}
+	if got := UUIDCharacteristic.UUID(); got != ble.New16BitUUID(0x2803) {
+		t.Errorf("UUIDCharacteristic.UUID() = %v; want 2803", got)
+	}
+	if got := UUIDClientCharacteristicConfig.UUID(); got != ble.New16BitUUID(0x2902) {
+		t.Errorf("UUIDClientCharacteristicConfig.UUID() = %v; want 2902", got)
+	}
+}
+
+func TestATTClientRequestPDUs(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		send func(*ATT) error
+		want []byte
+	}{
+		{
+			name: "read by group type request",
+			send: func(a *ATT) error {
+				return a.ReadByGroupReq(testConnHandle, 0x0001, 0xffff, UUIDPrimaryService)
+			},
+			want: []byte{OpReadByGroupReq, 0x01, 0x00, 0xff, 0xff, 0x00, 0x28},
+		},
+		{
+			name: "read by type request",
+			send: func(a *ATT) error {
+				return a.ReadByTypeReq(testConnHandle, 0x0002, 0x0009, UUIDCharacteristic)
+			},
+			want: []byte{OpReadByTypeReq, 0x02, 0x00, 0x09, 0x00, 0x03, 0x28},
+		},
+		{
+			name: "find information request",
+			send: func(a *ATT) error {
+				return a.FindInfoReq(testConnHandle, 0x0004, 0x0006)
+			},
+			want: []byte{OpFindInfoReq, 0x04, 0x00, 0x06, 0x00},
+		},
+		{
+			name: "write request",
+			send: func(a *ATT) error {
+				return a.WriteReq(testConnHandle, 0x0004, []byte{0x01, 0x00})
+			},
+			want: []byte{OpWriteReq, 0x04, 0x00, 0x01, 0x00},
+		},
+		{
+			name: "exchange MTU request",
+			send: func(a *ATT) error {
+				return a.MTUReq(testConnHandle)
+			},
+			want: []byte{OpMTUReq, byte(MaximumMTU), 0x00},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s, f := newTestATT(t)
+
+			// Nothing answers, so the request times out. The bytes it put on
+			// the wire are what matter.
+			if err := tc.send(s.ATT); err != ErrATTTimeout {
+				t.Fatalf("request = %v; want ErrATTTimeout", err)
+			}
+
+			if got := sentPDU(t, f, 0); !bytes.Equal(got, tc.want) {
+				t.Errorf("wrote %#v; want %#v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestATTServerReadByTypeRequest(t *testing.T) {
+	s, f := newTestATT(t)
+
+	svc := s.ATT.AddLocalAttribute(AttributeTypeService, 0,
+		UUIDPrimaryService.UUID(), 0, nil)
+	chr := s.ATT.AddLocalAttribute(AttributeTypeCharacteristic, svc,
+		UUIDCharacteristic.UUID(), 0x12, nil)
+	val := s.ATT.AddLocalAttribute(AttributeTypeCharacteristicValue, chr,
+		ble.New16BitUUID(0x2a19), 0x12, []byte{42})
+
+	s.ATT.AddLocalCharacteristic(chr, 0x12, val, ble.New16BitUUID(0x2a19),
+		CharacteristicHandler{})
+
+	// Read By Type Request for characteristic declarations.
+	pdu := []byte{OpReadByTypeReq, 0x01, 0x00, 0xff, 0xff, 0x03, 0x28}
+	if err := s.ATT.handleData(testConnHandle, pdu); err != nil {
+		t.Fatalf("handleData: %v", err)
+	}
+
+	got := sentPDU(t, f, 0)
+	if got[0] != OpReadByTypeResponse {
+		t.Fatalf("opcode = %#x; want OpReadByTypeResponse", got[0])
+	}
+	// handle, properties, value handle and a 16 bit UUID.
+	if got[1] != 7 {
+		t.Errorf("entry length = %d; want 7", got[1])
+	}
+	if got[4] != 0x12 {
+		t.Errorf("properties = %#x; want 0x12", got[4])
+	}
+	if uuid := binary.LittleEndian.Uint16(got[7:]); uuid != 0x2a19 {
+		t.Errorf("UUID = %#x; want 0x2a19", uuid)
+	}
+}
+
+func TestATTServerReadByTypeRequestNothingFound(t *testing.T) {
+	s, f := newTestATT(t)
+
+	pdu := []byte{OpReadByTypeReq, 0x01, 0x00, 0xff, 0xff, 0x03, 0x28}
+	if err := s.ATT.handleData(testConnHandle, pdu); err != nil {
+		t.Fatalf("handleData: %v", err)
+	}
+
+	got := sentPDU(t, f, 0)
+	if got[0] != OpError || got[4] != byte(ble.ErrAttNotFound) {
+		t.Errorf("response = %#v; want an attribute not found error", got)
+	}
+}
+
+func TestATTServerFindInfoRequest(t *testing.T) {
+	s, f := newTestATT(t)
+
+	svc := s.ATT.AddLocalAttribute(AttributeTypeService, 0,
+		UUIDPrimaryService.UUID(), 0, nil)
+	chr := s.ATT.AddLocalAttribute(AttributeTypeCharacteristic, svc,
+		UUIDCharacteristic.UUID(), 0, nil)
+	s.ATT.AddLocalAttribute(AttributeTypeCharacteristicValue, chr,
+		ble.New16BitUUID(0x2a19), 0, nil)
+	s.ATT.AddLocalAttribute(AttributeTypeDescriptor, chr,
+		UUIDClientCharacteristicConfig.UUID(), 0, []byte{0, 0})
+
+	pdu := []byte{OpFindInfoReq, 0x01, 0x00, 0xff, 0xff}
+	if err := s.ATT.handleData(testConnHandle, pdu); err != nil {
+		t.Fatalf("handleData: %v", err)
+	}
+
+	got := sentPDU(t, f, 0)
+	if got[0] != OpFindInfoResponse {
+		t.Fatalf("opcode = %#x; want OpFindInfoResponse", got[0])
+	}
+
+	// The format must be one of the two the specification defines. It should
+	// be 1 here, because every UUID in this database is 16 bit, but the server
+	// picks the format from the attribute type. See the TODO in
+	// handleFindInfoReq.
+	if got[1] != attFindInfoFormat16Bit && got[1] != attFindInfoFormat128Bit {
+		t.Errorf("format = %#x; want 1 or 2", got[1])
+	}
+}
+
+func TestATTServerFindInfoRequestNothingFound(t *testing.T) {
+	s, f := newTestATT(t)
+
+	pdu := []byte{OpFindInfoReq, 0x10, 0x00, 0x20, 0x00}
+	if err := s.ATT.handleData(testConnHandle, pdu); err != nil {
+		t.Fatalf("handleData: %v", err)
+	}
+
+	got := sentPDU(t, f, 0)
+	if got[0] != OpError || got[4] != byte(ble.ErrAttNotFound) {
+		t.Errorf("response = %#v; want an attribute not found error", got)
+	}
+}
+
+func TestATTClientFindInfoResponse(t *testing.T) {
+	s, _ := newTestATT(t)
+
+	// Format 1, then handle and 16 bit UUID pairs.
+	pdu := []byte{OpFindInfoResponse, 0x01, 0x04, 0x00, 0x02, 0x29}
+	if err := s.ATT.handleData(testConnHandle, pdu); err != nil {
+		t.Fatalf("handleData: %v", err)
+	}
+
+	cd, _ := s.ATT.ConnectionData(testConnHandle)
+	if len(cd.Descriptors) != 1 {
+		t.Fatalf("found %d descriptors; want 1", len(cd.Descriptors))
+	}
+	if cd.Descriptors[0].Handle != 4 {
+		t.Errorf("Handle = %d; want 4", cd.Descriptors[0].Handle)
+	}
+}
+
+func TestATTMTUAndSetMaxMTU(t *testing.T) {
+	s, _ := newTestATT(t)
+
+	if err := s.ATT.SetMaxMTU(100); err != nil {
+		t.Fatalf("SetMaxMTU: %v", err)
+	}
+
+	// A request above the new maximum is clamped to it, and the negotiated
+	// value is what MTU reports.
+	if err := s.ATT.handleData(testConnHandle, []byte{OpMTUReq, 0xf0, 0x00}); err != nil {
+		t.Fatalf("handleData: %v", err)
+	}
+	if got := s.ATT.MTU(); got != 100 {
+		t.Errorf("MTU = %d; want 100", got)
+	}
+
+	cd, _ := s.ATT.ConnectionData(testConnHandle)
+	if cd.MTU != 100 {
+		t.Errorf("ConnectionData().MTU = %d; want 100", cd.MTU)
+	}
+}
+
+func TestATTMTUStartsAtTheDefault(t *testing.T) {
+	// Before an exchange the MTU is 23. It must not be zero, because the
+	// server uses it as the size budget for a discovery response.
+	s, _ := newTestATT(t)
+
+	if got := s.ATT.MTU(); got != DefaultMTU {
+		t.Errorf("MTU = %d; want %d", got, DefaultMTU)
+	}
+}
+
+func TestATTMTUResponseIsRecorded(t *testing.T) {
+	s, _ := newTestATT(t)
+
+	if err := s.ATT.handleData(testConnHandle, []byte{OpMTUResponse, 0x40, 0x00}); err != nil {
+		t.Fatalf("handleData: %v", err)
+	}
+	if got := s.ATT.MTU(); got != 0x40 {
+		t.Errorf("MTU = %d; want 64", got)
+	}
+}
+
+func TestATTMTUResponseTooShort(t *testing.T) {
+	s, _ := newTestATT(t)
+
+	if err := s.ATT.handleData(testConnHandle, []byte{OpMTUResponse, 0x40}); err != ErrInvalidPacket {
+		t.Errorf("handleData = %v; want ErrInvalidPacket", err)
+	}
+}
+
+func TestATTClearLocalData(t *testing.T) {
+	s, _ := newTestATT(t)
+
+	handle := s.ATT.AddLocalAttribute(AttributeTypeService, 0,
+		UUIDPrimaryService.UUID(), 0, nil)
+	s.ATT.AddLocalService(handle, handle, ble.New16BitUUID(0x180f))
+
+	s.ATT.ClearLocalData()
+
+	if len(s.ATT.attributes) != 0 || len(s.ATT.localServices) != 0 {
+		t.Error("ClearLocalData left attributes or services behind")
+	}
+}
+
+func TestATTRemoveConnection(t *testing.T) {
+	s, _ := newTestATT(t)
+
+	if err := s.ATT.removeConnection(testConnHandle); err != nil {
+		t.Fatalf("removeConnection: %v", err)
+	}
+	if _, err := s.ATT.ConnectionData(testConnHandle); err != ErrATTUnknownConnection {
+		t.Errorf("ConnectionData after remove = %v; want ErrATTUnknownConnection", err)
+	}
+}
+
+func TestATTPollDelegatesToHCI(t *testing.T) {
+	s, _ := newTestATT(t, commandComplete(OpCode(OGFHostCtl, OCFReset), 0))
+
+	if err := s.ATT.Poll(); err != nil {
+		t.Errorf("Poll = %v; want nil", err)
+	}
+}
+
+func TestATTServiceWithA128BitUUID(t *testing.T) {
+	s, f := newTestATT(t)
+
+	uuid, err := ble.ParseUUID("6e400001-b5a3-f393-e0a9-e50e24dcca9e")
+	if err != nil {
+		t.Fatalf("ParseUUID: %v", err)
+	}
+
+	handle := s.ATT.AddLocalAttribute(AttributeTypeService, 0,
+		UUIDPrimaryService.UUID(), 0, nil)
+	s.ATT.AddLocalService(handle, handle, uuid)
+
+	pdu := []byte{OpReadByGroupReq, 0x01, 0x00, 0xff, 0xff, 0x00, 0x28}
+	if err := s.ATT.handleData(testConnHandle, pdu); err != nil {
+		t.Fatalf("handleData: %v", err)
+	}
+
+	got := sentPDU(t, f, 0)
+	// start handle, end handle and a 128 bit UUID.
+	if got[1] != 20 {
+		t.Errorf("entry length = %d; want 20 for a 128 bit UUID", got[1])
+	}
+
+	want := uuid.BytesLittleEndian()
+	if !bytes.Equal(got[6:22], want[:]) {
+		t.Errorf("UUID = % x; want % x", got[6:22], want)
+	}
+}
+
+func TestATTFindInfoResponseParsing(t *testing.T) {
+	// The format byte and the entry widths come off the wire. A response that
+	// does not add up used to run off the end of the buffer and panic.
+	for _, tc := range []struct {
+		name  string
+		pdu   []byte
+		want  error
+		count int
+	}{
+		{
+			name:  "one 16 bit entry",
+			pdu:   []byte{OpFindInfoResponse, attFindInfoFormat16Bit, 0x04, 0x00, 0x02, 0x29},
+			count: 1,
+		},
+		{
+			name: "two 16 bit entries",
+			pdu: []byte{OpFindInfoResponse, attFindInfoFormat16Bit,
+				0x04, 0x00, 0x02, 0x29,
+				0x05, 0x00, 0x01, 0x29},
+			count: 2,
+		},
+		{
+			name: "one 128 bit entry",
+			pdu: append([]byte{OpFindInfoResponse, attFindInfoFormat128Bit, 0x04, 0x00},
+				make([]byte, 16)...),
+			count: 1,
+		},
+		{
+			name:  "a trailing partial entry is ignored",
+			pdu:   []byte{OpFindInfoResponse, attFindInfoFormat16Bit, 0x04, 0x00, 0x02, 0x29, 0x05},
+			count: 1,
+		},
+		{
+			name:  "an entry narrower than the format claims",
+			pdu:   []byte{OpFindInfoResponse, attFindInfoFormat128Bit, 0x04, 0x00, 0x02},
+			count: 0,
+		},
+		{
+			name: "no format byte",
+			pdu:  []byte{OpFindInfoResponse},
+			want: ErrInvalidPacket,
+		},
+		{
+			name: "unknown format",
+			pdu:  []byte{OpFindInfoResponse, 0x09, 0x04, 0x00, 0x02, 0x29},
+			want: ErrInvalidPacket,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s, _ := newTestATT(t)
+
+			// This must not panic, whatever the response claims.
+			if err := s.ATT.handleData(testConnHandle, tc.pdu); err != tc.want {
+				t.Fatalf("handleData = %v; want %v", err, tc.want)
+			}
+			if tc.want != nil {
+				return
+			}
+
+			cd, _ := s.ATT.ConnectionData(testConnHandle)
+			if len(cd.Descriptors) != tc.count {
+				t.Errorf("found %d descriptors; want %d", len(cd.Descriptors), tc.count)
+			}
+		})
+	}
+}
+
+func TestATTTruncatedResponses(t *testing.T) {
+	// Every response arrives over the air, so none of them may panic.
+	for _, name := range []struct {
+		name string
+		pdu  []byte
+	}{
+		{"error response with no code", []byte{OpError, OpReadReq, 0x01}},
+		{"MTU request with no value", []byte{OpMTUReq, 0x40}},
+		{"read by group response with no length", []byte{OpReadByGroupResponse}},
+		{"read by type response with no length", []byte{OpReadByTypeResponse}},
+		{"read request with no handle", []byte{OpReadReq, 0x03}},
+		{"write request with no handle", []byte{OpWriteReq, 0x03}},
+		{"notification with no handle", []byte{OpHandleNotify, 0x03}},
+		{"empty", []byte{}},
+	} {
+		t.Run(name.name, func(t *testing.T) {
+			s, _ := newTestATT(t)
+
+			// It must be rejected rather than parsed, and it must not panic.
+			if err := s.ATT.handleData(testConnHandle, name.pdu); err != ErrInvalidPacket {
+				t.Errorf("handleData = %v; want ErrInvalidPacket", err)
+			}
+		})
+	}
+}
+
+func TestATTNoOpcodePanicsOnAShortPDU(t *testing.T) {
+	// Every opcode, at every length from empty up to 24 bytes. None of them
+	// may panic, whatever the content.
+	opcodes := []uint8{
+		OpError, OpMTUReq, OpMTUResponse, OpFindInfoReq, OpFindInfoResponse,
+		OpFindByTypeReq, OpFindByTypeResponse, OpReadByTypeReq,
+		OpReadByTypeResponse, OpReadReq, OpReadResponse, OpReadBlobReq,
+		OpReadBlobResponse, OpReadMultiReq, OpReadMultiResponse,
+		OpReadByGroupReq, OpReadByGroupResponse, OpWriteReq, OpWriteResponse,
+		OpWriteCmd, OpPrepWriteReq, OpPrepWriteResponse, OpExecWriteReq,
+		OpExecWriteResponse, OpHandleNotify, OpHandleInd, OpHandleCNF,
+		OpSignedWriteCmd,
+	}
+
+	for _, op := range opcodes {
+		for n := 0; n <= 24; n++ {
+			pdu := make([]byte, n)
+			if n > 0 {
+				pdu[0] = op
+				// Fill the rest with a value that claims a large length, so
+				// that a missing bounds check shows up.
+				for i := 1; i < n; i++ {
+					pdu[i] = 0xff
+				}
+			}
+
+			s, _ := newTestATT(t)
+			_ = s.ATT.handleData(testConnHandle, pdu)
+		}
+	}
+}

--- a/hci/command_test.go
+++ b/hci/command_test.go
@@ -1,0 +1,275 @@
+package hci
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+
+	"tinygo.org/x/bluetooth/ble"
+)
+
+// answering returns a stack whose transport answers the given opcode with a
+// successful Command Complete event, so that a command that waits completes.
+func answering(opcode uint16, ret ...byte) (*Stack, *fakeTransport) {
+	f := &fakeTransport{rx: [][]byte{commandComplete(opcode, 0, ret...)}}
+
+	return newTestStack(f), f
+}
+
+// wantCommand checks the opcode and the parameters of the nth written command.
+func wantCommand(t *testing.T, f *fakeTransport, n int, opcode uint16, params ...byte) {
+	t.Helper()
+
+	if len(f.tx) <= n {
+		t.Fatalf("only %d packets written; want at least %d", len(f.tx), n+1)
+	}
+
+	want := append([]byte{PacketCommand, byte(opcode), byte(opcode >> 8), byte(len(params))}, params...)
+	if !bytes.Equal(f.tx[n], want) {
+		t.Errorf("wrote %#v; want %#v", f.tx[n], want)
+	}
+}
+
+func TestSetEventMask(t *testing.T) {
+	opcode := OpCode(OGFHostCtl, OCFSetEventMask)
+	s, f := answering(opcode)
+
+	if err := s.HCI.SetEventMask(0x3FFFFFFFFFFFFFFF); err != nil {
+		t.Fatalf("SetEventMask: %v", err)
+	}
+	wantCommand(t, f, 0, opcode, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x3f)
+}
+
+func TestSetLEEventMask(t *testing.T) {
+	// The LE Set Event Mask opcode is 0x01 in the LE controller group.
+	opcode := OpCode(OGFLECtrl, 0x01)
+	s, f := answering(opcode)
+
+	if err := s.HCI.SetLEEventMask(0x00000000000003FF); err != nil {
+		t.Fatalf("SetLEEventMask: %v", err)
+	}
+	wantCommand(t, f, 0, opcode, 0xff, 0x03, 0, 0, 0, 0, 0, 0)
+}
+
+func TestReadBdAddr(t *testing.T) {
+	opcode := OpCode(OGFInfoParam, OCFReadBDAddr)
+
+	t.Run("valid", func(t *testing.T) {
+		// The return parameter is the address, least significant byte first.
+		s, _ := answering(opcode, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66)
+
+		if err := s.HCI.ReadBdAddr(); err != nil {
+			t.Fatalf("ReadBdAddr: %v", err)
+		}
+
+		want := ble.MAC{0x11, 0x22, 0x33, 0x44, 0x55, 0x66}
+		if got := s.HCI.Address().MAC; got != want {
+			t.Errorf("Address().MAC = %v; want %v", got, want)
+		}
+	})
+
+	t.Run("response too short", func(t *testing.T) {
+		s, _ := answering(opcode, 0x11, 0x22)
+
+		if err := s.HCI.ReadBdAddr(); err != ErrInvalidPacket {
+			t.Errorf("ReadBdAddr = %v; want ErrInvalidPacket", err)
+		}
+	})
+}
+
+func TestLESetScanParameters(t *testing.T) {
+	opcode := OpCode(OGFLECtrl, OCFLESetScanParameters)
+	s, f := answering(opcode)
+
+	// active scanning, 80 ms interval, 30 ms window, public own address, no
+	// filter
+	if err := s.HCI.LESetScanParameters(0x01, 0x0080, 0x0030, 0x00, 0x00); err != nil {
+		t.Fatalf("LESetScanParameters: %v", err)
+	}
+	wantCommand(t, f, 0, opcode, 0x01, 0x80, 0x00, 0x30, 0x00, 0x00, 0x00)
+}
+
+func TestLESetAdvertisingParameters(t *testing.T) {
+	opcode := OpCode(OGFLECtrl, OCFLESetAdvertisingParameters)
+	s, f := answering(opcode)
+
+	err := s.HCI.LESetAdvertisingParameters(0x00a0, 0x00a0, 0x00, 0x00,
+		0x00, [6]byte{}, 0x07, 0x00)
+	if err != nil {
+		t.Fatalf("LESetAdvertisingParameters: %v", err)
+	}
+	wantCommand(t, f, 0, opcode,
+		0xa0, 0x00, // min interval
+		0xa0, 0x00, // max interval
+		0x00,             // advertising type
+		0x00,             // own address type
+		0x00,             // direct address type
+		0, 0, 0, 0, 0, 0, // direct address
+		0x07, // channel map
+		0x00, // filter policy
+	)
+}
+
+func TestLESetAdvertisingData(t *testing.T) {
+	opcode := OpCode(OGFLECtrl, OCFLESetAdvertisingData)
+	s, f := answering(opcode)
+
+	if err := s.HCI.LESetAdvertisingData([]byte{0x02, 0x01, 0x06}); err != nil {
+		t.Fatalf("LESetAdvertisingData: %v", err)
+	}
+
+	// The command always carries 32 bytes: the significant length and a
+	// 31 byte padded field.
+	params := make([]byte, 32)
+	params[0] = 3
+	copy(params[1:], []byte{0x02, 0x01, 0x06})
+	wantCommand(t, f, 0, opcode, params...)
+}
+
+func TestLESetScanResponseData(t *testing.T) {
+	opcode := OpCode(OGFLECtrl, OCFLESetScanResponseData)
+	s, f := answering(opcode)
+
+	if err := s.HCI.LESetScanResponseData([]byte{0x05, 0x09, 'a', 'b', 'c', 'd'}); err != nil {
+		t.Fatalf("LESetScanResponseData: %v", err)
+	}
+
+	params := make([]byte, 32)
+	params[0] = 6
+	copy(params[1:], []byte{0x05, 0x09, 'a', 'b', 'c', 'd'})
+	wantCommand(t, f, 0, opcode, params...)
+}
+
+func TestLECreateConn(t *testing.T) {
+	opcode := OpCode(OGFLECtrl, OCFLECreateConn)
+	s, f := answering(opcode)
+
+	peer := [6]byte{6, 5, 4, 3, 2, 1}
+	err := s.HCI.LECreateConn(0x0060, 0x0030, 0x00, 0x00, peer, 0x00,
+		0x0006, 0x000c, 0x0000, 0x00c8, 0x0004, 0x0006)
+	if err != nil {
+		t.Fatalf("LECreateConn: %v", err)
+	}
+
+	params := []byte{
+		0x60, 0x00, // scan interval
+		0x30, 0x00, // scan window
+		0x00,             // initiator filter
+		0x00,             // peer address type
+		6, 5, 4, 3, 2, 1, // peer address
+		0x00,       // own address type
+		0x06, 0x00, // min interval
+		0x0c, 0x00, // max interval
+		0x00, 0x00, // latency
+		0xc8, 0x00, // supervision timeout
+		0x04, 0x00, // min connection event length
+		0x06, 0x00, // max connection event length
+	}
+	wantCommand(t, f, 0, opcode, params...)
+}
+
+func TestLECancelConn(t *testing.T) {
+	opcode := OpCode(OGFLECtrl, OCFLECancelConn)
+	s, f := answering(opcode)
+
+	if err := s.HCI.LECancelConn(); err != nil {
+		t.Fatalf("LECancelConn: %v", err)
+	}
+	wantCommand(t, f, 0, opcode)
+}
+
+func TestLEConnUpdate(t *testing.T) {
+	opcode := OpCode(OGFLECtrl, OCFLEConnUpdate)
+	s, f := answering(opcode)
+
+	if err := s.HCI.LEConnUpdate(0x0040, 0x0006, 0x000c, 0x0000, 0x00c8); err != nil {
+		t.Fatalf("LEConnUpdate: %v", err)
+	}
+
+	got := f.tx[0]
+	if binary.LittleEndian.Uint16(got[1:]) != opcode {
+		t.Errorf("opcode = %#x; want %#x", binary.LittleEndian.Uint16(got[1:]), opcode)
+	}
+	if handle := binary.LittleEndian.Uint16(got[4:]); handle != 0x0040 {
+		t.Errorf("handle = %#x; want 0x40", handle)
+	}
+}
+
+func TestDisconnect(t *testing.T) {
+	opcode := OpCode(OGFLinkCtl, OCFDisconnect)
+	s, f := answering(opcode)
+
+	if err := s.HCI.Disconnect(0x0040); err != nil {
+		t.Fatalf("Disconnect: %v", err)
+	}
+	wantCommand(t, f, 0, opcode, 0x40, 0x00, ReasonRemoteUserTerminated)
+}
+
+func TestReadLEBufferSize(t *testing.T) {
+	opcode := OpCode(OGFLECtrl, OCFLEReadBufferSize)
+
+	t.Run("a small packet length is raised to the minimum", func(t *testing.T) {
+		// The specification requires at least 27 bytes.
+		s, _ := answering(opcode, 0x10, 0x00, 0x04)
+
+		if err := s.HCI.ReadLEBufferSize(); err != nil {
+			t.Fatalf("ReadLEBufferSize: %v", err)
+		}
+		if s.ATT.maxMTU != 27 {
+			t.Errorf("maxMTU = %d; want 27", s.ATT.maxMTU)
+		}
+		if s.HCI.maxPkt != 4 {
+			t.Errorf("maxPkt = %d; want 4", s.HCI.maxPkt)
+		}
+	})
+
+	t.Run("a length in range is used as it is", func(t *testing.T) {
+		s, _ := answering(opcode, 0xf0, 0x00, 0x08)
+
+		if err := s.HCI.ReadLEBufferSize(); err != nil {
+			t.Fatalf("ReadLEBufferSize: %v", err)
+		}
+		if s.ATT.maxMTU != 240 {
+			t.Errorf("maxMTU = %d; want 240", s.ATT.maxMTU)
+		}
+	})
+
+	t.Run("a large packet length is clamped to the maximum MTU", func(t *testing.T) {
+		// The response buffers are sized for MaximumMTU, so a controller that
+		// offers more must not raise the MTU past it.
+		s, _ := answering(opcode, 0x00, 0x04, 0x08)
+
+		if err := s.HCI.ReadLEBufferSize(); err != nil {
+			t.Fatalf("ReadLEBufferSize: %v", err)
+		}
+		if s.ATT.maxMTU != MaximumMTU {
+			t.Errorf("maxMTU = %d; want %d", s.ATT.maxMTU, MaximumMTU)
+		}
+	})
+
+	t.Run("response too short", func(t *testing.T) {
+		s, _ := answering(opcode, 0x10)
+
+		if err := s.HCI.ReadLEBufferSize(); err != ErrInvalidPacket {
+			t.Errorf("ReadLEBufferSize = %v; want ErrInvalidPacket", err)
+		}
+	})
+}
+
+func TestSendVendorCommandWaitsForCompletion(t *testing.T) {
+	opcode := OpCode(OGFVendor, 0x0001)
+	s, f := answering(opcode)
+
+	if err := s.HCI.SendVendorCommand(0x0001, []byte{0xaa}); err != nil {
+		t.Fatalf("SendVendorCommand: %v", err)
+	}
+	wantCommand(t, f, 0, opcode, 0xaa)
+}
+
+func TestStop(t *testing.T) {
+	s := newTestStack(&fakeTransport{})
+
+	if err := s.HCI.Stop(); err != nil {
+		t.Errorf("Stop = %v; want nil", err)
+	}
+}

--- a/hci/example_test.go
+++ b/hci/example_test.go
@@ -1,0 +1,56 @@
+package hci_test
+
+import (
+	"tinygo.org/x/bluetooth/hci"
+)
+
+// nullTransport is the shape a board supplies. A real one reads from and
+// writes to the controller, over a UART or a packet interface.
+type nullTransport struct{}
+
+func (nullTransport) StartRead()                 {}
+func (nullTransport) EndRead()                   {}
+func (nullTransport) Buffered() int              { return 0 }
+func (nullTransport) Read(p []byte) (int, error) { return 0, nil }
+func (nullTransport) Write(p []byte) (int, error) {
+	return len(p), nil
+}
+
+// ExampleNewStack brings a controller up over a transport.
+func ExampleNewStack() {
+	stack := hci.NewStack(nullTransport{})
+
+	if err := stack.HCI.Start(); err != nil {
+		return
+	}
+	if err := stack.HCI.Reset(); err != nil {
+		return
+	}
+	if err := stack.HCI.SetEventMask(0x3FFFFFFFFFFFFFFF); err != nil {
+		return
+	}
+	if err := stack.HCI.SetLEEventMask(0x00000000000003FF); err != nil {
+		return
+	}
+
+	// The caller polls for events, and the stack dispatches them.
+	_ = stack.HCI.Poll()
+}
+
+// ExampleHCI_SetEventHandler consumes a controller specific event that this
+// package does not handle.
+func ExampleHCI_SetEventHandler() {
+	stack := hci.NewStack(nullTransport{})
+
+	stack.HCI.SetEventHandler(func(event uint8, params []byte) (bool, error) {
+		if event != 0xff {
+			return false, nil
+		}
+
+		// Handle the vendor event here.
+		return true, nil
+	})
+
+	// A matching vendor command goes out the same way.
+	_ = stack.HCI.SendVendorCommandWithoutResponse(0x0001, []byte{0x01})
+}

--- a/hci/hci.go
+++ b/hci/hci.go
@@ -257,9 +257,9 @@ func (h *HCI) Address() ble.MACAddress {
 	return h.address
 }
 
-// CommandResponse returns the parameters of the most recent Command Complete
-// event. The slice points into the read buffer and is only valid until the
-// next poll.
+// CommandResponse returns the return parameters of the most recent Command
+// Complete event, without the status byte. The slice points into the read
+// buffer and is only valid until the next poll.
 func (h *HCI) CommandResponse() []byte {
 	return h.cmdResponse
 }
@@ -481,11 +481,13 @@ func (h *HCI) ReadBdAddr() error {
 		return err
 	}
 
-	if len(h.cmdResponse) < 7 {
+	// The return parameter is the six byte address, least significant byte
+	// first, which is the order that MAC uses.
+	if len(h.cmdResponse) < 6 {
 		return ErrInvalidPacket
 	}
 
-	copy(h.address.MAC[:], h.cmdResponse[:7])
+	copy(h.address.MAC[:], h.cmdResponse[:6])
 
 	return nil
 }
@@ -518,19 +520,26 @@ func (h *HCI) ReadLEBufferSize() error {
 		return err
 	}
 
-	pktLen := binary.LittleEndian.Uint16(h.buf[0:])
-	h.maxPkt = uint16(h.buf[2])
+	// The return parameters are the packet length and the number of packets.
+	if len(h.cmdResponse) < 3 {
+		return ErrInvalidPacket
+	}
+
+	pktLen := binary.LittleEndian.Uint16(h.cmdResponse[0:])
+	h.maxPkt = uint16(h.cmdResponse[2])
 
 	// pkt len must be at least 27 bytes
 	if pktLen < 27 {
 		pktLen = 27
 	}
 
-	if err := h.att.SetMaxMTU(pktLen); err != nil {
-		return err
+	// The response buffers are sized for MaximumMTU, so a controller that
+	// offers more than that must not raise the MTU above it.
+	if pktLen > MaximumMTU {
+		pktLen = MaximumMTU
 	}
 
-	return nil
+	return h.att.SetMaxMTU(pktLen)
 }
 
 func (h *HCI) LESetScanEnable(enabled, duplicates bool) error {
@@ -839,8 +848,12 @@ func (h *HCI) handleEventData(buf []byte) error {
 
 		h.cmdCompleteOpcode = binary.LittleEndian.Uint16(buf[3:])
 		h.cmdCompleteStatus = buf[5]
-		if plen > 0 {
-			h.cmdResponse = buf[1 : plen+2]
+
+		// The event parameters are the number of allowed command packets, the
+		// opcode and the status, followed by the return parameters of the
+		// command. Keep only the return parameters.
+		if plen > 4 {
+			h.cmdResponse = buf[6 : plen+2]
 		} else {
 			h.cmdResponse = buf[:0]
 		}

--- a/hci/hci.go
+++ b/hci/hci.go
@@ -160,6 +160,13 @@ type HCI struct {
 
 	eventHandler   func(event uint8, params []byte) (bool, error)
 	leEventHandler func(subevent uint8, params []byte) (bool, error)
+
+	// The timeouts and the delay between polls. A test shortens them so that
+	// a timeout path finishes at once. They are unexported, because the
+	// defaults are the only supported setting.
+	commandTimeout  time.Duration
+	responseTimeout time.Duration
+	retryDelay      time.Duration
 }
 
 // Advertisement returns the most recent LE advertising report, and whether one
@@ -265,9 +272,12 @@ func (h *HCI) CommandStatus() uint8 {
 
 func newHCI(t Transport) *HCI {
 	return &HCI{
-		transport: t,
-		buf:       make([]byte, ReadBufferSize),
-		writebuf:  make([]byte, 256),
+		transport:       t,
+		buf:             make([]byte, ReadBufferSize),
+		writebuf:        make([]byte, 256),
+		commandTimeout:  3 * time.Second,
+		responseTimeout: 10 * time.Second,
+		retryDelay:      5 * time.Millisecond,
 	}
 }
 
@@ -354,7 +364,7 @@ func (h *HCI) Poll() error {
 			h.pos = 0
 			h.end = 0
 
-			time.Sleep(5 * time.Millisecond)
+			time.Sleep(h.retryDelay)
 		case err != nil:
 			// some other error, so return
 			h.pos = 0
@@ -382,7 +392,7 @@ func (h *HCI) Poll() error {
 			h.pos = 0
 			h.end = 0
 
-			time.Sleep(5 * time.Millisecond)
+			time.Sleep(h.retryDelay)
 		case h.transport.Buffered() == 0:
 			// Incomplete packet with nothing more to read for now. Keep it and
 			// pick up where we left off on the next poll.
@@ -661,13 +671,13 @@ func (h *HCI) SendCommandWithParams(opcode uint16, params []byte) error {
 	h.cmdCompleteOpcode = 0xffff
 	h.cmdCompleteStatus = 0xff
 
-	start := time.Now().UnixNano()
+	start := time.Now()
 	for h.cmdCompleteOpcode != opcode {
 		if err := h.Poll(); err != nil {
 			return err
 		}
 
-		if (time.Now().UnixNano()-start)/int64(time.Second) > 3 {
+		if time.Since(start) > h.commandTimeout {
 			return ErrTimeout
 		}
 	}

--- a/hci/hci_test.go
+++ b/hci/hci_test.go
@@ -1,0 +1,799 @@
+package hci
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+)
+
+// parseEvent hands one event packet straight to the event parser, so that a
+// malformed one can be checked. Poll deliberately swallows a parse error and
+// resets, which TestPollSwallowsAParseError covers.
+func parseEvent(packet []byte) (*Stack, error) {
+	s := newTestStack(&fakeTransport{})
+
+	return s, s.HCI.handleEventData(packet[1:])
+}
+
+// pollOnce feeds the scripted packets to the stack and polls once.
+func pollOnce(t *testing.T, packets ...[]byte) (*Stack, *fakeTransport, error) {
+	t.Helper()
+
+	f := &fakeTransport{rx: packets}
+	s := newTestStack(f)
+
+	return s, f, s.HCI.Poll()
+}
+
+func TestPollBracketsTheRead(t *testing.T) {
+	_, f, err := pollOnce(t, commandComplete(OpCode(OGFHostCtl, OCFReset), 0))
+	if err != nil {
+		t.Fatalf("Poll: %v", err)
+	}
+	if f.starts != 1 || f.ends != 1 {
+		t.Errorf("StartRead/EndRead called %d/%d times; want 1/1", f.starts, f.ends)
+	}
+}
+
+func TestCommandComplete(t *testing.T) {
+	opcode := OpCode(OGFInfoParam, OCFReadBDAddr)
+	addr := []byte{1, 2, 3, 4, 5, 6}
+
+	s, _, err := pollOnce(t, commandComplete(opcode, 0, addr...))
+	if err != nil {
+		t.Fatalf("Poll: %v", err)
+	}
+	if s.HCI.CommandStatus() != 0 {
+		t.Errorf("CommandStatus = %d; want 0", s.HCI.CommandStatus())
+	}
+	// The response starts at the number of packets byte and covers the whole
+	// parameter list.
+	if got := s.HCI.CommandResponse(); len(got) == 0 {
+		t.Error("CommandResponse is empty; want the event parameters")
+	}
+}
+
+func TestCommandCompleteNoParameters(t *testing.T) {
+	// An event with a zero parameter length must not index past the buffer.
+	s, _, err := pollOnce(t, []byte{PacketEvent, EventCmdComplete, 0, 0, 0, 0})
+	if err != nil {
+		t.Fatalf("Poll: %v", err)
+	}
+	if len(s.HCI.CommandResponse()) != 0 {
+		t.Errorf("CommandResponse = %v; want empty", s.HCI.CommandResponse())
+	}
+}
+
+func TestTruncatedEvents(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		packet []byte
+	}{
+		{"event with no length byte", []byte{PacketEvent, EventCmdComplete}},
+		{"command complete too short", []byte{PacketEvent, EventCmdComplete, 4, 1, 0x03}},
+		{"command complete length past end", []byte{PacketEvent, EventCmdComplete, 200, 1, 0x03, 0x0c, 0}},
+		{"command status too short", []byte{PacketEvent, EventCmdStatus, 4, 0, 1}},
+		{"disconnect complete too short", []byte{PacketEvent, EventDisconnComplete, 4, 0, 1}},
+		{"num completed packets too short", []byte{PacketEvent, EventNumCompPkts, 1, 1}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := parseEvent(tc.packet); err != ErrInvalidPacket {
+				t.Errorf("handleEventData = %v; want ErrInvalidPacket", err)
+			}
+		})
+	}
+}
+
+func TestNumCompletedPackets(t *testing.T) {
+	t.Run("one handle", func(t *testing.T) {
+		f := &fakeTransport{}
+		s := newTestStack(f)
+		s.HCI.pendingPkt = 5
+
+		// numHandles, handle, count
+		f.rx = [][]byte{event(EventNumCompPkts, 1, 0x40, 0x00, 0x02, 0x00)}
+		if err := s.HCI.Poll(); err != nil {
+			t.Fatalf("Poll: %v", err)
+		}
+		if s.HCI.pendingPkt != 3 {
+			t.Errorf("pendingPkt = %d; want 3", s.HCI.pendingPkt)
+		}
+	})
+
+	t.Run("three handles", func(t *testing.T) {
+		f := &fakeTransport{}
+		s := newTestStack(f)
+		s.HCI.pendingPkt = 10
+
+		f.rx = [][]byte{event(EventNumCompPkts, 3,
+			0x40, 0x00, 0x01, 0x00,
+			0x41, 0x00, 0x02, 0x00,
+			0x42, 0x00, 0x03, 0x00)}
+		if err := s.HCI.Poll(); err != nil {
+			t.Fatalf("Poll: %v", err)
+		}
+		if s.HCI.pendingPkt != 4 {
+			t.Errorf("pendingPkt = %d; want 4", s.HCI.pendingPkt)
+		}
+	})
+
+	t.Run("count larger than pending does not wrap", func(t *testing.T) {
+		f := &fakeTransport{}
+		s := newTestStack(f)
+		s.HCI.pendingPkt = 1
+
+		f.rx = [][]byte{event(EventNumCompPkts, 1, 0x40, 0x00, 0x09, 0x00)}
+		if err := s.HCI.Poll(); err != nil {
+			t.Fatalf("Poll: %v", err)
+		}
+		if s.HCI.pendingPkt != 0 {
+			t.Errorf("pendingPkt = %d; want 0", s.HCI.pendingPkt)
+		}
+	})
+
+	t.Run("handle count overruns the event", func(t *testing.T) {
+		// The count comes off the wire and claims more entries than are here.
+		_, err := parseEvent(event(EventNumCompPkts, 4, 0x40, 0x00, 0x01, 0x00))
+		if err != ErrInvalidPacket {
+			t.Errorf("handleEventData = %v; want ErrInvalidPacket", err)
+		}
+	})
+}
+
+func TestAdvertisingReport(t *testing.T) {
+	// numReports, type, addressType, address, dataLen, data..., rssi
+	report := func(dataLen byte, data []byte, extra ...byte) []byte {
+		params := []byte{1, 0x00, 0x01, 6, 5, 4, 3, 2, 1, dataLen}
+		params = append(params, data...)
+		params = append(params, extra...)
+
+		return leEvent(LEMetaAdvertisingReport, params...)
+	}
+
+	t.Run("valid", func(t *testing.T) {
+		s, _, err := pollOnce(t, report(3, []byte{0x02, 0x01, 0x06}, 0xc5))
+		if err != nil {
+			t.Fatalf("Poll: %v", err)
+		}
+		if !s.HCI.HasAdvertisement() {
+			t.Fatal("HasAdvertisement = false; want true")
+		}
+
+		rep, ok := s.HCI.Advertisement()
+		if !ok {
+			t.Fatal("Advertisement reported not ok")
+		}
+		if rep.DataLen != 3 {
+			t.Errorf("DataLen = %d; want 3", rep.DataLen)
+		}
+		if !bytes.Equal(rep.Data[:3], []byte{0x02, 0x01, 0x06}) {
+			t.Errorf("Data = %v; want 02 01 06", rep.Data[:3])
+		}
+		if rep.Address != [6]byte{6, 5, 4, 3, 2, 1} {
+			t.Errorf("Address = %v; want 06 05 04 03 02 01", rep.Address)
+		}
+		if rep.RSSI != -59 {
+			t.Errorf("RSSI = %d; want -59", rep.RSSI)
+		}
+		if rep.AddressType != 1 {
+			t.Errorf("AddressType = %d; want 1", rep.AddressType)
+		}
+
+		s.HCI.ClearAdvertisement()
+		if s.HCI.HasAdvertisement() {
+			t.Error("HasAdvertisement after ClearAdvertisement = true; want false")
+		}
+	})
+
+	t.Run("data length 31 is allowed", func(t *testing.T) {
+		s, _, err := pollOnce(t, report(31, make([]byte, 31), 0))
+		if err != nil {
+			t.Fatalf("Poll: %v", err)
+		}
+		if !s.HCI.HasAdvertisement() {
+			t.Error("a 31 byte report was rejected; want accepted")
+		}
+	})
+
+	t.Run("data length 32 is rejected", func(t *testing.T) {
+		s, err := parseEvent(report(32, make([]byte, 32), 0))
+		if err != ErrInvalidPacket {
+			t.Errorf("handleEventData = %v; want ErrInvalidPacket", err)
+		}
+		if s.HCI.HasAdvertisement() {
+			t.Error("a rejected report was reported; want not reported")
+		}
+	})
+
+	t.Run("data length past the end of the event", func(t *testing.T) {
+		// Claims 20 bytes of data but carries 3. Reading it would run off the
+		// end of the packet.
+		s, err := parseEvent(report(20, []byte{1, 2, 3}, 0xc5))
+		if err != ErrInvalidPacket {
+			t.Errorf("handleEventData = %v; want ErrInvalidPacket", err)
+		}
+		if s.HCI.HasAdvertisement() {
+			t.Error("a rejected report was reported; want not reported")
+		}
+	})
+
+	t.Run("report too short for the fixed part", func(t *testing.T) {
+		_, err := parseEvent(leEvent(LEMetaAdvertisingReport, 1, 0x00, 0x01, 6, 5))
+		if err != ErrInvalidPacket {
+			t.Errorf("handleEventData = %v; want ErrInvalidPacket", err)
+		}
+	})
+
+	t.Run("more than one report leaves the RSSI alone", func(t *testing.T) {
+		// Multiple reports in one event are not handled yet, so the RSSI must
+		// not be taken from the wrong offset.
+		params := []byte{2, 0x00, 0x01, 6, 5, 4, 3, 2, 1, 1, 0x00, 0xc5}
+		s, _, err := pollOnce(t, leEvent(LEMetaAdvertisingReport, params...))
+		if err != nil {
+			t.Fatalf("Poll: %v", err)
+		}
+
+		rep, _ := s.HCI.Advertisement()
+		if rep.RSSI != 0 {
+			t.Errorf("RSSI = %d; want 0 for a multi report event", rep.RSSI)
+		}
+	})
+}
+
+func TestConnectionComplete(t *testing.T) {
+	// status, handle, role, addressType, address, interval, latency, timeout,
+	// accuracy
+	base := []byte{0x00, 0x40, 0x00, 0x01, 0x01, 6, 5, 4, 3, 2, 1,
+		0x06, 0x00, 0x00, 0x00, 0xc8, 0x00, 0x00}
+
+	t.Run("connection complete", func(t *testing.T) {
+		s, _, err := pollOnce(t, leEvent(LEMetaConnComplete, base...))
+		if err != nil {
+			t.Fatalf("Poll: %v", err)
+		}
+		if !s.HCI.HasConnection() {
+			t.Fatal("HasConnection = false; want true")
+		}
+
+		conn, _ := s.HCI.Connection()
+		if conn.Handle != 0x0040 {
+			t.Errorf("Handle = %#x; want 0x40", conn.Handle)
+		}
+		if conn.Role != 1 {
+			t.Errorf("Role = %d; want 1", conn.Role)
+		}
+		if conn.Interval != 0x0006 {
+			t.Errorf("Interval = %#x; want 0x6", conn.Interval)
+		}
+		if conn.Timeout != 0x00c8 {
+			t.Errorf("Timeout = %#x; want 0xc8", conn.Timeout)
+		}
+		if conn.Address != [6]byte{6, 5, 4, 3, 2, 1} {
+			t.Errorf("Address = %v; want 06 05 04 03 02 01", conn.Address)
+		}
+	})
+
+	t.Run("enhanced connection complete reads the later offsets", func(t *testing.T) {
+		// The enhanced variant carries the local and peer resolvable private
+		// addresses before the interval, so the interval and the timeout sit
+		// 12 bytes further along.
+		params := []byte{0x00, 0x41, 0x00, 0x00, 0x01, 6, 5, 4, 3, 2, 1}
+		params = append(params, make([]byte, 12)...) // the two extra addresses
+		params = append(params, 0x10, 0x00, 0x00, 0x00, 0xd0, 0x07, 0x00, 0x00)
+
+		s, _, err := pollOnce(t, leEvent(LEMetaEnhancedConnectionComplete, params...))
+		if err != nil {
+			t.Fatalf("Poll: %v", err)
+		}
+
+		conn, ok := s.HCI.Connection()
+		if !ok {
+			t.Fatal("no connection reported")
+		}
+		if conn.Handle != 0x0041 {
+			t.Errorf("Handle = %#x; want 0x41", conn.Handle)
+		}
+		if conn.Interval != 0x0010 {
+			t.Errorf("Interval = %#x; want 0x10", conn.Interval)
+		}
+		if conn.Timeout != 0x07d0 {
+			t.Errorf("Timeout = %#x; want 0x7d0", conn.Timeout)
+		}
+	})
+
+	t.Run("connection complete too short", func(t *testing.T) {
+		_, err := parseEvent(leEvent(LEMetaConnComplete, base[:8]...))
+		if err != ErrInvalidPacket {
+			t.Errorf("handleEventData = %v; want ErrInvalidPacket", err)
+		}
+	})
+
+	t.Run("enhanced connection complete too short", func(t *testing.T) {
+		// Long enough for the plain variant, too short for the enhanced one.
+		_, err := parseEvent(leEvent(LEMetaEnhancedConnectionComplete, base...))
+		if err != ErrInvalidPacket {
+			t.Errorf("handleEventData = %v; want ErrInvalidPacket", err)
+		}
+	})
+}
+
+func TestDisconnectionComplete(t *testing.T) {
+	s, _, err := pollOnce(t, event(EventDisconnComplete, 0x00, 0x40, 0x00, ReasonRemoteUserTerminated))
+	if err != nil {
+		t.Fatalf("Poll: %v", err)
+	}
+	if !s.HCI.HasDisconnection() {
+		t.Fatal("HasDisconnection = false; want true")
+	}
+
+	disc, _ := s.HCI.Disconnection()
+	if disc.Handle != 0x0040 {
+		t.Errorf("Handle = %#x; want 0x40", disc.Handle)
+	}
+	if disc.Reason != ReasonRemoteUserTerminated {
+		t.Errorf("Reason = %#x; want %#x", disc.Reason, ReasonRemoteUserTerminated)
+	}
+
+	s.HCI.ClearConnection()
+	if s.HCI.HasDisconnection() {
+		t.Error("HasDisconnection after ClearConnection = true; want false")
+	}
+}
+
+func TestUnknownEventGoesToTheHandler(t *testing.T) {
+	const vendorEvent = 0xff
+
+	t.Run("consumed", func(t *testing.T) {
+		f := &fakeTransport{rx: [][]byte{event(vendorEvent, 1, 2, 3)}}
+		s := newTestStack(f)
+
+		var gotEvent uint8
+		var gotParams []byte
+		s.HCI.SetEventHandler(func(e uint8, params []byte) (bool, error) {
+			gotEvent = e
+			gotParams = append([]byte{}, params...)
+			return true, nil
+		})
+
+		if err := s.HCI.Poll(); err != nil {
+			t.Fatalf("Poll: %v", err)
+		}
+		if gotEvent != vendorEvent {
+			t.Errorf("event = %#x; want %#x", gotEvent, vendorEvent)
+		}
+		if !bytes.Equal(gotParams, []byte{1, 2, 3}) {
+			t.Errorf("params = %v; want 1 2 3", gotParams)
+		}
+	})
+
+	t.Run("declined", func(t *testing.T) {
+		f := &fakeTransport{rx: [][]byte{event(vendorEvent, 1)}}
+		s := newTestStack(f)
+		s.HCI.SetEventHandler(func(uint8, []byte) (bool, error) { return false, nil })
+
+		// An event the handler declines is not an error, because an unknown
+		// event was already ignored before the hook existed.
+		if err := s.HCI.Poll(); err != nil {
+			t.Errorf("Poll = %v; want nil", err)
+		}
+	})
+
+	t.Run("no handler", func(t *testing.T) {
+		if _, _, err := pollOnce(t, event(vendorEvent, 1)); err != nil {
+			t.Errorf("Poll = %v; want nil", err)
+		}
+	})
+}
+
+func TestUnknownLEEventGoesToTheHandler(t *testing.T) {
+	const vendorSubevent = 0x7f
+
+	t.Run("consumed", func(t *testing.T) {
+		f := &fakeTransport{rx: [][]byte{leEvent(vendorSubevent, 9, 8)}}
+		s := newTestStack(f)
+
+		var got uint8
+		s.HCI.SetLEEventHandler(func(sub uint8, params []byte) (bool, error) {
+			got = sub
+			return true, nil
+		})
+
+		if err := s.HCI.Poll(); err != nil {
+			t.Fatalf("Poll: %v", err)
+		}
+		if got != vendorSubevent {
+			t.Errorf("subevent = %#x; want %#x", got, vendorSubevent)
+		}
+	})
+
+	t.Run("declined", func(t *testing.T) {
+		s := newTestStack(&fakeTransport{})
+		s.HCI.SetLEEventHandler(func(uint8, []byte) (bool, error) { return false, nil })
+
+		pkt := leEvent(vendorSubevent, 9)
+		if err := s.HCI.handleEventData(pkt[1:]); err != ErrUnknownEvent {
+			t.Errorf("handleEventData = %v; want ErrUnknownEvent", err)
+		}
+	})
+
+	t.Run("no handler", func(t *testing.T) {
+		if _, err := parseEvent(leEvent(vendorSubevent, 9)); err != ErrUnknownEvent {
+			t.Errorf("handleEventData = %v; want ErrUnknownEvent", err)
+		}
+	})
+}
+
+func TestHardwareError(t *testing.T) {
+	if _, err := parseEvent(event(EventHardwareError, 0x01)); err != ErrUnknownEvent {
+		t.Errorf("handleEventData = %v; want ErrUnknownEvent", err)
+	}
+}
+
+func TestUnknownPacketType(t *testing.T) {
+	s := newTestStack(&fakeTransport{})
+	copy(s.HCI.buf, []byte{0x09, 1, 2, 3, 4})
+	s.HCI.end = 5
+	s.HCI.pos = 5
+
+	if _, err := s.HCI.processPacket(); err != ErrUnknown {
+		t.Errorf("processPacket = %v; want ErrUnknown", err)
+	}
+}
+
+func TestSynchronousDataIsSkipped(t *testing.T) {
+	// BLE has no synchronous data, so such a packet is stepped over and the
+	// next one is handled.
+	sco := []byte{PacketSynchronousData, 0x40, 0x00, 2, 0xaa, 0xbb}
+	s, _, err := pollOnce(t, sco, commandComplete(OpCode(OGFHostCtl, OCFReset), 0))
+	if err != nil {
+		t.Fatalf("Poll: %v", err)
+	}
+	_ = s
+}
+
+func TestACLPacketLongerThanTheBufferCanHold(t *testing.T) {
+	// The ACL length comes off the wire. A length that no buffer could ever
+	// hold has to be rejected rather than waited on.
+	pkt := []byte{PacketACLData, 0x40, 0x00, 0xff, 0xff, 0, 0, 0, 0}
+	s := newTestStack(&fakeTransport{})
+	copy(s.HCI.buf, pkt)
+	s.HCI.end = len(pkt)
+	s.HCI.pos = len(pkt)
+
+	if _, err := s.HCI.processPacket(); err != ErrInvalidPacket {
+		t.Errorf("processPacket = %v; want ErrInvalidPacket", err)
+	}
+}
+
+func TestResetWritesTheCommandAndWaitsForCompletion(t *testing.T) {
+	opcode := OpCode(OGFHostCtl, OCFReset)
+	f := &fakeTransport{rx: [][]byte{commandComplete(opcode, 0)}}
+	s := newTestStack(f)
+
+	if err := s.HCI.Reset(); err != nil {
+		t.Fatalf("Reset: %v", err)
+	}
+	if len(f.tx) != 1 {
+		t.Fatalf("wrote %d packets; want 1", len(f.tx))
+	}
+
+	// Command packet, opcode little endian, zero parameters.
+	want := []byte{PacketCommand, 0x03, 0x0c, 0x00}
+	if !bytes.Equal(f.tx[0], want) {
+		t.Errorf("wrote %#v; want %#v", f.tx[0], want)
+	}
+}
+
+func TestCommandWithoutAnAnswerTimesOut(t *testing.T) {
+	f := &fakeTransport{}
+	s := newTestStack(f)
+
+	if err := s.HCI.Reset(); err != ErrTimeout {
+		t.Errorf("Reset = %v; want ErrTimeout", err)
+	}
+}
+
+func TestSendCommandPropagatesAWriteError(t *testing.T) {
+	f := &fakeTransport{writeErr: errFakeRead}
+	s := newTestStack(f)
+
+	if err := s.HCI.Reset(); err != errFakeRead {
+		t.Errorf("Reset = %v; want the write error", err)
+	}
+}
+
+func TestSetRandomAddress(t *testing.T) {
+	opcode := OpCode(OGFLECtrl, OCFLESetRandomAddress)
+	f := &fakeTransport{rx: [][]byte{commandComplete(opcode, 0)}}
+	s := newTestStack(f)
+
+	mac := [6]byte{0xc0, 0x01, 0x02, 0x03, 0x04, 0x05}
+	if err := s.HCI.SetRandomAddress(mac); err != nil {
+		t.Fatalf("SetRandomAddress: %v", err)
+	}
+
+	want := append([]byte{PacketCommand, 0x05, 0x20, 0x06}, mac[:]...)
+	if !bytes.Equal(f.tx[0], want) {
+		t.Errorf("wrote %#v; want %#v", f.tx[0], want)
+	}
+	if !s.HCI.Address().IsRandom() {
+		t.Error("Address().IsRandom() = false; want true")
+	}
+}
+
+func TestScanEnableAndAdvertiseEnableBytes(t *testing.T) {
+	t.Run("scan enable with duplicate filtering", func(t *testing.T) {
+		opcode := OpCode(OGFLECtrl, OCFLESetScanEnable)
+		f := &fakeTransport{rx: [][]byte{commandComplete(opcode, 0)}}
+		s := newTestStack(f)
+
+		if err := s.HCI.LESetScanEnable(true, true); err != nil {
+			t.Fatalf("LESetScanEnable: %v", err)
+		}
+
+		want := []byte{PacketCommand, 0x0c, 0x20, 0x02, 0x01, 0x01}
+		if !bytes.Equal(f.tx[0], want) {
+			t.Errorf("wrote %#v; want %#v", f.tx[0], want)
+		}
+	})
+
+	t.Run("advertise enable does not wait for a response", func(t *testing.T) {
+		f := &fakeTransport{}
+		s := newTestStack(f)
+
+		// This command is sent without waiting, so it succeeds with nothing
+		// scripted to answer it.
+		if err := s.HCI.LESetAdvertiseEnable(true); err != nil {
+			t.Fatalf("LESetAdvertiseEnable: %v", err)
+		}
+
+		want := []byte{PacketCommand, 0x0a, 0x20, 0x01, 0x01}
+		if !bytes.Equal(f.tx[0], want) {
+			t.Errorf("wrote %#v; want %#v", f.tx[0], want)
+		}
+	})
+}
+
+func TestStartDrainsTheTransport(t *testing.T) {
+	f := &fakeTransport{rx: [][]byte{{1, 2, 3, 4}, {5, 6, 7, 8}}}
+	s := newTestStack(f)
+
+	if err := s.HCI.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if f.Buffered() != 0 {
+		t.Errorf("Buffered after Start = %d; want 0", f.Buffered())
+	}
+}
+
+func TestStartRejectsAnOversizedLeftover(t *testing.T) {
+	// Start discards whatever is left over into the packet buffer, so an entry
+	// larger than that buffer cannot be drained.
+	f := &fakeTransport{rx: [][]byte{make([]byte, ReadBufferSize+8)}}
+	s := newTestStack(f)
+
+	if err := s.HCI.Start(); err != ErrInvalidPacket {
+		t.Errorf("Start = %v; want ErrInvalidPacket", err)
+	}
+}
+
+func TestTwoEventsInOneRead(t *testing.T) {
+	// A stream transport can hand back two packets at once. The second must be
+	// kept and handled on the next poll.
+	first := event(EventDisconnComplete, 0x00, 0x40, 0x00, 0x13)
+	second := commandComplete(OpCode(OGFHostCtl, OCFReset), 0)
+
+	f := &fakeTransport{rx: [][]byte{append(append([]byte{}, first...), second...)}}
+	s := newTestStack(f)
+
+	if err := s.HCI.Poll(); err != nil {
+		t.Fatalf("first Poll: %v", err)
+	}
+	if !s.HCI.HasDisconnection() {
+		t.Error("first poll did not handle the disconnection")
+	}
+
+	if err := s.HCI.Poll(); err != nil {
+		t.Fatalf("second Poll: %v", err)
+	}
+	if s.HCI.cmdCompleteOpcode != OpCode(OGFHostCtl, OCFReset) {
+		t.Errorf("second poll did not handle the command complete")
+	}
+}
+
+func TestPacketSplitAcrossTwoReads(t *testing.T) {
+	// A stream transport can hand back half a packet. The stack keeps it and
+	// finishes it on a later poll.
+	full := commandComplete(OpCode(OGFHostCtl, OCFReset), 0)
+	f := &fakeTransport{rx: [][]byte{full[:3], full[3:]}}
+	s := newTestStack(f)
+
+	if err := s.HCI.Poll(); err != nil {
+		t.Fatalf("first Poll: %v", err)
+	}
+	if err := s.HCI.Poll(); err != nil {
+		t.Fatalf("second Poll: %v", err)
+	}
+	if s.HCI.cmdCompleteOpcode != OpCode(OGFHostCtl, OCFReset) {
+		t.Error("the split packet was not handled")
+	}
+}
+
+func TestPacketTransportReadsWholePackets(t *testing.T) {
+	f := &fakeTransport{packet: true, rx: [][]byte{
+		commandComplete(OpCode(OGFHostCtl, OCFReset), 0),
+	}}
+	s := newTestStack(f)
+
+	if err := s.HCI.Poll(); err != nil {
+		t.Fatalf("Poll: %v", err)
+	}
+	if s.HCI.cmdCompleteOpcode != OpCode(OGFHostCtl, OCFReset) {
+		t.Error("the packet was not handled")
+	}
+}
+
+func TestOpCode(t *testing.T) {
+	for _, tc := range []struct {
+		ogf, ocf, want uint16
+	}{
+		{OGFHostCtl, OCFReset, 0x0c03},
+		{OGFLECtrl, OCFLESetScanEnable, 0x200c},
+		{OGFInfoParam, OCFReadBDAddr, 0x1009},
+		{OGFVendor, 0x0001, 0xfc01},
+	} {
+		if got := OpCode(tc.ogf, tc.ocf); got != tc.want {
+			t.Errorf("OpCode(%#x, %#x) = %#x; want %#x", tc.ogf, tc.ocf, got, tc.want)
+		}
+	}
+}
+
+func TestSendVendorCommand(t *testing.T) {
+	f := &fakeTransport{}
+	s := newTestStack(f)
+
+	if err := s.HCI.SendVendorCommandWithoutResponse(0x0001, []byte{1, 2, 3}); err != nil {
+		t.Fatalf("SendVendorCommandWithoutResponse: %v", err)
+	}
+
+	want := []byte{PacketCommand, 0x01, 0xfc, 0x03, 1, 2, 3}
+	if !bytes.Equal(f.tx[0], want) {
+		t.Errorf("wrote %#v; want %#v", f.tx[0], want)
+	}
+}
+
+func TestPollSwallowsAParseError(t *testing.T) {
+	// A malformed packet must not stop the caller's poll loop. Poll drops what
+	// it has and returns nil, so that scanning survives a bad advertisement.
+	bad := leEvent(LEMetaAdvertisingReport, 1, 0x00, 0x01, 6, 5, 4, 3, 2, 1, 32)
+	good := commandComplete(OpCode(OGFHostCtl, OCFReset), 0)
+
+	f := &fakeTransport{rx: [][]byte{bad, good}}
+	s := newTestStack(f)
+
+	if err := s.HCI.Poll(); err != nil {
+		t.Errorf("Poll on a malformed packet = %v; want nil", err)
+	}
+	if s.HCI.HasAdvertisement() {
+		t.Error("a malformed report was reported; want not reported")
+	}
+
+	// The stack recovers and handles the next packet.
+	if err := s.HCI.Poll(); err != nil {
+		t.Fatalf("Poll after recovery: %v", err)
+	}
+	if s.HCI.cmdCompleteOpcode != OpCode(OGFHostCtl, OCFReset) {
+		t.Error("the packet after a malformed one was not handled")
+	}
+}
+
+func TestPollPropagatesATransportError(t *testing.T) {
+	f := &fakeTransport{rx: [][]byte{{1, 2, 3, 4}}, readErr: errFakeRead}
+	s := newTestStack(f)
+
+	if err := s.HCI.Poll(); err != errFakeRead {
+		t.Errorf("Poll = %v; want the read error", err)
+	}
+}
+
+func TestPollRejectsAPacketThatCanNeverFit(t *testing.T) {
+	// A packet transport that offers more than the read buffer can hold, with
+	// nothing already buffered to drain, can never be satisfied.
+	f := &fakeTransport{packet: true, rx: [][]byte{make([]byte, ReadBufferSize+4)}}
+	s := newTestStack(f)
+
+	if err := s.HCI.Poll(); err != ErrInvalidPacket {
+		t.Errorf("Poll = %v; want ErrInvalidPacket", err)
+	}
+}
+
+func TestNoEventPanicsOnAShortPacket(t *testing.T) {
+	// Every event code and every LE meta subevent, at every length up to 40
+	// bytes. None of them may panic, whatever the content.
+	events := []uint8{
+		EventDisconnComplete, EventEncryptionChange, EventCmdComplete,
+		EventCmdStatus, EventHardwareError, EventNumCompPkts,
+		EventReturnLinkKeys, EventLEMeta, 0x00, 0xff,
+	}
+	subevents := []uint8{
+		LEMetaConnComplete, LEMetaAdvertisingReport,
+		LEMetaConnectionUpdateComplete, LEMetaReadRemoteUsedFeaturesComplete,
+		LEMetaLongTermKeyRequest, LEMetaRemoteConnParamReq,
+		LEMetaDataLengthChange, LEMetaReadLocalP256Complete,
+		LEMetaGenerateDHKeyComplete, LEMetaEnhancedConnectionComplete,
+		LEMetaDirectAdvertisingReport, 0x00, 0xff,
+	}
+
+	fill := func(buf []byte, from int) {
+		for i := from; i < len(buf); i++ {
+			buf[i] = 0xff
+		}
+	}
+
+	for _, evt := range events {
+		for n := 0; n <= 40; n++ {
+			buf := make([]byte, n)
+			if n > 0 {
+				buf[0] = evt
+			}
+			fill(buf, 1)
+
+			s := newTestStack(&fakeTransport{})
+			_ = s.HCI.handleEventData(buf)
+		}
+	}
+
+	for _, sub := range subevents {
+		for n := 2; n <= 40; n++ {
+			buf := make([]byte, n)
+			buf[0] = EventLEMeta
+			buf[1] = byte(n - 2)
+			if n > 2 {
+				buf[2] = sub
+			}
+			fill(buf, 3)
+
+			s := newTestStack(&fakeTransport{})
+			_ = s.HCI.handleEventData(buf)
+		}
+	}
+}
+
+func TestNoACLPacketPanicsOnAShortPayload(t *testing.T) {
+	for _, cid := range []uint16{CIDATT, CIDSignaling, CIDSecurity, 0x0099} {
+		for n := 0; n <= 24; n++ {
+			buf := make([]byte, n)
+			if n >= 8 {
+				binary.LittleEndian.PutUint16(buf[0:], testConnHandle)
+				binary.LittleEndian.PutUint16(buf[2:], uint16(n-4+4))
+				binary.LittleEndian.PutUint16(buf[4:], uint16(n-8))
+				binary.LittleEndian.PutUint16(buf[6:], cid)
+				for i := 8; i < n; i++ {
+					buf[i] = 0xff
+				}
+			}
+
+			s := newTestStack(&fakeTransport{})
+			_ = s.ATT.addConnection(testConnHandle)
+			_ = s.HCI.handleACLData(buf)
+		}
+	}
+}
+
+func TestNoPacketPanicsThroughPoll(t *testing.T) {
+	// Whole packets straight off a transport, at every length and with each
+	// packet type byte.
+	for _, typ := range []uint8{PacketCommand, PacketACLData,
+		PacketSynchronousData, PacketEvent, PacketSecurity, 0x00, 0xff} {
+		for n := 1; n <= 32; n++ {
+			pkt := make([]byte, n)
+			pkt[0] = typ
+			for i := 1; i < n; i++ {
+				pkt[i] = 0xff
+			}
+
+			s := newTestStack(&fakeTransport{rx: [][]byte{pkt}})
+			_ = s.HCI.Poll()
+		}
+	}
+}

--- a/hci/l2cap.go
+++ b/hci/l2cap.go
@@ -33,19 +33,6 @@ func (l *l2capConnectionParamReqPkt) unmarshal(buf []byte) (int, error) {
 	return 8, nil
 }
 
-func (l *l2capConnectionParamReqPkt) marshal(p []byte) (int, error) {
-	if len(p) < 8 {
-		return 0, errInvalidPayloadLength
-	}
-
-	binary.LittleEndian.PutUint16(p[0:], l.minInterval)
-	binary.LittleEndian.PutUint16(p[2:], l.maxInterval)
-	binary.LittleEndian.PutUint16(p[4:], l.latency)
-	binary.LittleEndian.PutUint16(p[6:], l.timeout)
-
-	return 8, nil
-}
-
 type l2capConnectionParamResponsePkt struct {
 	code       uint8
 	identifier uint8
@@ -98,15 +85,17 @@ func (l *l2cap) removeConnection(handle uint16) error {
 }
 
 func (l *l2cap) handleData(handle uint16, buf []byte) error {
-	code := buf[0]
-	identifier := buf[1]
-	//length := binary.LittleEndian.Uint16(buf[2:4])
-
 	if debug {
 		println("l2cap.handleData:", handle, "data:", hex.EncodeToString(buf))
 	}
 
-	// TODO: check length
+	// Every signalling packet carries a code, an identifier and a length.
+	if len(buf) < 4 {
+		return errInvalidPayloadLength
+	}
+
+	code := buf[0]
+	identifier := buf[1]
 
 	switch code {
 	case connectionParamUpdateRequest:
@@ -125,7 +114,9 @@ func (l *l2cap) handleParameterUpdateRequest(connectionHandle uint16, identifier
 	}
 
 	req := l2capConnectionParamReqPkt{}
-	req.unmarshal(data)
+	if _, err := req.unmarshal(data); err != nil {
+		return err
+	}
 
 	// TODO: check against min/max
 

--- a/hci/l2cap_test.go
+++ b/hci/l2cap_test.go
@@ -1,0 +1,169 @@
+package hci
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+)
+
+// signalingPDU returns the L2CAP signalling payload of the nth write.
+func signalingPDU(t *testing.T, f *fakeTransport, n int) []byte {
+	t.Helper()
+
+	pkt := f.tx[n]
+	if cid := binary.LittleEndian.Uint16(pkt[7:]); cid != CIDSignaling {
+		t.Fatalf("write %d has CID %#x; want the signalling channel", n, cid)
+	}
+
+	return pkt[9:]
+}
+
+func TestL2CAPParameterUpdateRequestIsAnswered(t *testing.T) {
+	f := &fakeTransport{}
+	s := newTestStack(f)
+
+	// code, identifier, length, then min and max interval, latency, timeout.
+	pdu := []byte{connectionParamUpdateRequest, 0x05, 0x08, 0x00,
+		0x06, 0x00, 0x0c, 0x00, 0x00, 0x00, 0xc8, 0x00}
+
+	if err := s.HCI.l2cap.handleData(testConnHandle, pdu); err != nil {
+		t.Fatalf("handleData: %v", err)
+	}
+
+	got := signalingPDU(t, f, 0)
+	// code, identifier echoed, length 2, result 0 for accepted.
+	want := []byte{connectionParamUpdateResponse, 0x05, 0x02, 0x00, 0x00, 0x00}
+	if !bytes.Equal(got, want) {
+		t.Errorf("response = %#v; want %#v", got, want)
+	}
+}
+
+func TestL2CAPParameterUpdateResponseIsAccepted(t *testing.T) {
+	f := &fakeTransport{}
+	s := newTestStack(f)
+
+	pdu := []byte{connectionParamUpdateResponse, 0x05, 0x02, 0x00, 0x00, 0x00}
+	if err := s.HCI.l2cap.handleData(testConnHandle, pdu); err != nil {
+		t.Fatalf("handleData: %v", err)
+	}
+	if len(f.tx) != 0 {
+		t.Errorf("wrote %d packets in reply to a response; want 0", len(f.tx))
+	}
+}
+
+func TestL2CAPUnknownCodeIsIgnored(t *testing.T) {
+	f := &fakeTransport{}
+	s := newTestStack(f)
+
+	if err := s.HCI.l2cap.handleData(testConnHandle, []byte{0x01, 0x05, 0x00, 0x00}); err != nil {
+		t.Errorf("handleData = %v; want nil", err)
+	}
+	if len(f.tx) != 0 {
+		t.Errorf("wrote %d packets for an unknown code; want 0", len(f.tx))
+	}
+}
+
+func TestL2CAPAddConnection(t *testing.T) {
+	t.Run("the peripheral asks for its parameters", func(t *testing.T) {
+		f := &fakeTransport{}
+		s := newTestStack(f)
+
+		if err := s.HCI.l2cap.addConnection(testConnHandle, 0x01, 0x0006, 0x00c8); err != nil {
+			t.Fatalf("addConnection: %v", err)
+		}
+
+		got := signalingPDU(t, f, 0)
+		if got[0] != connectionParamUpdateRequest {
+			t.Fatalf("code = %#x; want a parameter update request", got[0])
+		}
+		if interval := binary.LittleEndian.Uint16(got[4:]); interval != 0x0006 {
+			t.Errorf("min interval = %#x; want 0x6", interval)
+		}
+		if timeout := binary.LittleEndian.Uint16(got[10:]); timeout != 0x00c8 {
+			t.Errorf("timeout = %#x; want 0xc8", timeout)
+		}
+	})
+
+	t.Run("a zero timeout falls back to the default", func(t *testing.T) {
+		f := &fakeTransport{}
+		s := newTestStack(f)
+
+		if err := s.HCI.l2cap.addConnection(testConnHandle, 0x01, 0x0006, 0); err != nil {
+			t.Fatalf("addConnection: %v", err)
+		}
+
+		got := signalingPDU(t, f, 0)
+		if timeout := binary.LittleEndian.Uint16(got[10:]); timeout != 0x00c8 {
+			t.Errorf("timeout = %#x; want the default 0xc8", timeout)
+		}
+	})
+
+	t.Run("the central sends nothing", func(t *testing.T) {
+		f := &fakeTransport{}
+		s := newTestStack(f)
+
+		if err := s.HCI.l2cap.addConnection(testConnHandle, 0x00, 0x0006, 0x00c8); err != nil {
+			t.Fatalf("addConnection: %v", err)
+		}
+		if len(f.tx) != 0 {
+			t.Errorf("the central wrote %d packets; want 0", len(f.tx))
+		}
+	})
+}
+
+func TestL2CAPParameterRequestTooShort(t *testing.T) {
+	f := &fakeTransport{}
+	s := newTestStack(f)
+
+	// The request needs 8 bytes of parameters and carries 4.
+	pdu := []byte{connectionParamUpdateRequest, 0x05, 0x08, 0x00, 0x06, 0x00, 0x0c, 0x00}
+	if err := s.HCI.l2cap.handleData(testConnHandle, pdu); err != errInvalidPayloadLength {
+		t.Errorf("handleData = %v; want errInvalidPayloadLength", err)
+	}
+}
+
+func TestL2CAPOverACLFromTheTransport(t *testing.T) {
+	// A signalling packet arrives from the controller and is answered.
+	pdu := []byte{connectionParamUpdateRequest, 0x05, 0x08, 0x00,
+		0x06, 0x00, 0x0c, 0x00, 0x00, 0x00, 0xc8, 0x00}
+
+	f := &fakeTransport{rx: [][]byte{aclPacket(testConnHandle, CIDSignaling, pdu)}}
+	s := newTestStack(f)
+
+	if err := s.HCI.Poll(); err != nil {
+		t.Fatalf("Poll: %v", err)
+	}
+
+	got := signalingPDU(t, f, 0)
+	if got[0] != connectionParamUpdateResponse {
+		t.Errorf("code = %#x; want a parameter update response", got[0])
+	}
+}
+
+func TestUnknownCIDIsIgnored(t *testing.T) {
+	// A channel this stack does not use must not be an error.
+	f := &fakeTransport{rx: [][]byte{aclPacket(testConnHandle, 0x0099, []byte{1, 2, 3, 4})}}
+	s := newTestStack(f)
+
+	if err := s.HCI.Poll(); err != nil {
+		t.Errorf("Poll = %v; want nil", err)
+	}
+}
+
+func TestNoL2CAPPacketPanicsOnAShortPayload(t *testing.T) {
+	for _, code := range []uint8{connectionParamUpdateRequest,
+		connectionParamUpdateResponse, 0x00, 0xff} {
+		for n := 0; n <= 20; n++ {
+			buf := make([]byte, n)
+			if n > 0 {
+				buf[0] = code
+			}
+			for i := 1; i < n; i++ {
+				buf[i] = 0xff
+			}
+
+			s := newTestStack(&fakeTransport{})
+			_ = s.HCI.l2cap.handleData(testConnHandle, buf)
+		}
+	}
+}

--- a/hci/transport_test.go
+++ b/hci/transport_test.go
@@ -1,0 +1,177 @@
+package hci
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+// errFakeRead is returned by a fake transport told to fail a read.
+var errFakeRead = errors.New("fake transport read error")
+
+// fakeTransport serves scripted packets and records what was written. Each
+// entry in rx is one thing the controller offers, so a stream transport hands
+// out its bytes as they fit and a packet transport hands out a whole entry or
+// nothing.
+type fakeTransport struct {
+	// rx holds what the controller has to offer, front first.
+	rx [][]byte
+
+	// tx holds each write, in order.
+	tx [][]byte
+
+	// packet makes the transport packet oriented, like the CYW43439 SDIO
+	// ring. It refuses a read that cannot take the whole rounded up entry and
+	// rounds its copy up to 4 bytes.
+	packet bool
+
+	// readErr, when set, fails the next read.
+	readErr error
+
+	// writeErr, when set, fails the next write.
+	writeErr error
+
+	starts, ends int
+}
+
+func (f *fakeTransport) StartRead() { f.starts++ }
+func (f *fakeTransport) EndRead()   { f.ends++ }
+
+func (f *fakeTransport) Buffered() int {
+	if len(f.rx) == 0 {
+		return 0
+	}
+
+	return len(f.rx[0])
+}
+
+func (f *fakeTransport) Read(buf []byte) (int, error) {
+	if f.readErr != nil {
+		err := f.readErr
+		f.readErr = nil
+		return 0, err
+	}
+
+	if len(f.rx) == 0 {
+		return 0, nil
+	}
+
+	front := f.rx[0]
+
+	if f.packet {
+		// A packet transport copies the whole entry, rounded up to 4 bytes, so
+		// it fails outright when the destination is too small.
+		if len(buf) < alignUp4(len(front)) {
+			return 0, errFakeRead
+		}
+
+		n := copy(buf, front)
+		f.rx = f.rx[1:]
+
+		return n, nil
+	}
+
+	n := copy(buf, front)
+	if n == len(front) {
+		f.rx = f.rx[1:]
+	} else {
+		f.rx[0] = front[n:]
+	}
+
+	return n, nil
+}
+
+func (f *fakeTransport) Write(buf []byte) (int, error) {
+	if f.writeErr != nil {
+		err := f.writeErr
+		f.writeErr = nil
+		return 0, err
+	}
+
+	f.tx = append(f.tx, append([]byte{}, buf...))
+
+	return len(buf), nil
+}
+
+// newTestStack returns a stack on a fake transport, with the timeouts short
+// enough that a timeout path finishes at once.
+func newTestStack(t *fakeTransport) *Stack {
+	s := NewStack(t)
+	s.HCI.commandTimeout = time.Millisecond
+	s.HCI.responseTimeout = time.Millisecond
+	s.HCI.retryDelay = 0
+
+	return s
+}
+
+// event wraps event parameters in an HCI event packet.
+func event(code uint8, params ...byte) []byte {
+	return append([]byte{PacketEvent, code, byte(len(params))}, params...)
+}
+
+// leEvent wraps LE meta subevent parameters in an HCI event packet.
+func leEvent(subevent uint8, params ...byte) []byte {
+	return event(EventLEMeta, append([]byte{subevent}, params...)...)
+}
+
+// commandComplete is a Command Complete event for an opcode, with a status and
+// any return parameters.
+func commandComplete(opcode uint16, status uint8, ret ...byte) []byte {
+	params := []byte{1, byte(opcode), byte(opcode >> 8), status}
+
+	return event(EventCmdComplete, append(params, ret...)...)
+}
+
+func TestFakeTransportStream(t *testing.T) {
+	f := &fakeTransport{rx: [][]byte{{1, 2, 3, 4, 5}}}
+
+	buf := make([]byte, 3)
+	n, err := f.Read(buf)
+	if err != nil || n != 3 {
+		t.Fatalf("first read = %d, %v; want 3, nil", n, err)
+	}
+	if f.Buffered() != 2 {
+		t.Errorf("Buffered after partial read = %d; want 2", f.Buffered())
+	}
+
+	n, err = f.Read(buf)
+	if err != nil || n != 2 {
+		t.Fatalf("second read = %d, %v; want 2, nil", n, err)
+	}
+	if f.Buffered() != 0 {
+		t.Errorf("Buffered after full read = %d; want 0", f.Buffered())
+	}
+}
+
+func TestFakeTransportPacket(t *testing.T) {
+	f := &fakeTransport{packet: true, rx: [][]byte{{1, 2, 3, 4, 5}}}
+
+	// 5 bytes round up to 8, so a 5 byte destination is not enough.
+	if _, err := f.Read(make([]byte, 5)); err == nil {
+		t.Error("read into a short buffer succeeded; want an error")
+	}
+
+	n, err := f.Read(make([]byte, 8))
+	if err != nil || n != 5 {
+		t.Fatalf("read = %d, %v; want 5, nil", n, err)
+	}
+}
+
+func TestAlignUp4(t *testing.T) {
+	for _, tc := range []struct{ in, want int }{
+		{0, 0}, {1, 4}, {3, 4}, {4, 4}, {5, 8}, {255, 256}, {256, 256},
+	} {
+		if got := alignUp4(tc.in); got != tc.want {
+			t.Errorf("alignUp4(%d) = %d; want %d", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestReadBufferSizeHoldsLargestPacket(t *testing.T) {
+	// The read buffer must be able to hold the largest packet that can
+	// legitimately arrive, plus whatever a transport adds on top.
+	if ReadBufferSize < MaxPacketSize+TransportOverhead {
+		t.Errorf("ReadBufferSize = %d; too small for MaxPacketSize %d plus overhead %d",
+			ReadBufferSize, MaxPacketSize, TransportOverhead)
+	}
+}


### PR DESCRIPTION
Adds unit tests to the HCI protocol stack, and corrects the eight defects that
they found.

This is the last of three stacked pull requests. It builds on #478
`hci: move the protocol stack into a subpackage`, which took the build tags off
the protocol code and made these tests possible.

## Tests

219 test cases, 87 percent statement coverage, race clean. The fake transport
comes in two flavours: a stream one that models a UART, including a packet
split over two reads, and a packet oriented one that models the CYW43439 ring,
including the read that does not fit. There is also a sweep over every ATT
opcode, every HCI event, every LE subevent and every L2CAP signalling code at
every length up to 24 bytes, which is what found most of the following.

## Defects the tests found

All of these are in code that has shipped.

1. **Find Information Response panicked.** Its format byte was treated as an
   entry length, so a well formed response from any peer sliced past the end of
   the buffer. Reachable over the air.
2. **Read By Type and Read By Group Type responses** took their entry length
   off the wire with no bounds check. A bad length read past the end, and a
   zero length looped forever.
3. **No ATT opcode checked its length** before reading, so a two byte protocol
   data unit panicked.
4. **`ReadBdAddr` returned the wrong address.** `cmdResponse` started at the
   event length byte rather than at the return parameters, so `Address()`
   returned `0a:01:09:10:00:11`. `CommandResponse()` now returns the return
   parameters alone.
5. **`ReadLEBufferSize` read the raw packet buffer**, taking the packet type and
   event code as the packet length, and raised the maximum MTU to 3588 against
   response buffers sized for 248. Nothing calls it yet, so the overflow was
   latent.
6. **`MTUReq` asked for an MTU of zero**, because it sent the connection MTU
   before any exchange.
7. **`att.mtu` was never assigned**, so `GetMTU` always returned zero and the
   server used zero as the size budget for a discovery response, sending one
   attribute per round trip.
8. **L2CAP accepted a truncated connection parameter update request**, answering
   it as accepted with zeroed parameters.

One protocol defect is **not** fixed here, because it is a behaviour change on
the peripheral discovery path that wants hardware validation: the Find
Information Response that this stack sends picks its format from the attribute
type rather than the UUID width, so a database whose first match is a service
declaration answers with format 2 and 16 bit UUIDs. It is marked with a TODO.

## Three commits, in order

1. `hci: make the timeouts settable so that tests do not wait`, so a timeout
   test does not wait 10 seconds.
2. `hci: add unit tests, and correct what they found`.
3. `ci: test every package, and add a faster HCI smoke test`. A new
   `make smoketest-hci` builds the four HCI transports and two `bledebug`
   configurations, which nothing covered before.

## Size

`-size=short`, against #478:

| target | example | flash before | after | RAM before | after |
| --- | --- | --- | --- | --- | --- |
| nano-rp2040 | discover | 41632 | 42784 | 6516 | 6524 |
| nano-rp2040 | heartrate | 61068 | 61964 | 8460 | 8468 |
| arduino-nano33 | discover | 39812 | 40908 | 5696 | 5704 |
| circuitplay-express `hci hci_uart` | advertisement | 56768 | 58036 | 5844 | 5852 |
| pico-w | discover | 671072 | 671792 | 37016 | 37024 |
| xiao-esp32c3 | discover | 307898 | 308614 | 58240 | 58256 |

The growth is the bounds checks. RAM is flat.

## Verification

`go vet`, `go test` and `go test -race` over `./ ./ble ./hci`, plus
`make smoketest-tinygo`, `smoketest-linux`, `smoketest-windows` and
`smoketest-hci`.

Run on hardware. `examples/discover`, which is the central path, works on one
ninafw board, one pico-w and one esp32, against `dev`, against the move and
against the tests. `examples/heartrate`, which is the peripheral path, was also
checked on a ninafw board with a host as the central: the service and
characteristic discovery, the MTU and the read permissions are the same in all
three. The peripheral path is not yet checked on pico-w or esp32.

