### PR TITLE
ble: move the core value types into a leaf package

### DIFF
--- a/adapter_nrf51.go
+++ b/adapter_nrf51.go
@@ -122,10 +122,7 @@ func (a *Adapter) Address() (MACAddress, error) {
 
 // Convert a C.ble_gap_addr_t to a MACAddress struct.
 func makeMACAddress(addr C.ble_gap_addr_t) MACAddress {
-	return MACAddress{
-		MAC:      makeAddress(addr.addr),
-		isRandom: addr.addr_type != 0,
-	}
+	return NewMACAddress(makeAddress(addr.addr), addr.addr_type != 0)
 }
 
 // Connect starts a connection attempt to the given peripheral device address.

--- a/adapter_nrf528xx.go
+++ b/adapter_nrf528xx.go
@@ -81,10 +81,7 @@ func (a *Adapter) Address() (MACAddress, error) {
 
 // Convert a C.ble_gap_addr_t to a MACAddress struct.
 func makeMACAddress(addr C.ble_gap_addr_t) MACAddress {
-	return MACAddress{
-		MAC:      makeAddress(addr.addr),
-		isRandom: addr.bitfield_addr_type() != 0,
-	}
+	return NewMACAddress(makeAddress(addr.addr), addr.bitfield_addr_type() != 0)
 }
 
 // Always let the BLE stack pick the right PHY.

--- a/att_hci.go
+++ b/att_hci.go
@@ -118,7 +118,7 @@ func (s *rawService) Read(p []byte) (int, error) {
 		binary.LittleEndian.PutUint16(p[4:], s.uuid.Get16Bit())
 		sz += 2
 	default:
-		uuid := s.uuid.bytes()
+		uuid := s.uuid.BytesLittleEndian()
 		copy(p[4:], uuid[:])
 		sz += 16
 	}
@@ -166,7 +166,7 @@ func (c *rawCharacteristic) Read(p []byte) (int, error) {
 		binary.LittleEndian.PutUint16(p[5:], c.uuid.Get16Bit())
 		sz += 2
 	default:
-		uuid := c.uuid.bytes()
+		uuid := c.uuid.BytesLittleEndian()
 		copy(p[5:], uuid[:])
 		sz += 16
 	}
@@ -232,7 +232,7 @@ func (a *rawAttribute) Read(p []byte) (int, error) {
 			binary.LittleEndian.PutUint16(p[sz:], a.uuid.Get16Bit())
 			sz += 2
 		default:
-			uuid := a.uuid.bytes()
+			uuid := a.uuid.BytesLittleEndian()
 			copy(p[sz:], uuid[:])
 			sz += 16
 		}

--- a/ble.go
+++ b/ble.go
@@ -1,0 +1,49 @@
+package bluetooth
+
+import "tinygo.org/x/bluetooth/ble"
+
+// The core value types live in the ble subpackage, so that the protocol
+// subpackages can use them without an import cycle. These are aliases, not new
+// types, so bluetooth.UUID and ble.UUID are interchangeable.
+type (
+	// UUID is a 16-bit, 32-bit, or 128-bit BLE UUID.
+	UUID = ble.UUID
+
+	// MAC represents a MAC address, in little endian format.
+	MAC = ble.MAC
+
+	// MACAddress contains a Bluetooth address which is a MAC address.
+	MACAddress = ble.MACAddress
+)
+
+// NewUUID returns a new 128-bit UUID for a 16 byte array in big endian order.
+func NewUUID(uuid [16]byte) UUID { return ble.NewUUID(uuid) }
+
+// New16BitUUID returns a new 128-bit UUID based on a 16-bit UUID.
+func New16BitUUID(shortUUID uint16) UUID { return ble.New16BitUUID(shortUUID) }
+
+// New32BitUUID returns a new 128-bit UUID based on a 32-bit UUID.
+func New32BitUUID(shortUUID uint32) UUID { return ble.New32BitUUID(shortUUID) }
+
+// ParseUUID parses the given UUID, which must be in one of the following
+// forms: 0000, 00000000, or 00000000-0000-1000-8000-00805F9B34FB.
+func ParseUUID(s string) (UUID, error) { return ble.ParseUUID(s) }
+
+// UUIDFromBytes returns the UUID for a 16 byte array in little endian order.
+func UUIDFromBytes(b [16]byte) UUID { return ble.UUIDFromBytes(b) }
+
+// ParseMAC parses the given MAC address, which must be in
+// 11:22:33:AA:BB:CC format.
+func ParseMAC(s string) (MAC, error) { return ble.ParseMAC(s) }
+
+// NewMACAddress returns a MACAddress for the given MAC, marked as random or
+// public.
+func NewMACAddress(mac MAC, random bool) MACAddress { return ble.NewMACAddress(mac, random) }
+
+// The error values are aliased so that a comparison against the old name still
+// holds.
+var (
+	ErrInvalidMAC        = ble.ErrInvalidMAC
+	ErrInvalidBinaryMac  = ble.ErrInvalidBinaryMac
+	ErrInvalidBinaryUUID = ble.ErrInvalidBinaryUUID
+)

--- a/ble/ble.go
+++ b/ble/ble.go
@@ -1,0 +1,9 @@
+// Package ble holds the core Bluetooth Low Energy value types that are shared
+// by the bluetooth package and its protocol subpackages.
+//
+// The bluetooth package aliases these types, so bluetooth.UUID and ble.UUID
+// are the same type.
+//
+// This package is not yet stable. Its API can change until the module reaches
+// version 1.0.
+package ble

--- a/ble/mac.go
+++ b/ble/mac.go
@@ -1,4 +1,4 @@
-package bluetooth
+package ble
 
 import (
 	"errors"
@@ -106,4 +106,38 @@ func (mac *MAC) UnmarshalBinary(data []byte) error {
 // (allocating a larger slice if necessary) and returns the updated slice.
 func (mac MAC) AppendBinary(b []byte) ([]byte, error) {
 	return append(b, mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]), nil
+}
+
+// MACAddress contains a Bluetooth address which is a MAC address.
+type MACAddress struct {
+	// MAC address of the Bluetooth device.
+	MAC
+
+	isRandom bool
+}
+
+// NewMACAddress returns a MACAddress for the given MAC, marked as random or
+// public.
+func NewMACAddress(mac MAC, random bool) MACAddress {
+	return MACAddress{MAC: mac, isRandom: random}
+}
+
+// IsRandom if the address is randomly created.
+func (mac MACAddress) IsRandom() bool {
+	return mac.isRandom
+}
+
+// SetRandom if is a random address.
+func (mac *MACAddress) SetRandom(val bool) {
+	mac.isRandom = val
+}
+
+// Set the address
+func (mac *MACAddress) Set(val string) {
+	m, err := ParseMAC(val)
+	if err != nil {
+		return
+	}
+
+	mac.MAC = m
 }

--- a/ble/mac_test.go
+++ b/ble/mac_test.go
@@ -1,4 +1,4 @@
-package bluetooth
+package ble
 
 import (
 	"bytes"

--- a/ble/uuid.go
+++ b/ble/uuid.go
@@ -1,4 +1,4 @@
-package bluetooth
+package ble
 
 // This file implements 16-bit and 128-bit UUIDs as defined in the Bluetooth
 // specification.
@@ -116,9 +116,9 @@ func (uuid UUID) BytesBigEndian() [16]byte {
 	}
 }
 
-// bytes returns a 16-byte array containing the raw UUID in little-endian
+// BytesLittleEndian returns a 16 byte array with the raw UUID in little endian
 // order.
-func (uuid UUID) bytes() [16]byte {
+func (uuid UUID) BytesLittleEndian() [16]byte {
 	return [16]byte{
 		0:  byte(uuid.id[0]),
 		1:  byte(uuid.id[0] >> 8),
@@ -142,7 +142,7 @@ func (uuid UUID) bytes() [16]byte {
 // AppendBinary appends the bytes of the uuid in little-endian order to the
 // given byte slice b.
 func (uuid UUID) AppendBinary(b []byte) ([]byte, error) {
-	id := uuid.bytes()
+	id := uuid.BytesLittleEndian()
 	return append(b, id[:]...), nil
 }
 
@@ -432,4 +432,15 @@ func (u *UUID) UnmarshalBinary(uuid []byte) error {
 	u.id[2] = uint32(uuid[8]) | uint32(uuid[9])<<8 | uint32(uuid[10])<<16 | uint32(uuid[11])<<24
 	u.id[3] = uint32(uuid[12]) | uint32(uuid[13])<<8 | uint32(uuid[14])<<16 | uint32(uuid[15])<<24
 	return nil
+}
+
+// UUIDFromBytes returns the UUID for a 16 byte array in little endian order.
+// It is the inverse of BytesLittleEndian.
+func UUIDFromBytes(b [16]byte) UUID {
+	var uuid UUID
+	uuid.id[0] = uint32(b[0]) | uint32(b[1])<<8 | uint32(b[2])<<16 | uint32(b[3])<<24
+	uuid.id[1] = uint32(b[4]) | uint32(b[5])<<8 | uint32(b[6])<<16 | uint32(b[7])<<24
+	uuid.id[2] = uint32(b[8]) | uint32(b[9])<<8 | uint32(b[10])<<16 | uint32(b[11])<<24
+	uuid.id[3] = uint32(b[12]) | uint32(b[13])<<8 | uint32(b[14])<<16 | uint32(b[15])<<24
+	return uuid
 }

--- a/ble/uuid_test.go
+++ b/ble/uuid_test.go
@@ -1,4 +1,4 @@
-package bluetooth
+package ble
 
 import (
 	"reflect"

--- a/gap.go
+++ b/gap.go
@@ -26,34 +26,6 @@ const (
 	GAPAddressTypeRandomPrivateNonResolvable = 0x03
 )
 
-// MACAddress contains a Bluetooth address which is a MAC address.
-type MACAddress struct {
-	// MAC address of the Bluetooth device.
-	MAC
-
-	isRandom bool
-}
-
-// IsRandom if the address is randomly created.
-func (mac MACAddress) IsRandom() bool {
-	return mac.isRandom
-}
-
-// SetRandom if is a random address.
-func (mac *MACAddress) SetRandom(val bool) {
-	mac.isRandom = val
-}
-
-// Set the address
-func (mac *MACAddress) Set(val string) {
-	m, err := ParseMAC(val)
-	if err != nil {
-		return
-	}
-
-	mac.MAC = m
-}
-
 type AdvertisingType int
 
 const (
@@ -351,7 +323,7 @@ func (buf *rawAdvertisementPayload) HasServiceUUID(uuid UUID) bool {
 		if len(b) == 0 {
 			b = buf.findField(0x06) // Incomplete List of 128-bit Service Class UUIDs
 		}
-		uuidBuf1 := uuid.bytes()
+		uuidBuf1 := uuid.BytesLittleEndian()
 		for i := 0; i < len(b)/16; i++ {
 			uuidBuf2 := b[i*16 : i*16+16]
 			match := true
@@ -588,7 +560,7 @@ func (buf *rawAdvertisementPayload) addServiceData(uuid UUID, data []byte) (ok b
 		// Add the data.
 		buf.data[buf.len+0] = byte(fieldLength - 1)
 		buf.data[buf.len+1] = 0x21
-		uuid_bytes := uuid.bytes()
+		uuid_bytes := uuid.BytesLittleEndian()
 		copy(buf.data[buf.len+2:], uuid_bytes[:])
 		copy(buf.data[buf.len+2+16:], data)
 		buf.len += uint8(fieldLength)
@@ -648,7 +620,7 @@ func (buf *rawAdvertisementPayload) addServiceUUID(uuid UUID) (ok bool) {
 		}
 		buf.data[buf.len+0] = 17   // length of field, including type
 		buf.data[buf.len+1] = 0x07 // type, 0x07 means "Complete List of 128-bit Service Class UUIDs"
-		rawUUID := uuid.bytes()
+		rawUUID := uuid.BytesLittleEndian()
 		copy(buf.data[buf.len+2:], rawUUID[:])
 		buf.len += 18
 		return true

--- a/gap_hci.go
+++ b/gap_hci.go
@@ -45,7 +45,7 @@ func (a *Adapter) Scan(callback func(*Adapter, ScanResult)) error {
 	// Active scanning transmits, so the controller needs to know which of our
 	// own addresses to put in the SCAN_REQ.
 	localRandom := uint8(0)
-	if a.hci.address.isRandom {
+	if a.hci.address.IsRandom() {
 		localRandom = GAPAddressTypeRandomStatic
 	}
 
@@ -135,10 +135,7 @@ func (a *Adapter) Scan(callback func(*Adapter, ScanResult)) error {
 
 			callback(a, ScanResult{
 				Address: Address{
-					MACAddress{
-						MAC:      makeAddress(a.hci.advData.peerBdaddr),
-						isRandom: random,
-					},
+					NewMACAddress(makeAddress(a.hci.advData.peerBdaddr), random),
 				},
 				RSSI: int16(a.hci.advData.rssi),
 				AdvertisementPayload: &advertisementFields{
@@ -192,11 +189,11 @@ func (a *Adapter) Connect(address Address, params ConnectionParams) (Device, err
 	}
 
 	peerRandom := uint8(0)
-	if address.isRandom {
+	if address.IsRandom() {
 		peerRandom = GAPAddressTypeRandomStatic
 	}
 	localRandom := uint8(0)
-	if a.hci.address.isRandom {
+	if a.hci.address.IsRandom() {
 		localRandom = GAPAddressTypeRandomStatic
 	}
 	if err := a.hci.leCreateConn(0x0060, // interval
@@ -226,15 +223,13 @@ func (a *Adapter) Connect(address Address, params ConnectionParams) (Device, err
 			defer a.hci.clearConnectData()
 
 			random := false
-			if address.isRandom {
+			if address.IsRandom() {
 				random = true
 			}
 
 			d := Device{
 				Address: Address{
-					MACAddress{
-						MAC:      makeAddress(a.hci.connectData.peerBdaddr),
-						isRandom: random},
+					NewMACAddress(makeAddress(a.hci.connectData.peerBdaddr), random),
 				},
 				deviceInternal: &deviceInternal{
 					adapter:                   a,
@@ -401,7 +396,7 @@ func (a *Advertisement) Start() error {
 	typ := uint8(a.advertisementType)
 
 	localRandom := uint8(0)
-	if a.adapter.hci.address.isRandom {
+	if a.adapter.hci.address.IsRandom() {
 		localRandom = GAPAddressTypeRandomStatic
 	}
 
@@ -432,7 +427,7 @@ func (a *Advertisement) Start() error {
 			binary.LittleEndian.PutUint16(advertisingData[5:], uuid.Get16Bit())
 		case uuid.Is32Bit():
 			sz = 6
-			data := uuid.bytes()
+			data := uuid.BytesLittleEndian()
 			slices.Reverse(data[:])
 			copy(advertisingData[5:], data[:])
 		}
@@ -492,9 +487,7 @@ func (a *Advertisement) Start() error {
 
 				d := Device{
 					Address: Address{
-						MACAddress{
-							MAC:      makeAddress(a.adapter.hci.connectData.peerBdaddr),
-							isRandom: random},
+						NewMACAddress(makeAddress(a.adapter.hci.connectData.peerBdaddr), random),
 					},
 					deviceInternal: &deviceInternal{
 						adapter:                   a.adapter,

--- a/gap_test.go
+++ b/gap_test.go
@@ -144,7 +144,7 @@ func TestServiceUUIDs(t *testing.T) {
 		raw      string
 		expected []UUID
 	}
-	uuidBytes := ServiceUUIDAdafruitSound.bytes()
+	uuidBytes := ServiceUUIDAdafruitSound.BytesLittleEndian()
 	tests := []testCase{
 		{},
 		{

--- a/gattc_hci.go
+++ b/gattc_hci.go
@@ -89,7 +89,7 @@ func (d Device) DiscoverServices(uuids []UUID) ([]DeviceService, error) {
 		}
 
 		for _, rawService := range cd.services {
-			if len(uuids) == 0 || rawService.uuid.isIn(uuids) {
+			if len(uuids) == 0 || uuidIn(rawService.uuid, uuids) {
 				foundServices[rawService.uuid] =
 					DeviceService{
 						device:      d,
@@ -197,7 +197,7 @@ func (s DeviceService) DiscoverCharacteristics(uuids []UUID) ([]DeviceCharacteri
 		}
 
 		for _, rawCharacteristic := range cd.characteristics {
-			if len(uuids) == 0 || rawCharacteristic.uuid.isIn(uuids) {
+			if len(uuids) == 0 || uuidIn(rawCharacteristic.uuid, uuids) {
 				dc := DeviceCharacteristic{
 					service:     &s,
 					uuid:        rawCharacteristic.uuid,

--- a/gattc_sd.go
+++ b/gattc_sd.go
@@ -83,7 +83,7 @@ func (d Device) DiscoverServices(uuids []UUID) ([]DeviceService, error) {
 		shortUUIDs = make([]C.ble_uuid_t, sz)
 		for i, uuid := range uuids {
 			var errCode C.uint32_t
-			shortUUIDs[i], errCode = uuid.shortUUID()
+			shortUUIDs[i], errCode = shortUUIDFor(uuid)
 			if errCode != 0 {
 				return nil, Error(errCode)
 			}
@@ -211,7 +211,7 @@ func (s DeviceService) DiscoverCharacteristics(uuids []UUID) ([]DeviceCharacteri
 		shortUUIDs = make([]C.ble_uuid_t, sz)
 		for i, uuid := range uuids {
 			var errCode C.uint32_t
-			shortUUIDs[i], errCode = uuid.shortUUID()
+			shortUUIDs[i], errCode = shortUUIDFor(uuid)
 			if errCode != 0 {
 				return nil, Error(errCode)
 			}

--- a/gatts_hci.go
+++ b/gatts_hci.go
@@ -15,13 +15,13 @@ type Characteristic struct {
 // AddService creates a new service with the characteristics listed in the
 // Service struct.
 func (a *Adapter) AddService(service *Service) error {
-	uuid := service.UUID.bytes()
+	uuid := service.UUID.BytesLittleEndian()
 	serviceHandle := a.att.addLocalAttribute(attributeTypeService, 0, shortUUID(gattServiceUUID).UUID(), 0, uuid[:])
 	valueHandle := serviceHandle
 	endHandle := serviceHandle
 
 	for i := range service.Characteristics {
-		data := service.Characteristics[i].UUID.bytes()
+		data := service.Characteristics[i].UUID.BytesLittleEndian()
 		cuuid := append([]byte{}, data[:]...)
 
 		// add characteristic declaration

--- a/gatts_sd.go
+++ b/gatts_sd.go
@@ -55,7 +55,7 @@ func secMode(level SecurityLevel) C.ble_gap_conn_sec_mode_t {
 // AddService creates a new service with the characteristics listed in the
 // Service struct.
 func (a *Adapter) AddService(service *Service) error {
-	uuid, errCode := service.UUID.shortUUID()
+	uuid, errCode := shortUUIDFor(service.UUID)
 	if errCode != 0 {
 		return Error(errCode)
 	}
@@ -72,7 +72,7 @@ func (a *Adapter) AddService(service *Service) error {
 		metadata.char_props.set_bitfield_notify(C.uint8_t(char.Flags>>4) & 1)
 		metadata.char_props.set_bitfield_indicate(C.uint8_t(char.Flags>>5) & 1)
 		handles := C.ble_gatts_char_handles_t{}
-		charUUID, errCode := char.UUID.shortUUID()
+		charUUID, errCode := shortUUIDFor(char.UUID)
 		if errCode != 0 {
 			return Error(errCode)
 		}
@@ -105,7 +105,7 @@ func (a *Adapter) AddService(service *Service) error {
 			char.Handle.permissions = char.Flags
 		}
 		for _, desc := range char.Descriptors {
-			descUUID, errCode := desc.UUID.shortUUID()
+			descUUID, errCode := shortUUIDFor(desc.UUID)
 			if errCode != 0 {
 				return Error(errCode)
 			}

--- a/tools/gen-characteristic-uuids/main.go
+++ b/tools/gen-characteristic-uuids/main.go
@@ -45,7 +45,7 @@ func (c Characteristic) UUIDFunc() string {
 	if err != nil {
 		panic(err)
 	}
-	b := uuid.bytes()
+	b := uuid.BytesLittleEndian()
 	bs := hex.EncodeToString(b[:])
 	bss := ""
 	for i := 0; i < len(bs); i += 2 {

--- a/tools/gen-service-uuids/main.go
+++ b/tools/gen-service-uuids/main.go
@@ -45,7 +45,7 @@ func (s Service) UUIDFunc() string {
 	if err != nil {
 		panic(err)
 	}
-	b := uuid.bytes()
+	b := uuid.BytesLittleEndian()
 	bs := hex.EncodeToString(b[:])
 	bss := ""
 	for i := 0; i < len(bs); i += 2 {

--- a/uuid_hci.go
+++ b/uuid_hci.go
@@ -9,8 +9,8 @@ func (s shortUUID) UUID() UUID {
 	return New16BitUUID(uint16(s))
 }
 
-// isIn checks the passed in slice of UUIDs to see if this uuid is in it.
-func (uuid UUID) isIn(uuids []UUID) bool {
+// uuidIn checks the passed in slice of UUIDs to see if uuid is in it.
+func uuidIn(uuid UUID, uuids []UUID) bool {
 	for _, u := range uuids {
 		if u == uuid {
 			return true

--- a/uuid_sd.go
+++ b/uuid_sd.go
@@ -10,14 +10,16 @@ import "unsafe"
 
 type shortUUID C.ble_uuid_t
 
-func (uuid UUID) shortUUID() (C.ble_uuid_t, C.uint32_t) {
+// shortUUIDFor returns the SoftDevice short UUID for a full length UUID.
+func shortUUIDFor(uuid UUID) (C.ble_uuid_t, C.uint32_t) {
 	var short C.ble_uuid_t
-	short.uuid = C.uint16_t(uuid.id[3])
+	short.uuid = C.uint16_t(uuid.Get16Bit())
 	if uuid.Is16Bit() {
 		short._type = C.BLE_UUID_TYPE_BLE
 		return short, 0
 	}
-	errCode := C.sd_ble_uuid_vs_add((*C.ble_uuid128_t)(unsafe.Pointer(&uuid.id[0])), &short._type)
+	raw := uuid.BytesLittleEndian()
+	errCode := C.sd_ble_uuid_vs_add((*C.ble_uuid128_t)(unsafe.Pointer(&raw[0])), &short._type)
 	return short, errCode
 }
 
@@ -27,9 +29,9 @@ func (s shortUUID) UUID() UUID {
 		return New16BitUUID(uint16(s.uuid))
 	}
 	var outLen C.uint8_t
-	var outUUID UUID
-	C.sd_ble_uuid_encode(((*C.ble_uuid_t)(unsafe.Pointer(&s))), &outLen, ((*C.uint8_t)(unsafe.Pointer(&outUUID.id))))
-	return outUUID
+	var raw [16]byte
+	C.sd_ble_uuid_encode(((*C.ble_uuid_t)(unsafe.Pointer(&s))), &outLen, ((*C.uint8_t)(unsafe.Pointer(&raw[0]))))
+	return UUIDFromBytes(raw)
 }
 
 // IsIn checks the passed in slice of short UUIDs to see if this uuid is in it.


### PR DESCRIPTION
Moves `UUID`, `MAC`, `MACAddress` and `AttributeProtocolError` into a leaf
package `tinygo.org/x/bluetooth/ble`.

This is the first of three stacked pull requests that move the HCI protocol
stack out of the root package. It carries no HCI logic and no behaviour change.
It is separate because the type move touches many files, and a reviewer should
be able to confirm that it is mechanical without the protocol changes in view.

## Why a leaf package

A subpackage cannot import the root package, so the HCI stack cannot move out
while the core value types stay in the root. `ble` holds those types and
imports nothing from this repository.

## Compatibility

**The root package aliases all four types**, so `bluetooth.UUID` and `ble.UUID`
are the same type, and existing code keeps compiling. The generated UUID tables
needed no change.

## Verification

`go vet` and `go test` over `./ ./ble`, both plain and with `-race`, plus
`make smoketest-linux` and `make smoketest-windows`.

## The rest of the stack

2. #478 `hci: move the protocol stack into a subpackage`
3. #476 `hci: add unit tests, and correct what they found`
